### PR TITLE
Start triggering Docker image builds on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,31 +118,18 @@ jobs:
 
     - # Upload the build artifacts to the release
       name: Upload the build artifacts to release
-      uses: svenstaro/upload-release-action@v2
       if: github.event_name == 'release'
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: dist/*
-        file_glob: true
-        tag: ${{ github.ref }}
+      run: gh release upload ${{ github.ref_name }} dist/*
+      env:
+        GH_TOKEN: ${{ github.token }}
 
-    - # Get the current package version for use in Docker images
-        name: Parse package version for Docker images
-        id: get-package-version
-        run: |
-          package_version=`python ./scripts/print_current_package_version.py`
-          echo "package_version=$package_version" >> $GITHUB_OUTPUT
-
-#    - # Trigger building the docker images in apify/apify-actor-docker repo
-#      name: Trigger Docker Image Build
-#      uses: peter-evans/repository-dispatch@v2
-#      if: steps.get-release-type.outputs.docker_image_tag != ''
-#      with:
-#        token: ${{ secrets.TRIGGER_DOCKER_IMAGE_BUILD_TOKEN }}
-#        repository: apify/apify-actor-docker
-#        event-type: build-python-images
-#        client-payload: >
-#          {
-#            "release_tag": "${{ steps.get-release-type.outputs.docker_image_tag }}",
-#            "apify_sdk_version": "${{ steps.get-package-version.outputs.package_version }}"
-#          }
+    - # Trigger building the Python Docker images in apify/apify-actor-docker repo
+      name: Trigger Docker image build
+      run: |
+        PACKAGE_VERSION=`python ./scripts/print_current_package_version.py`
+        gh api -X POST "/repos/apify/apify-actor-docker/dispatches" \
+          -F event_type=build-python-images \
+          -F client_payload[release_tag]=${{ steps.get-release-type.outputs.docker_image_tag }} \
+          -F client_payload[apify_version]=$PACKAGE_VERSION
+      env:
+        GH_TOKEN: ${{ secrets.BUILD_DOCKER_IMAGES_REPOSITORY_DISPATCH_GH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 [1.0.0](../../releases/tag/v1.0.0) - Upcoming
 ---------------------------------------------
 
+### Internal changes
+
+- started triggering base Docker image builds when releasing a new version
+
 [0.2.0](../../releases/tag/v0.2.0) - 2023-03-06
 -----------------------------------------------
 


### PR DESCRIPTION
Since we're about to release 1.0.0, we should start including it in our base images.

This will start calling the `repository_dispatch` event in https://github.com/apify/apify-actor-docker/blob/master/.github/workflows/release-python.yml#L13-L14 (and other Python image workflows), and that will start building the images.

There's also an [accompanying PR](https://github.com/apify/apify-actor-docker/pull/93) in `apify-actor-docker`, which has to be merged first.

I've also simplified the workflow a bit and rewrote it to not use third-party actions, so that we're not that vulnerable to supply chain attacks, especially since we're passing PATs with high permissions to the actions.