### PR TITLE
Fixed parsing messages from the platform events websocket when they have no event data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Changelog
 [0.2.0](../../releases/tag/v0.2.0) - Upcoming
 ---------------------------------------------
 
-Upcoming release.
+### Fixed
+
+- fixed parsing messages from the platform events websocket when they have no event data
 
 [0.1.0](../../releases/tag/v0.1.0) - 2023-02-09
 -----------------------------------------------

--- a/src/apify/event_manager.py
+++ b/src/apify/event_manager.py
@@ -178,8 +178,9 @@ class EventManager:
                 async for message in websocket:
                     try:
                         parsed_message = json.loads(message)
+                        assert isinstance(parsed_message, dict)
                         event_name = parsed_message['name']
-                        event_data = parsed_message['data']
+                        event_data = parsed_message.get('data')  # 'data' can be missing
 
                         self._event_emitter.emit(event_name, event_data)
 


### PR DESCRIPTION
The `MIGRATING` platform event sends no `data` property in the message, so its parsing would fail. This fixes it.

I realized we have no unit tests for the event manager which would cover this, I will write them later.