### PR TITLE
Run unit tests on Windows as well

### DIFF
--- a/.github/workflows/lint_and_type_checks.yaml
+++ b/.github/workflows/lint_and_type_checks.yaml
@@ -1,11 +1,11 @@
-name: Lint and test
+name: Lint and type checks
 
 on:
   workflow_call:
 
 jobs:
-  lint_and_test:
-    name: Lint, check types and run unit tests
+  lint_and_type_checks:
+    name: Lint and type checks
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -23,11 +23,8 @@ jobs:
     - name: Install dependencies
       run: make install-dev
 
-    - name: Lint
+    - name: Run lint
       run: make lint
 
-    - name: Type check
+    - name: Run type checks
       run: make type-check
-
-    - name: Unit tests
-      run: make unit-tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,13 @@ on:
           - 'final'
 
 jobs:
-  lint_and_test:
-    name: Run lint and unit tests
-    uses: ./.github/workflows/lint_and_test.yaml
+  lint_and_type_checks:
+    name: Run lint and type_checks
+    uses: ./.github/workflows/lint_and_type_checks.yaml
+
+  unit_tests:
+    name: Run unit tests
+    uses: ./.github/workflows/unit_tests.yaml
 
   integration_tests:
     name: Run integration tests
@@ -39,7 +43,7 @@ jobs:
 
   deploy:
     name: Publish to PyPI
-    needs: [lint_and_test, integration_tests, check_docs]
+    needs: [lint_and_type_checks, unit_tests, integration_tests, check_docs]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -4,9 +4,14 @@ on:
   pull_request:
 
 jobs:
-  lint_and_test:
-    name: Run lint and unit tests
-    uses: ./.github/workflows/lint_and_test.yaml
+  lint_and_type_checks:
+    name: Run lint and type checks
+    uses: ./.github/workflows/lint_and_type_checks.yaml
+
+  unit_tests:
+    name: Run unit tests
+    needs: [lint_and_type_checks]
+    uses: ./.github/workflows/unit_tests.yaml
 
   check_docs:
     name: Check whether the documentation is up to date
@@ -14,6 +19,6 @@ jobs:
 
   integration_tests:
     name: Run integration tests
-    needs: [lint_and_test, check_docs]
+    needs: [lint_and_type_checks, unit_tests, check_docs]
     uses: ./.github/workflows/integration_tests.yaml
     secrets: inherit

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,28 @@
+name: Unit tests
+
+on:
+  workflow_call:
+
+jobs:
+  unit_tests:
+    name: Run unit tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: make install-dev
+
+    - name: Run unit tests
+      run: make unit-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog
 
 - fixed parsing messages from the platform events websocket when they have no event data
 
+### Internal changes
+
+- started running unit tests in CI on Windows runners in addition to Linux
+
 [0.1.0](../../releases/tag/v0.1.0) - 2023-02-09
 -----------------------------------------------
 

--- a/tests/unit/memory_storage/resource_clients/test_dataset.py
+++ b/tests/unit/memory_storage/resource_clients/test_dataset.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import pytest
@@ -30,6 +31,7 @@ async def test_not_implemented(dataset_client: DatasetClient) -> None:
 
 
 async def test_get(dataset_client: DatasetClient) -> None:
+    await asyncio.sleep(0.1)
     info = await dataset_client.get()
     assert info is not None
     assert info['id'] == dataset_client._id
@@ -39,12 +41,15 @@ async def test_get(dataset_client: DatasetClient) -> None:
 async def test_update(dataset_client: DatasetClient) -> None:
     new_dataset_name = 'test-update'
     await dataset_client.push_items({'abc': 123})
+
     old_dataset_info = await dataset_client.get()
     assert old_dataset_info is not None
     old_dataset_directory = os.path.join(dataset_client._client._datasets_directory, old_dataset_info['name'])
     new_dataset_directory = os.path.join(dataset_client._client._datasets_directory, new_dataset_name)
     assert os.path.exists(os.path.join(old_dataset_directory, '000000001.json')) is True
     assert os.path.exists(os.path.join(new_dataset_directory, '000000001.json')) is False
+
+    await asyncio.sleep(0.1)
     updated_dataset_info = await dataset_client.update(name=new_dataset_name)
     assert os.path.exists(os.path.join(old_dataset_directory, '000000001.json')) is False
     assert os.path.exists(os.path.join(new_dataset_directory, '000000001.json')) is True
@@ -52,6 +57,7 @@ async def test_update(dataset_client: DatasetClient) -> None:
     assert old_dataset_info['createdAt'] == updated_dataset_info['createdAt']
     assert old_dataset_info['modifiedAt'] != updated_dataset_info['modifiedAt']
     assert old_dataset_info['accessedAt'] != updated_dataset_info['accessedAt']
+
     # Should fail with the same name
     with pytest.raises(ValueError):
         await dataset_client.update(name=new_dataset_name)

--- a/tests/unit/memory_storage/resource_clients/test_key_value_store.py
+++ b/tests/unit/memory_storage/resource_clients/test_key_value_store.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import pytest
@@ -32,6 +33,7 @@ async def test_not_implemented(key_value_store_client: KeyValueStoreClient) -> N
 
 
 async def test_get(key_value_store_client: KeyValueStoreClient) -> None:
+    await asyncio.sleep(0.1)
     info = await key_value_store_client.get()
     assert info is not None
     assert info['id'] == key_value_store_client._id
@@ -47,6 +49,8 @@ async def test_update(key_value_store_client: KeyValueStoreClient) -> None:
     new_kvs_directory = os.path.join(key_value_store_client._client._key_value_stores_directory, new_kvs_name)
     assert os.path.exists(os.path.join(old_kvs_directory, 'test.json')) is True
     assert os.path.exists(os.path.join(new_kvs_directory, 'test.json')) is False
+
+    await asyncio.sleep(0.1)
     updated_kvs_info = await key_value_store_client.update(name=new_kvs_name)
     assert os.path.exists(os.path.join(old_kvs_directory, 'test.json')) is False
     assert os.path.exists(os.path.join(new_kvs_directory, 'test.json')) is True
@@ -54,6 +58,7 @@ async def test_update(key_value_store_client: KeyValueStoreClient) -> None:
     assert old_kvs_info['createdAt'] == updated_kvs_info['createdAt']
     assert old_kvs_info['modifiedAt'] != updated_kvs_info['modifiedAt']
     assert old_kvs_info['accessedAt'] != updated_kvs_info['accessedAt']
+
     # Should fail with the same name
     with pytest.raises(ValueError):
         await key_value_store_client.update(name=new_kvs_name)

--- a/tests/unit/memory_storage/resource_clients/test_request_queue.py
+++ b/tests/unit/memory_storage/resource_clients/test_request_queue.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from datetime import datetime, timezone
 
@@ -23,6 +24,7 @@ async def test_nonexistent(memory_storage: MemoryStorage) -> None:
 
 
 async def test_get(request_queue_client: RequestQueueClient) -> None:
+    await asyncio.sleep(0.1)
     info = await request_queue_client.get()
     assert info is not None
     assert info['id'] == request_queue_client._id
@@ -41,6 +43,8 @@ async def test_update(request_queue_client: RequestQueueClient) -> None:
     new_rq_directory = os.path.join(request_queue_client._client._request_queues_directory, new_rq_name)
     assert os.path.exists(os.path.join(old_rq_directory, 'fvwscO2UJLdr10B.json')) is True
     assert os.path.exists(os.path.join(new_rq_directory, 'fvwscO2UJLdr10B.json')) is False
+
+    await asyncio.sleep(0.1)
     updated_rq_info = await request_queue_client.update(name=new_rq_name)
     assert os.path.exists(os.path.join(old_rq_directory, 'fvwscO2UJLdr10B.json')) is False
     assert os.path.exists(os.path.join(new_rq_directory, 'fvwscO2UJLdr10B.json')) is True
@@ -48,6 +52,7 @@ async def test_update(request_queue_client: RequestQueueClient) -> None:
     assert old_rq_info['createdAt'] == updated_rq_info['createdAt']
     assert old_rq_info['modifiedAt'] != updated_rq_info['modifiedAt']
     assert old_rq_info['accessedAt'] != updated_rq_info['accessedAt']
+
     # Should fail with the same name
     with pytest.raises(ValueError):
         await request_queue_client.update(name=new_rq_name)


### PR DESCRIPTION
Since we test a lot of the local behavior of the SDK in unit tests, we should run those tests on Windows as well.

This PR adds Windows in the matrix by which we run the unit tests, and refactors the workflows a bit to accommodate that.

It also fixes some unit tests which were failing on Windows because the `datetime.now()` resolution is lower there, and if you ran two `datetime.now()` calls in quick succession, they would return the same value, which caused some of the timestamp checking tests in memory storage to fail.