### PR TITLE
chore: Pin apify deps versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apify"
-version = "1.1.3"
+version = "1.1.2"
 description = "Apify SDK for Python"
 readme = "README.md"
 license = {text = "Apache Software License"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apify"
-version = "1.1.2"
+version = "1.1.3"
 description = "Apify SDK for Python"
 readme = "README.md"
 license = {text = "Apache Software License"}
@@ -25,8 +25,8 @@ requires-python = ">=3.8"
 dependencies = [
     "aiofiles >= 22.1.0",
     "aioshutil >= 1.0",
-    "apify-client >= 1.3.1",
-    "apify-shared >= 1.0.2",
+    "apify-client == 1.3.1",
+    "apify-shared == 1.0.2",
     "colorama >= 0.4.6",
     "cryptography >= 39.0.0",
     "httpx >= 0.24.1",


### PR DESCRIPTION
We pin Apify deps versions to prevent newer packages breaking older SDK versions