### PR TITLE
Resolve a few TODOs, fix flaky unit test

### DIFF
--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -277,7 +277,16 @@ def _guess_file_extension(content_type: str) -> Optional[str]:
     """Guess the file extension based on content type."""
     # e.g. mimetypes.guess_extension('application/json ') does not work...
     actual_content_type = content_type.split(';')[0].strip()
+
+    # mimetypes.guess_extension returns 'xsl' in this case, because 'application/xxx' is "structured"
+    # ('text/xml' would be "unstructured" and return 'xml')
+    # we have to explicitly override it here
+    if actual_content_type == 'application/xml':
+        return 'xml'
+
+    # Guess the extension from the mime type
     ext = mimetypes.guess_extension(actual_content_type)
+
     # Remove the leading dot if extension successfully parsed
     return ext[1:] if ext is not None else ext
 

--- a/src/apify/actor.py
+++ b/src/apify/actor.py
@@ -317,12 +317,10 @@ class Actor(metaclass=_ActorContextManager):
         # Send final persist state event
         self._event_manager.emit(ActorEventTypes.PERSIST_STATE, {'isMigrating': False})
 
-        # Sleep for a bit so that the listeners have a chance to trigger,
+        # Sleep for a bit so that the listeners have a chance to trigger
         await asyncio.sleep(0.1)
 
         await self._event_manager.close(event_listeners_timeout_secs=event_listeners_timeout_secs)
-
-        # TODO: once we have in-memory storage, teardown the in-memory storage client here
 
         self._is_initialized = False
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -118,15 +118,15 @@ async def test__run_func_at_interval_async() -> None:
         nonlocal test_var
         test_var += 1
 
-    sync_increment_task = asyncio.create_task(_run_func_at_interval_async(sync_increment, 0.3))
+    sync_increment_task = asyncio.create_task(_run_func_at_interval_async(sync_increment, 1))
 
-    await asyncio.sleep(0.2)
+    await asyncio.sleep(0.5)
     assert test_var == 0
-    await asyncio.sleep(0.3)
+    await asyncio.sleep(1)
     assert test_var == 1
-    await asyncio.sleep(0.3)
+    await asyncio.sleep(1)
     assert test_var == 2
-    await asyncio.sleep(0.3)
+    await asyncio.sleep(1)
     assert test_var == 3
 
     sync_increment_task.cancel()
@@ -146,15 +146,15 @@ async def test__run_func_at_interval_async() -> None:
         await asyncio.sleep(0.1)
         test_var += 1
 
-    async_increment_task = asyncio.create_task(_run_func_at_interval_async(async_increment, 0.3))
+    async_increment_task = asyncio.create_task(_run_func_at_interval_async(async_increment, 1))
 
-    await asyncio.sleep(0.2)
+    await asyncio.sleep(0.5)
     assert test_var == 0
-    await asyncio.sleep(0.3)
+    await asyncio.sleep(1)
     assert test_var == 1
-    await asyncio.sleep(0.3)
+    await asyncio.sleep(1)
     assert test_var == 2
-    await asyncio.sleep(0.3)
+    await asyncio.sleep(1)
     assert test_var == 3
 
     async_increment_task.cancel()
@@ -256,7 +256,7 @@ def test__raise_on_duplicate_storage() -> None:
 def test__guess_file_extension() -> None:
     # Can guess common types properly
     assert _guess_file_extension('application/json') == 'json'
-    # assert _guess_file_extension('application/xml') == 'xml' # TODO: This shit library returns xsl for no apparent reason
+    assert _guess_file_extension('application/xml') == 'xml'
     assert _guess_file_extension('text/plain') == 'txt'
 
     # Can handle unusual formats


### PR DESCRIPTION
The `run_func_at_interval` was flaky on Windows, probably because the timing was too strict. This loosens it a bit.

Also this resolves a few small TODOs.