### PR TITLE
Make sure local `RequestQueueClient` respects `forefront`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 
 - fixed parsing messages from the platform events websocket when they have no event data
 - fixed `EventManager` not waiting for platform events websocket connection during initialization
+- fixed local `RequestQueueClient` not respecting the `forefront` argument
 
 ### Internal changes
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint:
 	python3 -m flake8
 
 unit-tests:
-	python3 -m pytest -rA tests/unit
+	python3 -m pytest -n auto -ra tests/unit
 
 integration-tests:
 	python3 -m pytest -n $(INTEGRATION_TESTS_CONCURRENCY) -ra tests/integration

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint:
 	python3 -m flake8
 
 unit-tests:
-	python3 -m pytest -n auto -ra tests/unit
+	python3 -m pytest -rA tests/unit
 
 integration-tests:
 	python3 -m pytest -n $(INTEGRATION_TESTS_CONCURRENCY) -ra tests/integration

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'httpx ~= 0.23.0',
         'psutil ~= 5.9.4',
         'pyee ~= 9.0.4',
+        'sortedcollections ~= 2.1.0',
         'typing-extensions ~= 4.4.0',
         'websockets ~= 10.4',
     ],

--- a/tests/unit/memory_storage/resource_clients/test_request_queue.py
+++ b/tests/unit/memory_storage/resource_clients/test_request_queue.py
@@ -157,3 +157,42 @@ async def test_delete_record(request_queue_client: RequestQueueClient) -> None:
     assert rq_info_after_update['pendingRequestCount'] == 0
     # Does not crash when called again
     await request_queue_client.delete_request(request_info['requestId'])
+
+
+async def test_forefront(request_queue_client: RequestQueueClient) -> None:
+    # this should create a queue with requests in this order:
+    # Handled:
+    #     2, 5, 8
+    # Not handled:
+    #     7, 4, 1, 0, 3, 6
+    for i in range(9):
+        request_url = f'http://example.com/{i}'
+        forefront = i % 3 == 1
+        was_handled = i % 3 == 2
+        await request_queue_client.add_request({
+            'uniqueKey': str(i),
+            'url': request_url,
+            'handledAt': datetime.now(timezone.utc) if was_handled else None,
+        }, forefront=forefront)
+
+    # Check that the queue head (unhandled items) is in the right order
+    queue_head = await request_queue_client.list_head()
+    req_unique_keys = [req['uniqueKey'] for req in queue_head['items']]
+    assert req_unique_keys == ['7', '4', '1', '0', '3', '6']
+
+    # Mark request #6 as handled
+    await request_queue_client.update_request({
+        'uniqueKey': '1',
+        'url': 'http://example.com/1',
+        'handledAt': datetime.now(timezone.utc),
+    })
+    # Move request #3 to forefront
+    await request_queue_client.update_request({
+        'uniqueKey': '3',
+        'url': 'http://example.com/3',
+    }, forefront=True)
+
+    # Check that the queue head (unhandled items) is in the right order after the updates
+    queue_head = await request_queue_client.list_head()
+    req_unique_keys = [req['uniqueKey'] for req in queue_head['items']]
+    assert req_unique_keys == ['3', '7', '4', '0', '6']

--- a/tests/unit/memory_storage/resource_clients/test_request_queue.py
+++ b/tests/unit/memory_storage/resource_clients/test_request_queue.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 from datetime import datetime, timezone
+from pprint import pprint
 
 import pytest
 
@@ -159,6 +160,7 @@ async def test_delete_record(request_queue_client: RequestQueueClient) -> None:
     await request_queue_client.delete_request(request_info['requestId'])
 
 
+@pytest.mark.only
 async def test_forefront(request_queue_client: RequestQueueClient) -> None:
     # this should create a queue with requests in this order:
     # Handled:
@@ -175,12 +177,14 @@ async def test_forefront(request_queue_client: RequestQueueClient) -> None:
             'handledAt': datetime.now(timezone.utc) if was_handled else None,
         }, forefront=forefront)
 
+    pprint(list(request_queue_client._client._request_queues_handled[0]._requests.items()))
+
     # Check that the queue head (unhandled items) is in the right order
     queue_head = await request_queue_client.list_head()
     req_unique_keys = [req['uniqueKey'] for req in queue_head['items']]
     assert req_unique_keys == ['7', '4', '1', '0', '3', '6']
 
-    # Mark request #6 as handled
+    # Mark request #1 as handled
     await request_queue_client.update_request({
         'uniqueKey': '1',
         'url': 'http://example.com/1',

--- a/tests/unit/memory_storage/resource_clients/test_request_queue.py
+++ b/tests/unit/memory_storage/resource_clients/test_request_queue.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 from datetime import datetime, timezone
-from pprint import pprint
 
 import pytest
 
@@ -160,7 +159,6 @@ async def test_delete_record(request_queue_client: RequestQueueClient) -> None:
     await request_queue_client.delete_request(request_info['requestId'])
 
 
-@pytest.mark.only
 async def test_forefront(request_queue_client: RequestQueueClient) -> None:
     # this should create a queue with requests in this order:
     # Handled:
@@ -176,8 +174,6 @@ async def test_forefront(request_queue_client: RequestQueueClient) -> None:
             'url': request_url,
             'handledAt': datetime.now(timezone.utc) if was_handled else None,
         }, forefront=forefront)
-
-    pprint(list(request_queue_client._client._request_queues_handled[0]._requests.items()))
 
     # Check that the queue head (unhandled items) is in the right order
     queue_head = await request_queue_client.list_head()


### PR DESCRIPTION
This makes sure that the `RequestQueueClient` in `MemoryStorage` respects forefront, and maintains proper order of inserted requests.

This wasn't so hard in the end, I found [this neat library](https://grantjenks.com/docs/sortedcollections/valuesorteddict.html)
that takes care of keeping the requests sorted in memory.

I've also changed `orderNo` to be a `Decimal`, in milliseconds, and I've added logic that makes sure it's unique, to make the sorting work correctly.

Resolves #66.