### PR TITLE
Add more logging to flaky request queue integration test

### DIFF
--- a/tests/integration/actor_source_base/src/__main__.py
+++ b/tests/integration/actor_source_base/src/__main__.py
@@ -1,5 +1,15 @@
 import asyncio
+import logging
+
+from apify_client._logging import _DebugLogFormatter
 
 from .main import main
+
+client_logger = logging.getLogger('apify_client')
+if not client_logger.hasHandlers():
+    client_logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler()
+    handler.setFormatter(_DebugLogFormatter())
+    client_logger.addHandler(handler)
 
 asyncio.run(main())

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -3,26 +3,32 @@ from apify import Actor
 from .conftest import ActorFactory
 
 
+# TODO: this test is flaky, and the actor often times out, figure out why and fix it
 class TestRequestQueue:
     async def test_simple(self, make_actor: ActorFactory) -> None:
         async def main() -> None:
             async with Actor:
                 desired_request_count = 100
+                print('Opening request queue...')
+                # I have seen it get stuck on this call
                 rq = await Actor.open_request_queue()
                 # Add some requests
                 for i in range(desired_request_count):
+                    print(f'Adding request {i}...')
                     await rq.add_request({
                         'url': f'https://example.com/{i}',
                     })
 
                 handled_request_count = 0
                 while next_request := await rq.fetch_next_request():
+                    print('Fetching next request...')
                     queue_operation_info = await rq.mark_request_as_handled(next_request)
                     assert queue_operation_info is not None
                     assert queue_operation_info['wasAlreadyHandled'] is False
                     handled_request_count += 1
 
                 assert handled_request_count == desired_request_count
+                print('Waiting for queue to be finished...')
                 is_finished = await rq.is_finished()
                 assert is_finished is True
 


### PR DESCRIPTION
Every now and then, the integration test for request queue times out. This adds more logging to the test so that we can debug it easier.