### PR TITLE
Parallel unit tests via `pytest-xdist`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint:
 	python3 -m flake8
 
 test:
-	python3 -m pytest -ra tests
+	python3 -m pytest -n auto -ra tests
 
 type-check:
 	python3 -m mypy

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
             'pytest ~= 7.2.0',
             'pytest-asyncio ~= 0.20.3',
             'pytest-randomly ~= 3.12.0',
+            'pytest-xdist ~= 3.1.0',
             'respx ~= 0.20.1',
             'sphinx ~= 5.3.0',
             'sphinx-autodoc-typehints ~= 1.19.5',


### PR DESCRIPTION
Make unit tests run in parallel via `pytest-xdist`.