### PR TITLE
feat: use test user token from organisation secrets

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -34,4 +34,4 @@ jobs:
     - name: Run integration tests
       run: make INTEGRATION_TESTS_CONCURRENCY=8 integration-tests
       env:
-        APIFY_TEST_USER_API_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
+        APIFY_TEST_USER_API_TOKEN: ${{ secrets.APIFY_TEST_USER_PYTHON_SDK_API_TOKEN }}


### PR DESCRIPTION
I removed `APIFY_TEST_USER_API_TOKEN` from repository secrets and keep only one from organisation.