### PR TITLE
Fixed `open_xxx` methods for default storages

### DIFF
--- a/src/apify/actor.py
+++ b/src/apify/actor.py
@@ -445,7 +445,6 @@ class Actor(metaclass=_ActorContextManager):
         self._raise_if_not_initialized()
 
         key_value_store_client = await self.open_key_value_store()
-        print(key)
         record = await key_value_store_client.get_record(key)
         if record:
             return record['value']


### PR DESCRIPTION
When you tried to open a storage by its ID, it would instead create a new named storage with the ID as the name. This fixes it.

I know this code will change soon, but I just need the quick fix in so I can develop the Python actor templates and the Python actor support in the CLI.