### PR TITLE
Remove `pydantic`

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1598,8 +1598,8 @@ If you want to use your own proxies, use the proxy_urls or new_url_function cons
 Your list of proxy URLs will be rotated by the configuration, if this option is provided.
 
 * [async initialize()](#proxyconfiguration-initialize)
-* [new\_url()](#proxyconfiguration-new\_url)
-* [new\_proxy\_info()](#proxyconfiguration-new\_proxy\_info)
+* [async new\_url()](#proxyconfiguration-new\_url)
+* [async new\_proxy\_info()](#proxyconfiguration-new\_proxy\_info)
 
 ***
 
@@ -1619,7 +1619,7 @@ to create a pre-initialized ProxyConfiguration instance instead of calling this 
 
 ***
 
-#### [](#proxyconfiguration-new_url) `ProxyConfiguration.new_url(session_id=None)`
+#### [](#proxyconfiguration-new_url) `async ProxyConfiguration.new_url(session_id=None)`
 
 Return a new proxy URL based on provided configuration options and the sessionId parameter.
 
@@ -1645,7 +1645,7 @@ Return a new proxy URL based on provided configuration options and the sessionId
 
 ***
 
-#### [](#proxyconfiguration-new_proxy_info) `ProxyConfiguration.new_proxy_info(session_id=None)`
+#### [](#proxyconfiguration-new_proxy_info) `async ProxyConfiguration.new_proxy_info(session_id=None)`
 
 Create a new ProxyInfo object.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,8 +6,6 @@ files =
     src,
     tests,
     setup.py
-plugins =
-    pydantic.mypy
 check_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_calls = True

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
         'cryptography ~= 39.0.1',
         'httpx ~= 0.23.0',
         'psutil ~= 5.9.4',
-        'pydantic ~= 1.10.2',
         'pyee ~= 9.0.4',
         'typing-extensions ~= 4.4.0',
         'websockets ~= 10.4',

--- a/src/apify/actor.py
+++ b/src/apify/actor.py
@@ -1292,8 +1292,8 @@ class Actor(metaclass=_ActorContextManager):
             country_code=country_code,
             proxy_urls=proxy_urls,
             new_url_function=new_url_function,
-            actor_config=self._config,
-            apify_client=self._apify_client,
+            _actor_config=self._config,
+            _apify_client=self._apify_client,
         )
 
         await proxy_configuration.initialize()

--- a/src/apify/proxy_configuration.py
+++ b/src/apify/proxy_configuration.py
@@ -1,11 +1,11 @@
 import inspect
+import ipaddress
 import re
-from typing import Any, Awaitable, Callable, Dict, List, Optional, TypedDict, Union
-from urllib.parse import urlparse
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Pattern, TypedDict, Union
+from urllib.parse import urljoin, urlparse
 
 import httpx
-from pydantic import AnyUrl, Field, validate_arguments
-from typing_extensions import Annotated, NotRequired
+from typing_extensions import NotRequired
 
 from apify_client import ApifyClientAsync
 
@@ -13,18 +13,33 @@ from .config import Configuration
 from .consts import ApifyEnvVars
 from .log import logger
 
-APIFY_PROXY_VALUE_REGEX = r'^[\w._~]+$'
-COUNTRY_CODE_REGEX = r'^[A-Z]{2}$'
+APIFY_PROXY_VALUE_REGEX = re.compile(r'^[\w._~]+$')
+COUNTRY_CODE_REGEX = re.compile(r'^[A-Z]{2}$')
 SESSION_ID_MAX_LENGTH = 50
-SESSION_ID_PYDANTIC_FIELD = Field(regex=APIFY_PROXY_VALUE_REGEX, max_length=SESSION_ID_MAX_LENGTH)
 
 
-# TODO: Remove this once Pydantic fixes https://github.com/pydantic/pydantic/issues/4333
+def _is_url(url: str) -> bool:
+    try:
+        parsed_url = urlparse(urljoin(url, '/'))
+        has_all_parts = all([parsed_url.scheme, parsed_url.netloc, parsed_url.path])
+        is_domain = '.' in parsed_url.netloc
+        is_localhost = parsed_url.netloc == 'localhost'
+        try:
+            ipaddress.ip_address(parsed_url.netloc)
+            is_ip_address = True
+        except Exception:
+            is_ip_address = False
+
+        return has_all_parts and any([is_domain, is_localhost, is_ip_address])
+    except Exception:
+        return False
+
+
 def _check(
     value: Any,
     *,
     label: Optional[str],
-    regex: Optional[str] = None,
+    pattern: Optional[Pattern] = None,
     min_length: Optional[int] = None,
     max_length: Optional[int] = None,
 ) -> None:
@@ -38,8 +53,8 @@ def _check(
     if max_length and len(value) > max_length:
         raise ValueError(f'{error_str} is longer than maximum allowed length {max_length}')
 
-    if regex and not re.match(regex, value):
-        raise ValueError(f'{error_str} does not match regex {regex}')
+    if pattern and not re.fullmatch(pattern, value):
+        raise ValueError(f'{error_str} does not match pattern {repr(pattern.pattern)}')
 
 
 class ProxyInfo(TypedDict):
@@ -107,17 +122,16 @@ class ProxyConfiguration:
     _actor_config: Configuration
     _apify_client: Optional[ApifyClientAsync] = None
 
-    @validate_arguments(config={'arbitrary_types_allowed': True})
     def __init__(
         self,
         *,
         password: Optional[str] = None,
-        groups: Optional[List[Annotated[str, Field(regex=APIFY_PROXY_VALUE_REGEX)]]] = None,
-        country_code: Optional[Annotated[str, Field(regex=COUNTRY_CODE_REGEX)]] = None,
-        proxy_urls: Optional[List[Annotated[str, AnyUrl]]] = None,
+        groups: Optional[List[str]] = None,
+        country_code: Optional[str] = None,
+        proxy_urls: Optional[List[str]] = None,
         new_url_function: Optional[Union[Callable[[Optional[str]], str], Callable[[Optional[str]], Awaitable[str]]]] = None,
-        actor_config: Optional[Configuration] = None,
-        apify_client: Optional[ApifyClientAsync] = None,
+        _actor_config: Optional[Configuration] = None,
+        _apify_client: Optional[ApifyClientAsync] = None,
     ):
         """Create a ProxyConfiguration instance. It is highly recommended to use `Actor.create_proxy_configuration()` instead of this.
 
@@ -127,12 +141,18 @@ class ProxyConfiguration:
             country_code (str, optional): Country which the Apify Proxy should use, if provided.
             proxy_urls (list of str, optional): Custom proxy server URLs which should be rotated through.
             new_url_function (Callable, optional): Function which returns a custom proxy URL to be used.
-        """  # noqa: D417 # we don't want to document the actor_config and apify_client arguments, they're internal
+        """
         if groups:
+            groups = [str(group) for group in groups]
             for group in groups:
-                _check(group, label='groups', regex=APIFY_PROXY_VALUE_REGEX)
+                _check(group, label='groups', pattern=APIFY_PROXY_VALUE_REGEX)
         if country_code:
-            _check(country_code, label='country_code', regex=COUNTRY_CODE_REGEX)
+            country_code = str(country_code)
+            _check(country_code, label='country_code', pattern=COUNTRY_CODE_REGEX)
+        if proxy_urls:
+            for (i, url) in enumerate(proxy_urls):
+                if not _is_url(url):
+                    raise ValueError(f'proxy_urls[{i}] ("{url}") is not a valid URL')
 
         # Validation
         if proxy_urls and new_url_function:
@@ -148,8 +168,8 @@ class ProxyConfiguration:
             logger.warning('Some Apify proxy features may work incorrectly. Please consider setting up Apify properties instead of `proxy_urls`.\n'
                            'See https://sdk.apify.com/docs/guides/proxy-management#apify-proxy-configuration')
 
-        self._actor_config = actor_config or Configuration._get_default_instance()
-        self._apify_client = apify_client
+        self._actor_config = _actor_config or Configuration._get_default_instance()
+        self._apify_client = _apify_client
 
         self._hostname = self._actor_config.proxy_hostname
         self._port = self._actor_config.proxy_port
@@ -175,8 +195,7 @@ class ProxyConfiguration:
             await self._maybe_fetch_password()
             await self._check_access()
 
-    @validate_arguments
-    async def new_url(self, session_id: Optional[Annotated[Union[int, str], SESSION_ID_PYDANTIC_FIELD]] = None) -> str:
+    async def new_url(self, session_id: Optional[Union[int, str]] = None) -> str:
         """Return a new proxy URL based on provided configuration options and the `sessionId` parameter.
 
         Args:
@@ -191,7 +210,7 @@ class ProxyConfiguration:
         """
         if session_id is not None:
             session_id = f'{session_id}'
-            _check(session_id, label='session_id', max_length=SESSION_ID_MAX_LENGTH, regex=APIFY_PROXY_VALUE_REGEX)
+            _check(session_id, label='session_id', max_length=SESSION_ID_MAX_LENGTH, pattern=APIFY_PROXY_VALUE_REGEX)
 
         if self._new_url_function:
             try:
@@ -219,8 +238,7 @@ class ProxyConfiguration:
 
         return f'http://{username}:{self._password}@{self._hostname}:{self._port}'
 
-    @validate_arguments
-    async def new_proxy_info(self, session_id: Optional[Annotated[Union[int, str], SESSION_ID_PYDANTIC_FIELD]] = None) -> ProxyInfo:
+    async def new_proxy_info(self, session_id: Optional[Union[int, str]] = None) -> ProxyInfo:
         """Create a new ProxyInfo object.
 
         Use it if you want to work with a rich representation of a proxy URL.
@@ -237,7 +255,7 @@ class ProxyConfiguration:
         """
         if session_id is not None:
             session_id = f'{session_id}'
-            _check(session_id, label='session_id', max_length=SESSION_ID_MAX_LENGTH, regex=APIFY_PROXY_VALUE_REGEX)
+            _check(session_id, label='session_id', max_length=SESSION_ID_MAX_LENGTH, pattern=APIFY_PROXY_VALUE_REGEX)
 
         url = await self.new_url(session_id)
         res: ProxyInfo

--- a/tests/unit/test_proxy_configuration.py
+++ b/tests/unit/test_proxy_configuration.py
@@ -7,7 +7,7 @@ import pytest
 from respx import MockRouter
 
 from apify.consts import ApifyEnvVars
-from apify.proxy_configuration import ProxyConfiguration
+from apify.proxy_configuration import ProxyConfiguration, _is_url
 from apify_client import ApifyClientAsync
 
 from .conftest import ApifyClientAsyncPatcher
@@ -63,6 +63,9 @@ class TestProxyConfiguration:
 
         with pytest.raises(ValueError, match='Cannot combine custom proxies with Apify Proxy'):
             ProxyConfiguration(proxy_urls=['http://proxy.com:1111'], groups=['GROUP1'])
+
+        with pytest.raises(ValueError, match=re.escape('proxy_urls[0] ("http://bad-url") is not a valid URL')):
+            ProxyConfiguration(proxy_urls=['http://bad-url'])
 
         with pytest.raises(ValueError, match='Cannot combine custom proxies with Apify Proxy'):
             ProxyConfiguration(new_url_function=lambda _: 'http://proxy.com:2222', groups=['GROUP1'])
@@ -304,7 +307,7 @@ class TestProxyConfigurationInitialize:
             'isManInTheMiddle': True,
         }))
 
-        proxy_configuration = ProxyConfiguration(apify_client=patched_apify_client)
+        proxy_configuration = ProxyConfiguration(_apify_client=patched_apify_client)
 
         await proxy_configuration.initialize()
 
@@ -360,7 +363,7 @@ class TestProxyConfigurationInitialize:
             'isManInTheMiddle': True,
         }))
 
-        proxy_configuration = ProxyConfiguration(apify_client=patched_apify_client)
+        proxy_configuration = ProxyConfiguration(_apify_client=patched_apify_client)
 
         await proxy_configuration.initialize()
 
@@ -427,3 +430,23 @@ class TestProxyConfigurationInitialize:
 
         assert len(patched_apify_client.calls['user']['get']) == 0  # type: ignore
         assert len(route.calls) == 0
+
+
+class TestIsUrl:
+    def test__is_url(self) -> None:
+        assert _is_url('http://dummy-proxy.com:8000') is True
+        assert _is_url('https://example.com') is True
+        assert _is_url('http://localhost') is True
+        assert _is_url('https://12.34.56.78') is True
+        assert _is_url('http://12.34.56.78:9012') is True
+        assert _is_url('http://::1') is True
+        assert _is_url('https://2f45:4da6:8f56:af8c:5dce:c1de:14d2:8661') is True
+
+        assert _is_url('dummy-proxy.com:8000') is False
+        assert _is_url('gyfwgfhkjhljkfhdsf') is False
+        assert _is_url('http://') is False
+        assert _is_url('http://example') is False
+        assert _is_url('http:/example.com') is False
+        assert _is_url('12.34.56.78') is False
+        assert _is_url('::1') is False
+        assert _is_url('https://4da6:8f56:af8c:5dce:c1de:14d2:8661') is False


### PR DESCRIPTION
This PR removes `pydantic` and replaces it with custom argument validation.

It had many drawbacks and it was not super useful for us:
- it broke marking methods as `async` in documentation
- it had ~2.5 MB (30% of all dependencies of the SDK)
- it was a pain to use correctly because it had bugs with validating nested annotated types
- we were only really using it to validate URLs

Now, the only huge dependency is the `cryptography` library, which has 5 MB, but that is much more valuable for us.