### PR TITLE
Try to make integration tests for actor events less flaky

### DIFF
--- a/tests/integration/test_actor_events.py
+++ b/tests/integration/test_actor_events.py
@@ -11,20 +11,21 @@ class TestActorEvents:
     async def test_interval_events(self, make_actor: ActorFactory) -> None:
         async def main() -> None:
             import os
+            from typing import Any, Callable
 
             from apify.consts import ActorEventType, ApifyEnvVars
 
             os.environ[ApifyEnvVars.PERSIST_STATE_INTERVAL_MILLIS] = '900'
 
-            def on_event(event_type):  # type: ignore
-                async def log_event(data):  # type: ignore
+            def on_event(event_type: ActorEventType) -> Callable:
+                async def log_event(data: Any) -> None:
                     await Actor.push_data({'event_type': event_type, 'data': data})
                 return log_event
 
             async with Actor:
-                Actor.on(ActorEventType.SYSTEM_INFO, on_event(ActorEventType.SYSTEM_INFO))  # type: ignore
-                Actor.on(ActorEventType.PERSIST_STATE, on_event(ActorEventType.PERSIST_STATE))  # type: ignore
-                await asyncio.sleep(3)
+                Actor.on(ActorEventType.SYSTEM_INFO, on_event(ActorEventType.SYSTEM_INFO))
+                Actor.on(ActorEventType.PERSIST_STATE, on_event(ActorEventType.PERSIST_STATE))
+                await asyncio.sleep(10)
 
         actor = await make_actor('actor-interval-events', main_func=main)
 


### PR DESCRIPTION
Let's try just waiting longer for the `SYSTEM_INFO` event to happen, I think it will be enough. If not, we can work on it more.