### PR TITLE
Add logger

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'aiofiles ~= 22.1.0',
         'aioshutil ~= 1.2',
         'cryptography ~= 39.0.1',
+        'colorama ~= 0.4.6',
     ],
     extras_require={
         'dev': [
@@ -91,6 +92,7 @@ setup(
             'sphinx-autodoc-typehints ~= 1.22',
             'sphinx-markdown-builder == 0.5.4',  # pinned to 0.5.4, because 0.5.5 has a formatting bug
             'types-aiofiles ~= 22.1.0.4',
+            'types-colorama ~= 0.4.15.7',
             'types-psutil ~= 5.9.5.5',
             'types-setuptools',  # always latest, since we always install latest setuptools
         ],

--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -42,18 +42,23 @@ from .consts import (
     ApifyEnvVars,
     StorageTypes,
 )
+from .log import logger
 
 
 def _log_system_info() -> None:
     python_version = '.'.join([str(x) for x in sys.version_info[:3]])
 
-    print('System info:')
-    print(f'    Apify SDK version: {sdk_version}')
-    print(f'    Apify Client version: {client_version}')
-    print(f'    OS: {sys.platform}')
-    print(f'    Python version: {python_version}')
+    system_info: Dict[str, Union[str, bool]] = {
+        'apify_sdk_version': sdk_version,
+        'apify_client_version': client_version,
+        'python_version': python_version,
+        'os': sys.platform,
+    }
+
     if _is_running_in_ipython():
-        print('    Running in IPython: True')
+        system_info['is_running_in_ipython'] = True
+
+    logger.info('System info', extra=system_info)
 
 
 DualPropertyType = TypeVar('DualPropertyType')
@@ -321,8 +326,8 @@ def _maybe_parse_body(body: bytes, content_type: str) -> Any:
             return json.loads(body)  # Returns any
         elif _is_content_type_xml(content_type) or _is_content_type_text(content_type):
             return body.decode('utf-8')
-    except ValueError as err:
-        print('_maybe_parse_body error', err)
+    except ValueError:
+        logger.exception('Error parsing key-value store record')
     return body
 
 

--- a/src/apify/log.py
+++ b/src/apify/log.py
@@ -9,7 +9,7 @@ from colorama import Fore, Style, just_fix_windows_console
 just_fix_windows_console()
 
 
-# Name of the logger used throughout the library
+# Name of the logger used throughout the library (resolves to 'apify')
 logger_name = __name__.split('.')[0]
 
 # Logger used throughout the library
@@ -31,6 +31,9 @@ _LOG_LEVEL_SHORT_ALIAS = {
     logging.ERROR: 'ERROR',
 }
 
+# So that all the log messages have the same alignment
+_LOG_MESSAGE_INDENT = ' ' * 6
+
 
 class ActorLogFormatter(logging.Formatter):
     """Log formatter that prints out the log message nicely formatted, with colored level and stringified extra fields."""
@@ -50,29 +53,33 @@ class ActorLogFormatter(logging.Formatter):
 
         This formats the log record so that it:
         - starts with the level (colorized, and padded to 5 chars so that it is nicely aligned)
-        - then has the actual log message
+        - then has the actual log message, if it's multiline then it's nicely indented
         - then has the stringified extra log fields
         - then, if an exception is a part of the log record, prints the formatted exception
         """
-        level_string = ''
-        if record.levelno != logging.NOTSET:
-            color_code = _LOG_LEVEL_COLOR.get(record.levelno, '')
-            short_alias = _LOG_LEVEL_SHORT_ALIAS.get(record.levelno, record.levelname)
-            level_string = f'{color_code}{short_alias}{Style.RESET_ALL} '
+        # Colorize the log level, and shorten it to 6 chars tops
+        level_color_code = _LOG_LEVEL_COLOR.get(record.levelno, '')
+        level_short_alias = _LOG_LEVEL_SHORT_ALIAS.get(record.levelno, record.levelname)
+        level_string = f'{level_color_code}{level_short_alias}{Style.RESET_ALL} '
 
+        # Format the exception, if there is some
+        # Basically just print the traceback and indent it a bit
         exception_string = ''
         if record.exc_info:
             exc_info = record.exc_info
             record.exc_info = None
             exception_string = ''.join(traceback.format_exception(*exc_info)).rstrip()
-            exception_string = '\n' + textwrap.indent(exception_string, '      ')
+            exception_string = '\n' + textwrap.indent(exception_string, _LOG_MESSAGE_INDENT)
 
-        extra = self._get_extra_fields(record)
+        # Format the extra log record fields, if there were some
+        # Just stringify them to JSON and color them gray
         extra_string = ''
+        extra = self._get_extra_fields(record)
         if extra:
             extra_string = f' {Fore.LIGHTBLACK_EX}({json.dumps(extra, ensure_ascii=False, default=str)}){Style.RESET_ALL}'
 
+        # Format the actual log message, and indent everything but the first line
         log_string = super().format(record)
-        log_string = textwrap.indent(log_string, '      ').lstrip()
+        log_string = textwrap.indent(log_string, _LOG_MESSAGE_INDENT).lstrip()
 
         return f'{level_string}{log_string}{extra_string}{exception_string}'

--- a/src/apify/log.py
+++ b/src/apify/log.py
@@ -38,6 +38,11 @@ _LOG_MESSAGE_INDENT = ' ' * 6
 class ActorLogFormatter(logging.Formatter):
     """Log formatter that prints out the log message nicely formatted, with colored level and stringified extra fields."""
 
+    # The fields that are added to the log record with `logger.log(..., extra={...})`
+    # are just merged in the log record with the other log record properties, and you can't get them in some nice, isolated way.
+    # So, to get the extra fields, we just compare all the properties present in the log record
+    # with properties present in an empty log record,
+    # and extract all the extra ones not present in the empty log record
     empty_record = logging.LogRecord('dummy', 0, 'dummy', 0, 'dummy', None, None)
 
     def _get_extra_fields(self, record: logging.LogRecord) -> Dict[str, Any]:

--- a/src/apify/log.py
+++ b/src/apify/log.py
@@ -1,0 +1,78 @@
+import json
+import logging
+import textwrap
+import traceback
+from typing import Any, Dict
+
+from colorama import Fore, Style, just_fix_windows_console
+
+just_fix_windows_console()
+
+
+# Name of the logger used throughout the library
+logger_name = __name__.split('.')[0]
+
+# Logger used throughout the library
+logger = logging.getLogger(logger_name)
+
+
+_LOG_LEVEL_COLOR = {
+    logging.DEBUG: Fore.BLUE,
+    logging.INFO: Fore.GREEN,
+    logging.WARNING: Fore.YELLOW,
+    logging.ERROR: Fore.RED,
+    logging.CRITICAL: Fore.RED,
+}
+
+_LOG_LEVEL_SHORT_ALIAS = {
+    logging.DEBUG: 'DEBUG',
+    logging.INFO: 'INFO ',
+    logging.WARNING: 'WARN ',
+    logging.ERROR: 'ERROR',
+}
+
+
+class ActorLogFormatter(logging.Formatter):
+    """Log formatter that prints out the log message nicely formatted, with colored level and stringified extra fields."""
+
+    empty_record = logging.LogRecord('dummy', 0, 'dummy', 0, 'dummy', None, None)
+
+    def _get_extra_fields(self, record: logging.LogRecord) -> Dict[str, Any]:
+        extra_fields: Dict[str, Any] = {}
+        for key, value in record.__dict__.items():
+            if key not in self.empty_record.__dict__:
+                extra_fields[key] = value
+
+        return extra_fields
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format the log record nicely.
+
+        This formats the log record so that it:
+        - starts with the level (colorized, and padded to 5 chars so that it is nicely aligned)
+        - then has the actual log message
+        - then has the stringified extra log fields
+        - then, if an exception is a part of the log record, prints the formatted exception
+        """
+        level_string = ''
+        if record.levelno != logging.NOTSET:
+            color_code = _LOG_LEVEL_COLOR.get(record.levelno, '')
+            short_alias = _LOG_LEVEL_SHORT_ALIAS.get(record.levelno, record.levelname)
+            level_string = f'{color_code}{short_alias}{Style.RESET_ALL} '
+
+        exception_string = ''
+        if record.exc_info:
+            exc_info = record.exc_info
+            record.exc_info = None
+            exception_string = ''.join(traceback.format_exception(*exc_info)).rstrip()
+            exception_string = '\n' + textwrap.indent(exception_string, '      ')
+
+        extra = self._get_extra_fields(record)
+        extra_string = ''
+        if extra:
+            extra_string = f' {Fore.LIGHTBLACK_EX}({json.dumps(extra, ensure_ascii=False, default=str)}){Style.RESET_ALL}'
+
+        log_string = super().format(record)
+        log_string = textwrap.indent(log_string, '      ').lstrip()
+
+        return f'{level_string}{log_string}{extra_string}{exception_string}'

--- a/src/apify/proxy_configuration.py
+++ b/src/apify/proxy_configuration.py
@@ -11,6 +11,7 @@ from apify_client import ApifyClientAsync
 
 from .config import Configuration
 from .consts import ApifyEnvVars
+from .log import logger
 
 APIFY_PROXY_VALUE_REGEX = r'^[\w._~]+$'
 COUNTRY_CODE_REGEX = r'^[A-Z]{2}$'
@@ -144,8 +145,8 @@ class ProxyConfiguration:
 
         # mypy has a bug with narrowing types for filter (https://github.com/python/mypy/issues/12682)
         if proxy_urls and next(filter(lambda url: 'apify.com' in url, proxy_urls), None):  # type: ignore
-            print('Some Apify proxy features may work incorrectly. Please consider setting up Apify properties instead of `proxy_urls`.\n'
-                  'See https://sdk.apify.com/docs/guides/proxy-management#apify-proxy-configuration')
+            logger.warning('Some Apify proxy features may work incorrectly. Please consider setting up Apify properties instead of `proxy_urls`.\n'
+                           'See https://sdk.apify.com/docs/guides/proxy-management#apify-proxy-configuration')
 
         self._actor_config = actor_config or Configuration._get_default_instance()
         self._apify_client = apify_client
@@ -278,8 +279,8 @@ class ProxyConfiguration:
 
                 if self._password:
                     if self._password != password:
-                        print('The Apify Proxy password you provided belongs to'
-                              ' a different user than the Apify token you are using. Are you sure this is correct?')
+                        logger.warning('The Apify Proxy password you provided belongs to'
+                                       ' a different user than the Apify token you are using. Are you sure this is correct?')
                 else:
                     self._password = password
 
@@ -308,8 +309,8 @@ class ProxyConfiguration:
 
             self.is_man_in_the_middle = status['isManInTheMiddle']
         else:
-            print('Apify Proxy access check timed out. Watch out for errors with status code 407. '
-                  "If you see some, it most likely means you don't have access to either all or some of the proxies you're trying to use.")
+            logger.warning('Apify Proxy access check timed out. Watch out for errors with status code 407. '
+                           "If you see some, it most likely means you don't have access to either all or some of the proxies you're trying to use.")
 
     def _get_username(self, session_id: Optional[Union[int, str]] = None) -> str:
         if session_id is not None:

--- a/src/apify/storages/request_queue.py
+++ b/src/apify/storages/request_queue.py
@@ -1,6 +1,4 @@
 import asyncio
-import json
-import logging
 from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Coroutine, Dict, Optional
@@ -14,6 +12,7 @@ from .._crypto import _crypto_random_object_id
 from .._utils import LRUCache, _budget_ow, _unique_key_to_request_id
 from ..config import Configuration
 from ..consts import REQUEST_QUEUE_HEAD_MAX_LIMIT
+from ..log import logger
 from ..memory_storage import MemoryStorage
 from ..memory_storage.resource_clients import RequestQueueClient
 from .storage_manager import StorageManager
@@ -208,11 +207,11 @@ class RequestQueue:
 
         # This should never happen, but...
         if next_request_id in self._in_progress or self._recently_handled.get(next_request_id):
-            logging.warning(f"""Queue head returned a request that is already in progress?! {json.dumps({
+            logger.warning('Queue head returned a request that is already in progress?!', extra={
                 'nextRequestId': next_request_id,
                 'inProgress': next_request_id in self._in_progress,
                 'recentlyHandled': next_request_id in self._recently_handled,
-            })}""")
+            })
             return None
         self._in_progress.add(next_request_id)
         self._last_activity = datetime.now(timezone.utc)
@@ -233,7 +232,7 @@ class RequestQueue:
                 will try to fetch this request again, until it eventually appears in the main table.
         """
         if request is None:
-            logging.debug(f'Cannot find a request from the beginning of queue, will be retried later. nextRequestId: {next_request_id}')
+            logger.debug('Cannot find a request from the beginning of queue, will be retried later', extra={'nextRequestId': next_request_id})
             asyncio.get_running_loop().call_later(STORAGE_CONSISTENCY_DELAY_MILLIS // 1000, lambda: self._in_progress.remove(next_request_id))
             return None
 
@@ -243,7 +242,7 @@ class RequestQueue:
                will not put the request again to queueHeadDict.
         """
         if request.get('handledAt') is not None:
-            logging.debug(f'Request fetched from the beginning of queue was already handled. nextRequestId: {next_request_id}')
+            logger.debug('Request fetched from the beginning of queue was already handled', extra={'nextRequestId': next_request_id})
             self._recently_handled[next_request_id] = True
             return None
 
@@ -268,7 +267,7 @@ class RequestQueue:
         })
         self._last_activity = datetime.now(timezone.utc)
         if request['id'] not in self._in_progress:
-            logging.debug(f'Cannot mark request {request["id"]} as handled, because it is not in progress!')
+            logger.debug('Cannot mark request as handled, because it is not in progress!', extra={'requestId': request['id']})
             return None
 
         request['handledAt'] = request.get('handledAt', datetime.now(timezone.utc))
@@ -305,7 +304,7 @@ class RequestQueue:
         self._last_activity = datetime.now(timezone.utc)
 
         if request['id'] not in self._in_progress:
-            logging.debug(f'Cannot reclaim request {request["id"]}, because it is not in progress!')
+            logger.debug('Cannot reclaim request, because it is not in progress!', extra={'requestId': request['id']})
             return None
 
         # TODO: If request hasn't been changed since the last getRequest(),
@@ -318,7 +317,7 @@ class RequestQueue:
         # This is to compensate for the limitation of DynamoDB, where writes might not be immediately visible to subsequent reads.
         def callback() -> None:
             if request['id'] not in self._in_progress:
-                logging.debug(f'The request is no longer marked as in progress in the queue?! requestId: {request["id"]}')
+                logger.debug('The request is no longer marked as in progress in the queue?!', {'requestId': request['id']})
                 return
 
             self._in_progress.remove(request['id'])
@@ -355,7 +354,7 @@ class RequestQueue:
         seconds_since_last_activity = (datetime.now(timezone.utc) - self._last_activity).seconds
         if self._in_progress_count() > 0 and seconds_since_last_activity > self._internal_timeout_seconds:
             message = f'The request queue seems to be stuck for {self._internal_timeout_seconds}s, resetting internal state.'
-            logging.warning(message)
+            logger.warning(message)
             self._reset()
 
         if (len(self._queue_head_dict) > 0 or self._in_progress_count() > 0):
@@ -433,7 +432,7 @@ class RequestQueue:
 
         # If limit was not reached in the call then there are no more requests to be returned.
         if (queue_head['prevLimit'] >= REQUEST_QUEUE_HEAD_MAX_LIMIT):
-            logging.warning(f'Reached the maximum number of requests in progress: {REQUEST_QUEUE_HEAD_MAX_LIMIT}.')
+            logger.warning('Reached the maximum number of requests in progress', extra={'limit': REQUEST_QUEUE_HEAD_MAX_LIMIT})
 
         should_repeat_with_higher_limit = len(
             self._queue_head_dict) == 0 and queue_head['wasLimitReached'] and queue_head['prevLimit'] < REQUEST_QUEUE_HEAD_MAX_LIMIT
@@ -462,7 +461,7 @@ class RequestQueue:
         if should_repeat_for_consistency:
             delay_seconds = (API_PROCESSED_REQUESTS_DELAY_MILLIS // 1000) - \
                 (datetime.now(timezone.utc) - queue_head['queueModifiedAt']).seconds
-            logging.info(f'Waiting for {delay_seconds}s before considering the queue as finished to ensure that the data is consistent.')
+            logger.info(f'Waiting for {delay_seconds}s before considering the queue as finished to ensure that the data is consistent.')
             await asyncio.sleep(delay_seconds)
 
         return await self._ensure_head_is_non_empty(ensure_consistency, next_limit, iteration + 1)

--- a/tests/integration/actor_source_base/src/__main__.py
+++ b/tests/integration/actor_source_base/src/__main__.py
@@ -1,15 +1,19 @@
 import asyncio
 import logging
 
-from apify_client._logging import _DebugLogFormatter
+from apify.log import ActorLogFormatter
 
 from .main import main
 
-client_logger = logging.getLogger('apify_client')
-if not client_logger.hasHandlers():
-    client_logger.setLevel(logging.DEBUG)
-    handler = logging.StreamHandler()
-    handler.setFormatter(_DebugLogFormatter())
-    client_logger.addHandler(handler)
+handler = logging.StreamHandler()
+handler.setFormatter(ActorLogFormatter())
+
+apify_client_logger = logging.getLogger('apify_client')
+apify_client_logger.setLevel(logging.DEBUG)
+apify_client_logger.addHandler(handler)
+
+apify_logger = logging.getLogger('apify')
+apify_logger.setLevel(logging.DEBUG)
+apify_logger.addHandler(handler)
 
 asyncio.run(main())

--- a/tests/integration/test_actor_log.py
+++ b/tests/integration/test_actor_log.py
@@ -1,0 +1,91 @@
+from apify import Actor, __version__
+from apify_client._version import __version__ as apify_client_version
+
+from .conftest import ActorFactory
+
+
+class TestActorLog:
+    async def test_actor_log(self, make_actor: ActorFactory) -> None:
+        async def main() -> None:
+            import logging
+
+            from apify.log import ActorLogFormatter, logger
+
+            # Clear any other log handlers, so they don't mess with this test
+            client_logger = logging.getLogger('apify_client')
+            apify_logger = logging.getLogger('apify')
+            client_logger.handlers.clear()
+            apify_logger.handlers.clear()
+
+            # Set handler only on the 'apify' logger
+            apify_logger.setLevel(logging.DEBUG)
+            handler = logging.StreamHandler()
+            handler.setFormatter(ActorLogFormatter())
+            apify_logger.addHandler(handler)
+
+            async with Actor:
+                # Test Actor.log
+                Actor.log.debug('Debug message')
+                Actor.log.info('Info message')
+
+                # Test logger
+                logger.warning('Warning message')
+                logger.error('Error message')
+
+                # Test that exception is logged with the traceback
+                try:
+                    raise ValueError('Dummy ValueError')
+                except Exception:
+                    Actor.log.exception('Exception message')
+
+                # Test multiline message being indented correctly
+                logger.info('Multi\nline\nlog\nmessage')
+
+                # Test that exception in Actor.main is logged with the traceback
+                raise RuntimeError('Dummy RuntimeError')
+
+        actor = await make_actor('actor-log', main_func=main)
+
+        run_result = await actor.call()
+
+        assert run_result is not None
+        assert run_result['status'] == 'FAILED'
+
+        run_log = await actor.last_run().log().get()
+        assert run_log is not None
+
+        run_log_lines = run_log.splitlines()
+
+        # This should prevent issues when the test run is migrated, and it would have its log restarted
+        expected_log_lines_count = 24
+        assert len(run_log_lines) >= expected_log_lines_count
+        run_log_lines = run_log_lines[-expected_log_lines_count:]
+
+        # This removes the datetime from the start of log lines
+        run_log_lines = list(map(lambda line: line[25:], run_log_lines))
+
+        # This might be way too specific and easy to break, but let's hope not
+        assert run_log_lines.pop(0) == 'ACTOR: Pulling Docker image from repository.'
+        assert run_log_lines.pop(0) == 'ACTOR: Creating Docker container.'
+        assert run_log_lines.pop(0) == 'ACTOR: Starting Docker container.'
+        assert run_log_lines.pop(0) == 'INFO  Initializing actor...'
+        assert run_log_lines.pop(0).startswith(f'INFO  System info ({{"apify_sdk_version": "{__version__}", "apify_client_version": "{apify_client_version}"')  # noqa: E501
+        assert run_log_lines.pop(0) == 'DEBUG Debug message'
+        assert run_log_lines.pop(0) == 'INFO  Info message'
+        assert run_log_lines.pop(0) == 'WARN  Warning message'
+        assert run_log_lines.pop(0) == 'ERROR Error message'
+        assert run_log_lines.pop(0) == 'ERROR Exception message'
+        assert run_log_lines.pop(0) == '      Traceback (most recent call last):'
+        assert run_log_lines.pop(0) == '        File "/usr/src/app/src/main.py", line 34, in main'
+        assert run_log_lines.pop(0) == "          raise ValueError('Dummy ValueError')"
+        assert run_log_lines.pop(0) == '      ValueError: Dummy ValueError'
+        assert run_log_lines.pop(0) == 'INFO  Multi'
+        assert run_log_lines.pop(0) == '      line'
+        assert run_log_lines.pop(0) == '      log'
+        assert run_log_lines.pop(0) == '      message'
+        assert run_log_lines.pop(0) == 'ERROR Actor failed with an exception'
+        assert run_log_lines.pop(0) == '      Traceback (most recent call last):'
+        assert run_log_lines.pop(0) == '        File "/usr/src/app/src/main.py", line 42, in main'
+        assert run_log_lines.pop(0) == "          raise RuntimeError('Dummy RuntimeError')"
+        assert run_log_lines.pop(0) == '      RuntimeError: Dummy RuntimeError'
+        assert run_log_lines.pop(0) == 'INFO  Exiting actor ({"exit_code": 91})'

--- a/tests/unit/actor/test_actor_helpers.py
+++ b/tests/unit/actor/test_actor_helpers.py
@@ -72,26 +72,30 @@ class TestActorCallStartAbortActor:
 class TestActorMethodsWorksOnlyOnPlatform:
     # NOTE: These medhods will be tested properly using integrations tests.
 
-    async def test_actor_metamorpth_not_work_locally(self, capfd: pytest.CaptureFixture) -> None:
+    async def test_actor_metamorpth_not_work_locally(self, caplog: pytest.LogCaptureFixture) -> None:
         async with Actor() as my_actor:
             await my_actor.metamorph('random-id')
-        out, err = capfd.readouterr()
-        assert 'Actor.metamorph() is only supported when running on the Apify platform.' in out
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == 'ERROR'
+        assert 'Actor.metamorph() is only supported when running on the Apify platform.' in caplog.records[0].message
 
-    async def test_actor_reboot_not_work_locally(self, capfd: pytest.CaptureFixture) -> None:
+    async def test_actor_reboot_not_work_locally(self, caplog: pytest.LogCaptureFixture) -> None:
         async with Actor() as my_actor:
             await my_actor.reboot()
-        out, err = capfd.readouterr()
-        assert 'Actor.reboot() is only supported when running on the Apify platform.' in out
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == 'ERROR'
+        assert 'Actor.reboot() is only supported when running on the Apify platform.' in caplog.records[0].message
 
-    async def test_actor_add_webhook_not_work_locally(self, capfd: pytest.CaptureFixture) -> None:
+    async def test_actor_add_webhook_not_work_locally(self, caplog: pytest.LogCaptureFixture) -> None:
         async with Actor() as my_actor:
             await my_actor.add_webhook(event_types=[WebhookEventType.ACTOR_BUILD_ABORTED], request_url='https://example.com')
-        out, err = capfd.readouterr()
-        assert 'Actor.add_webhook() is only supported when running on the Apify platform.' in out
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == 'ERROR'
+        assert 'Actor.add_webhook() is only supported when running on the Apify platform.' in caplog.records[0].message
 
-    async def test_actor_set_status_message_not_work_locally(self, capfd: pytest.CaptureFixture) -> None:
+    async def test_actor_set_status_message_not_work_locally(self, caplog: pytest.LogCaptureFixture) -> None:
         async with Actor() as my_actor:
             await my_actor.set_status_message('test')
-        out, err = capfd.readouterr()
-        assert 'Actor.set_status_message() is only supported when running on the Apify platform.' in out
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == 'ERROR'
+        assert 'Actor.set_status_message() is only supported when running on the Apify platform.' in caplog.records[0].message

--- a/tests/unit/actor/test_actor_log.py
+++ b/tests/unit/actor/test_actor_log.py
@@ -1,0 +1,86 @@
+import logging
+import sys
+
+import pytest
+
+from apify import Actor, __version__
+from apify.log import logger
+from apify_client._version import __version__ as apify_client_version
+
+
+class TestActorLog:
+    async def test_actor_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.DEBUG)
+        try:
+            async with Actor:
+                # Test Actor.log
+                Actor.log.debug('Debug message')
+                Actor.log.info('Info message')
+
+                # Test logger
+                logger.warning('Warning message')
+                logger.error('Error message')
+
+                # Test that exception is logged with the traceback
+                try:
+                    raise ValueError('Dummy ValueError')
+                except Exception:
+                    Actor.log.exception('Exception message')
+
+                # Test multiline message being indented correctly
+                logger.info('Multi\nline\nlog\nmessage')
+
+                # Test that exception in Actor.main is logged with the traceback
+                raise RuntimeError('Dummy RuntimeError')
+        except RuntimeError:
+            pass
+
+        assert len(caplog.records) == 12
+
+        assert caplog.records[0].levelno == logging.INFO
+        assert caplog.records[0].message == 'Initializing actor...'
+
+        assert caplog.records[1].levelno == logging.INFO
+        assert caplog.records[1].message == 'System info'
+        assert getattr(caplog.records[1], 'apify_sdk_version', None) == __version__
+        assert getattr(caplog.records[1], 'apify_client_version', None) == apify_client_version
+        assert getattr(caplog.records[1], 'python_version', None) == '.'.join([str(x) for x in sys.version_info[:3]])
+        assert getattr(caplog.records[1], 'os', None) == sys.platform
+
+        assert caplog.records[2].levelno == logging.DEBUG
+        assert caplog.records[2].message.startswith('APIFY_ACTOR_EVENTS_WS_URL env var not set')
+
+        assert caplog.records[3].levelno == logging.DEBUG
+        assert caplog.records[3].message == 'Debug message'
+
+        assert caplog.records[4].levelno == logging.INFO
+        assert caplog.records[4].message == 'Info message'
+
+        assert caplog.records[5].levelno == logging.WARNING
+        assert caplog.records[5].message == 'Warning message'
+
+        assert caplog.records[6].levelno == logging.ERROR
+        assert caplog.records[6].message == 'Error message'
+
+        assert caplog.records[7].levelno == logging.ERROR
+        assert caplog.records[7].message == 'Exception message'
+        assert caplog.records[7].exc_info is not None
+        assert caplog.records[7].exc_info[0] == ValueError
+        assert isinstance(caplog.records[7].exc_info[1], ValueError)
+        assert str(caplog.records[7].exc_info[1]) == 'Dummy ValueError'
+
+        assert caplog.records[8].levelno == logging.INFO
+        assert caplog.records[8].message == 'Multi\nline\nlog\nmessage'
+
+        assert caplog.records[9].levelno == logging.ERROR
+        assert caplog.records[9].message == 'Actor failed with an exception'
+        assert caplog.records[9].exc_info is not None
+        assert caplog.records[9].exc_info[0] == RuntimeError
+        assert isinstance(caplog.records[9].exc_info[1], RuntimeError)
+        assert str(caplog.records[9].exc_info[1]) == 'Dummy RuntimeError'
+
+        assert caplog.records[10].levelno == logging.INFO
+        assert caplog.records[10].message == 'Exiting actor'
+
+        assert caplog.records[11].levelno == logging.DEBUG
+        assert caplog.records[11].message == 'Not calling sys.exit(91) because actor is running in an unit test'

--- a/tests/unit/test_proxy_configuration.py
+++ b/tests/unit/test_proxy_configuration.py
@@ -344,7 +344,7 @@ class TestProxyConfigurationInitialize:
     async def test_initialize_manual_password_different_than_user_one(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        capsys: pytest.CaptureFixture,
+        caplog: pytest.LogCaptureFixture,
         respx_mock: MockRouter,
         patched_apify_client: ApifyClientAsync,
     ) -> None:
@@ -367,8 +367,9 @@ class TestProxyConfigurationInitialize:
         assert proxy_configuration._password == different_dummy_password
         assert proxy_configuration.is_man_in_the_middle is True
 
-        out, _ = capsys.readouterr()
-        assert 'The Apify Proxy password you provided belongs to a different user' in out
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == 'WARNING'
+        assert 'The Apify Proxy password you provided belongs to a different user' in caplog.records[0].message
 
     async def test_initialize_not_connected(
         self,
@@ -392,7 +393,7 @@ class TestProxyConfigurationInitialize:
     async def test_initialize_status_page_unavailable(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        capsys: pytest.CaptureFixture,
+        caplog: pytest.LogCaptureFixture,
         respx_mock: MockRouter,
     ) -> None:
         dummy_proxy_status_url = 'http://dummy-proxy-status-url.com'
@@ -404,8 +405,9 @@ class TestProxyConfigurationInitialize:
 
         await proxy_configuration.initialize()
 
-        out, _ = capsys.readouterr()
-        assert 'Apify Proxy access check timed out' in out
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == 'WARNING'
+        assert 'Apify Proxy access check timed out' in caplog.records[0].message
 
     async def test_initialize_not_called_non_apify_proxy(
         self,


### PR DESCRIPTION
This PR adds a new submodule, `apify.log`, and in it a `logger`, which is just a standard logger from the `logging` library, with name `apify` as per best practices for Python logging. It also makes it available under the `Actor.log` property, for convenience.

The main magic happens in the `ActorLogFormatter`, which is a log formatter that consumes the logging messages, and formats them so they are pretty:

<img width="1327" alt="Screenshot 2023-02-15 at 10 31 01" src="https://user-images.githubusercontent.com/2934111/218988666-97fdc1b3-c33f-4f71-a7f1-842a86de8433.png">

The log formatter and handler is attached in the actor setup, so in the `__main__.py` file. We'll have to put the setup in all the Python actor templates so that it's applied in the actors by default.

The integration tests and unit tests might be too strict, and any slight change might break them, so if it happens too often, we can rewrite them a bit.