### PR TITLE
Fix detecting signature of built-in functions in event handler

### DIFF
--- a/tests/unit/test_event_manager.py
+++ b/tests/unit/test_event_manager.py
@@ -3,6 +3,7 @@ import json
 import logging
 import time
 from collections import defaultdict
+from pprint import pprint
 from typing import Any, Callable, Dict, Optional, Set
 
 import pytest
@@ -152,6 +153,9 @@ class TestEventManagerLocal:
 
         # built-in functions should work too
         event_manager.on(ActorEventTypes.SYSTEM_INFO, print)
+
+        # functions from the standard library should work too
+        event_manager.on(ActorEventTypes.SYSTEM_INFO, pprint)
 
         with pytest.raises(ValueError, match='The "listener" argument must be a callable which accepts 0 or 1 arguments!'):
             event_manager.on(ActorEventTypes.SYSTEM_INFO, sync_two_arguments)  # type: ignore[arg-type]

--- a/tests/unit/test_event_manager.py
+++ b/tests/unit/test_event_manager.py
@@ -135,10 +135,23 @@ class TestEventManagerLocal:
         async def async_two_arguments(_arg1: Any, _arg2: Any) -> None:
             pass
 
+        def sync_two_arguments_one_default(event_data: Any, _arg2: Any = 'default_value') -> None:
+            nonlocal event_calls
+            event_calls.append(('sync_two_arguments_one_default', event_data))
+
+        async def async_two_arguments_one_default(event_data: Any, _arg2: Any = 'default_value') -> None:
+            nonlocal event_calls
+            event_calls.append(('async_two_arguments_one_default', event_data))
+
         event_manager.on(ActorEventTypes.SYSTEM_INFO, sync_no_arguments)
         event_manager.on(ActorEventTypes.SYSTEM_INFO, async_no_arguments)
         event_manager.on(ActorEventTypes.SYSTEM_INFO, sync_one_argument)
         event_manager.on(ActorEventTypes.SYSTEM_INFO, async_one_argument)
+        event_manager.on(ActorEventTypes.SYSTEM_INFO, sync_two_arguments_one_default)
+        event_manager.on(ActorEventTypes.SYSTEM_INFO, async_two_arguments_one_default)
+
+        # built-in functions should work too
+        event_manager.on(ActorEventTypes.SYSTEM_INFO, print)
 
         with pytest.raises(ValueError, match='The "listener" argument must be a callable which accepts 0 or 1 arguments!'):
             event_manager.on(ActorEventTypes.SYSTEM_INFO, sync_two_arguments)  # type: ignore[arg-type]
@@ -148,11 +161,13 @@ class TestEventManagerLocal:
         event_manager.emit(ActorEventTypes.SYSTEM_INFO, 'DUMMY_SYSTEM_INFO')
         await asyncio.sleep(0.1)
 
-        assert len(event_calls) == 4
+        assert len(event_calls) == 6
         assert ('sync_no_arguments', None) in event_calls
         assert ('async_no_arguments', None) in event_calls
         assert ('sync_one_argument', 'DUMMY_SYSTEM_INFO') in event_calls
         assert ('async_one_argument', 'DUMMY_SYSTEM_INFO') in event_calls
+        assert ('sync_two_arguments_one_default', 'DUMMY_SYSTEM_INFO') in event_calls
+        assert ('async_two_arguments_one_default', 'DUMMY_SYSTEM_INFO') in event_calls
 
     async def test_event_async_handling_local(self) -> None:
         config = Configuration()


### PR DESCRIPTION
I found out that `inspect.signature()` cannot read the signature of built-in methods, so e.g. `Actor.on(ActorEventTypes.SYSTEM_INFO, print)` would not work.

This fixes it by rewriting the signature-processing to ignore errors when the signature can't be read, and also to better check methods which have default arguments, by just trying to bind the arguments to the method signature.