### PR TITLE
Converted `unittest`-style tests to `pytest`-style tests

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,4 +3,5 @@ include_trailing_comma = True
 line_length = 150
 use_parentheses = True
 multi_line_output = 3
-sections = FUTURE,STDLIB,FIRSTPARTY,THIRDPARTY,LOCALFOLDER
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+known_first_party = apify,apify_client

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
             'pep8-naming ~= 0.13.2',
             'pre-commit ~= 2.20.0',
             'pytest ~= 7.2.0',
+            'pytest-asyncio ~= 0.20.3',
             'sphinx ~= 5.3.0',
             'sphinx-autodoc-typehints ~= 1.19.5',
             'sphinx-markdown-builder == 0.5.4',  # pinned to 0.5.4, because 0.5.5 has a formatting bug

--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Generic, Optional, TypeVar, Union, cast
 
 import psutil
+
 from apify_client import __version__ as client_version
 
 from ._version import __version__ as sdk_version

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import datetime
-import os
-import unittest
+
+import pytest
 
 from apify._utils import (
     _fetch_and_parse_env_var,
@@ -14,111 +14,113 @@ from apify._utils import (
 )
 
 
-class UtilsTest(unittest.IsolatedAsyncioTestCase):
-    def test__fetch_and_parse_env_var(self) -> None:
-        os.environ['APIFY_IS_AT_HOME'] = 'True'
-        os.environ['APIFY_MEMORY_MBYTES'] = '1024'
-        os.environ['APIFY_META_ORIGIN'] = 'API'
-        os.environ['APIFY_STARTED_AT'] = '2022-12-02T15:19:34.907Z'
-        os.environ['DUMMY_BOOL'] = '1'
-        os.environ['DUMMY_DATETIME'] = '2022-12-02T15:19:34.907Z'
-        os.environ['DUMMY_INT'] = '1'
-        os.environ['DUMMY_STRING'] = 'DUMMY'
+def test__fetch_and_parse_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('APIFY_IS_AT_HOME', 'True')
+    monkeypatch.setenv('APIFY_MEMORY_MBYTES', '1024')
+    monkeypatch.setenv('APIFY_META_ORIGIN', 'API')
+    monkeypatch.setenv('APIFY_STARTED_AT', '2022-12-02T15:19:34.907Z')
+    monkeypatch.setenv('DUMMY_BOOL', '1')
+    monkeypatch.setenv('DUMMY_DATETIME', '2022-12-02T15:19:34.907Z')
+    monkeypatch.setenv('DUMMY_INT', '1')
+    monkeypatch.setenv('DUMMY_STRING', 'DUMMY')
 
-        self.assertEqual(_fetch_and_parse_env_var('APIFY_IS_AT_HOME'), True)
-        self.assertEqual(_fetch_and_parse_env_var('APIFY_MEMORY_MBYTES'), 1024)
-        self.assertEqual(_fetch_and_parse_env_var('APIFY_META_ORIGIN'), 'API')
-        self.assertEqual(
-            _fetch_and_parse_env_var('APIFY_STARTED_AT'),
-            datetime.datetime(2022, 12, 2, 15, 19, 34, 907000, tzinfo=datetime.timezone.utc),
-        )
+    assert _fetch_and_parse_env_var('APIFY_IS_AT_HOME') is True
+    assert _fetch_and_parse_env_var('APIFY_MEMORY_MBYTES') == 1024
+    assert _fetch_and_parse_env_var('APIFY_META_ORIGIN') == 'API'
+    assert _fetch_and_parse_env_var('APIFY_STARTED_AT') == \
+        datetime.datetime(2022, 12, 2, 15, 19, 34, 907000, tzinfo=datetime.timezone.utc)
 
-        self.assertEqual(_fetch_and_parse_env_var('DUMMY_BOOL'), '1')
-        self.assertEqual(_fetch_and_parse_env_var('DUMMY_DATETIME'), '2022-12-02T15:19:34.907Z')
-        self.assertEqual(_fetch_and_parse_env_var('DUMMY_INT'), '1')
-        self.assertEqual(_fetch_and_parse_env_var('DUMMY_STRING'), 'DUMMY')
-        self.assertEqual(_fetch_and_parse_env_var('NONEXISTENT_ENV_VAR'), None)
-        self.assertEqual(_fetch_and_parse_env_var('NONEXISTENT_ENV_VAR', 'default'), 'default')
+    assert _fetch_and_parse_env_var('DUMMY_BOOL') == '1'
+    assert _fetch_and_parse_env_var('DUMMY_DATETIME') == '2022-12-02T15:19:34.907Z'
+    assert _fetch_and_parse_env_var('DUMMY_INT') == '1'
+    assert _fetch_and_parse_env_var('DUMMY_STRING') == 'DUMMY'
+    assert _fetch_and_parse_env_var('NONEXISTENT_ENV_VAR') is None
+    assert _fetch_and_parse_env_var('NONEXISTENT_ENV_VAR', 'default') == 'default'
 
-    def test__get_cpu_usage_percent(self) -> None:
-        self.assertGreaterEqual(_get_cpu_usage_percent(), 0)
-        self.assertLessEqual(_get_cpu_usage_percent(), 100)
 
-    def test__get_memory_usage_bytes(self) -> None:
-        self.assertGreaterEqual(_get_memory_usage_bytes(), 0)
-        self.assertLessEqual(_get_memory_usage_bytes(), 1024 * 1024 * 1024 * 1024)
+def test__get_cpu_usage_percent() -> None:
+    assert _get_cpu_usage_percent() >= 0
+    assert _get_cpu_usage_percent() <= 100
 
-    def test__maybe_parse_bool(self) -> None:
-        self.assertEqual(_maybe_parse_bool('True'), True)
-        self.assertEqual(_maybe_parse_bool('true'), True)
-        self.assertEqual(_maybe_parse_bool('1'), True)
-        self.assertEqual(_maybe_parse_bool('False'), False)
-        self.assertEqual(_maybe_parse_bool('false'), False)
-        self.assertEqual(_maybe_parse_bool('0'), False)
-        self.assertEqual(_maybe_parse_bool(None), False)
-        self.assertEqual(_maybe_parse_bool('bflmpsvz'), False)
 
-    def test__maybe_parse_datetime(self) -> None:
-        self.assertEqual(
-            _maybe_parse_datetime('2022-12-02T15:19:34.907Z'),
-            datetime.datetime(2022, 12, 2, 15, 19, 34, 907000, tzinfo=datetime.timezone.utc),
-        )
-        self.assertEqual(_maybe_parse_datetime('2022-12-02T15:19:34.907'), '2022-12-02T15:19:34.907')
-        self.assertEqual(_maybe_parse_datetime('anything'), 'anything')
-        self.assertEqual(_maybe_parse_datetime(None), None)
+def test__get_memory_usage_bytes() -> None:
+    assert _get_memory_usage_bytes() >= 0
+    assert _get_memory_usage_bytes() <= 1024 * 1024 * 1024 * 1024
 
-    def test__maybe_parse_int(self) -> None:
-        self.assertEqual(_maybe_parse_int('0'), 0)
-        self.assertEqual(_maybe_parse_int('1'), 1)
-        self.assertEqual(_maybe_parse_int('-1'), -1)
-        self.assertEqual(_maybe_parse_int('136749825'), 136749825)
-        self.assertEqual(_maybe_parse_int(''), None)
-        self.assertEqual(_maybe_parse_int(None), None)
 
-    async def test__run_func_at_interval_async(self) -> None:
-        # Test that it works with a synchronous functions
-        test_var = 0
+def test__maybe_parse_bool() -> None:
+    assert _maybe_parse_bool('True') is True
+    assert _maybe_parse_bool('true') is True
+    assert _maybe_parse_bool('1') is True
+    assert _maybe_parse_bool('False') is False
+    assert _maybe_parse_bool('false') is False
+    assert _maybe_parse_bool('0') is False
+    assert _maybe_parse_bool(None) is False
+    assert _maybe_parse_bool('bflmpsvz') is False
 
-        def sync_increment() -> None:
-            nonlocal test_var
-            test_var += 1
 
-        sync_increment_task = asyncio.create_task(_run_func_at_interval_async(sync_increment, 0.3))
+def test__maybe_parse_datetime() -> None:
+    assert _maybe_parse_datetime('2022-12-02T15:19:34.907Z') == \
+        datetime.datetime(2022, 12, 2, 15, 19, 34, 907000, tzinfo=datetime.timezone.utc)
+    assert _maybe_parse_datetime('2022-12-02T15:19:34.907') == '2022-12-02T15:19:34.907'
+    assert _maybe_parse_datetime('anything') == 'anything'
+    assert _maybe_parse_datetime(None) is None
 
-        await asyncio.sleep(0.2)
-        self.assertEqual(test_var, 0)
-        await asyncio.sleep(0.3)
-        self.assertEqual(test_var, 1)
-        await asyncio.sleep(0.3)
-        self.assertEqual(test_var, 2)
-        await asyncio.sleep(0.3)
-        self.assertEqual(test_var, 3)
 
-        sync_increment_task.cancel()
+def test__maybe_parse_int() -> None:
+    assert _maybe_parse_int('0') == 0
+    assert _maybe_parse_int('1') == 1
+    assert _maybe_parse_int('-1') == -1
+    assert _maybe_parse_int('136749825') == 136749825
+    assert _maybe_parse_int('') is None
+    assert _maybe_parse_int(None) is None
 
-        await asyncio.sleep(1)
-        self.assertEqual(test_var, 3)
 
-        # Test that it works with an asynchronous functions
-        test_var = 0
+@pytest.mark.asyncio
+async def test__run_func_at_interval_async() -> None:
+    # Test that it works with a synchronous functions
+    test_var = 0
 
-        async def async_increment() -> None:
-            nonlocal test_var
-            await asyncio.sleep(0.1)
-            test_var += 1
+    def sync_increment() -> None:
+        nonlocal test_var
+        test_var += 1
 
-        async_increment_task = asyncio.create_task(_run_func_at_interval_async(async_increment, 0.3))
+    sync_increment_task = asyncio.create_task(_run_func_at_interval_async(sync_increment, 0.3))
 
-        await asyncio.sleep(0.2)
-        self.assertEqual(test_var, 0)
-        await asyncio.sleep(0.3)
-        self.assertEqual(test_var, 1)
-        await asyncio.sleep(0.3)
-        self.assertEqual(test_var, 2)
-        await asyncio.sleep(0.3)
-        self.assertEqual(test_var, 3)
+    await asyncio.sleep(0.2)
+    assert test_var == 0
+    await asyncio.sleep(0.3)
+    assert test_var == 1
+    await asyncio.sleep(0.3)
+    assert test_var == 2
+    await asyncio.sleep(0.3)
+    assert test_var == 3
 
-        async_increment_task.cancel()
+    sync_increment_task.cancel()
 
-        await asyncio.sleep(1)
-        self.assertEqual(test_var, 3)
+    await asyncio.sleep(1)
+    assert test_var == 3
+
+    # Test that it works with an asynchronous functions
+    test_var = 0
+
+    async def async_increment() -> None:
+        nonlocal test_var
+        await asyncio.sleep(0.1)
+        test_var += 1
+
+    async_increment_task = asyncio.create_task(_run_func_at_interval_async(async_increment, 0.3))
+
+    await asyncio.sleep(0.2)
+    assert test_var == 0
+    await asyncio.sleep(0.3)
+    assert test_var == 1
+    await asyncio.sleep(0.3)
+    assert test_var == 2
+    await asyncio.sleep(0.3)
+    assert test_var == 3
+
+    async_increment_task.cancel()
+
+    await asyncio.sleep(1)
+    assert test_var == 3


### PR DESCRIPTION
I want to use the [fixture features](https://docs.pytest.org/en/stable/how-to/fixtures.html) that `pytest` provides, and it's quite hard to do with the `unittest`-style tests, so I converted all the tests to use the `pytest` style. I think it's a bit more readable as well.