### PR TITLE
Correctly exit actors in unit tests

### DIFF
--- a/tests/unit/actor/test_actor_env_helpers.py
+++ b/tests/unit/actor/test_actor_env_helpers.py
@@ -48,3 +48,5 @@ class TestGetEnv:
 
         await Actor.init()
         assert expected_get_env == Actor.get_env()
+
+        await Actor.exit()

--- a/tests/unit/actor/test_actor_lifecycle.py
+++ b/tests/unit/actor/test_actor_lifecycle.py
@@ -127,6 +127,9 @@ class TestActorMainMethod:
         # NOTE: Actor didn't call sys.exit() during testing, check if fail was called.
         my_actor.fail.assert_called_with(exit_code=91, _exc_type=type(err), _exc_value=err, _exc_traceback=err.__traceback__)
 
+        # This is necessary to stop the event emitting intervals
+        await my_actor.exit()
+
     async def test_actor_main_method_raise_return_value(self) -> None:
         my_actor = Actor()
         expected_string = 'Hello world'


### PR DESCRIPTION
We had a small bug in the unit tests that some actors were not exited cleanly, so their event-emitting intervals were still running, and pytest was showing a warning about an async task being destroyed but still pending:

<img width="1060" alt="Screenshot 2023-02-02 at 12 07 39" src="https://user-images.githubusercontent.com/2934111/216310782-ff56e856-baea-4784-9300-768a324913a0.png">

This fixes it.