### PR TITLE
Actor.reboot method uses the new reboot endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+[1.2.0](../../releases/tag/v1.2.0) - 2023-08-23
+-----------------------------------------------
+
+### Added
+
+- Update the `Actor.reboot` method to use the new reboot endpoint
+
+### Internal changes
+
+- Unify indentation in configuration files
+
 [1.1.2](../../releases/tag/v1.1.2) - 2023-08-02
 -----------------------------------------------
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -869,7 +869,7 @@ The system stops the current container and starts a new one, with the same run I
 
   * **event_listeners_timeout_secs** (`int`, *optional*) – How long should the actor wait for actor event listeners to finish before exiting
 
-  * **custom_after_sleep_millis** (`int`, *optional*) – How long to sleep for after the metamorph, to wait for the container to be stopped.
+  * **custom_after_sleep_millis** (`int`, *optional*) – How long to sleep for after the reboot, to wait for the container to be stopped.
 
 * **Return type**
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -859,7 +859,7 @@ and the new input is stored under the INPUT-METAMORPH-1 key in the same default 
 
 ***
 
-#### [](#actor-reboot) `async Actor.reboot(*, event_listeners_timeout_secs=5)`
+#### [](#actor-reboot) `async Actor.reboot(*, event_listeners_timeout_secs=5, custom_after_sleep_millis=None)`
 
 Internally reboot this actor.
 
@@ -868,6 +868,8 @@ The system stops the current container and starts a new one, with the same run I
 * **Parameters**
 
   * **event_listeners_timeout_secs** (`int`, *optional*) – How long should the actor wait for actor event listeners to finish before exiting
+
+  * **custom_after_sleep_millis** (`int`, *optional*) – How long to sleep for after the metamorph, to wait for the container to be stopped.
 
 * **Return type**
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -557,13 +557,15 @@ Get the actor input value from the default key-value store associated with the c
 
 ***
 
-#### [](#actor-get_value) `async Actor.get_value(key)`
+#### [](#actor-get_value) `async Actor.get_value(key, default_value=None)`
 
 Get a value from the default key-value store associated with the current actor run.
 
 * **Parameters**
 
   * **key** (`str`) – The key of the record which to retrieve.
+
+  * **default_value** (`Any`, *optional*) – Default value returned in case the record does not exist.
 
 * **Return type**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.8"
 dependencies = [
     "aiofiles >= 22.1.0",
     "aioshutil >= 1.0",
-    "apify-client == 1.3.1",
+    "apify-client == 1.4.0",
     "apify-shared == 1.0.2",
     "colorama >= 0.4.6",
     "cryptography >= 39.0.0",

--- a/src/apify/actor.py
+++ b/src/apify/actor.py
@@ -1140,6 +1140,7 @@ class Actor(metaclass=_ActorContextManager):
 
         # If is_at_home() is True, config.actor_id is always set
         assert self._config.actor_id is not None
+
         actor_run_id = cast(str, self._config.actor_run_id)  # to satisfy mypy, for some reason assert is not good enough
         await self._apify_client.run(actor_run_id).reboot()
 

--- a/src/apify/actor.py
+++ b/src/apify/actor.py
@@ -1140,8 +1140,8 @@ class Actor(metaclass=_ActorContextManager):
 
         # If is_at_home() is True, config.actor_id is always set
         assert self._config.actor_id is not None
-
-        await self.metamorph(self._config.actor_id)
+        actor_run_id = cast(str, self._config.actor_run_id)  # to satisfy mypy, for some reason assert is not good enough
+        await self._apify_client.run(actor_run_id).reboot()
 
     @classmethod
     async def add_webhook(

--- a/src/apify/actor.py
+++ b/src/apify/actor.py
@@ -31,6 +31,7 @@ from .log import logger
 from .proxy_configuration import ProxyConfiguration
 from .storages import Dataset, KeyValueStore, RequestQueue, StorageClientManager
 
+T = TypeVar('T')
 MainReturnType = TypeVar('MainReturnType')
 
 # This metaclass is needed so you can do `async with Actor: ...` instead of `async with Actor() as a: ...`
@@ -629,19 +630,20 @@ class Actor(metaclass=_ActorContextManager):
         return input_value
 
     @classmethod
-    async def get_value(cls, key: str) -> Any:
+    async def get_value(cls, key: str, default_value: Optional[T] = None) -> Any:
         """Get a value from the default key-value store associated with the current actor run.
 
         Args:
             key (str): The key of the record which to retrieve.
+            default_value (Any, optional): Default value returned in case the record does not exist.
         """
-        return await cls._get_default_instance().get_value(key=key)
+        return await cls._get_default_instance().get_value(key=key, default_value=default_value)
 
-    async def _get_value_internal(self, key: str) -> Any:
+    async def _get_value_internal(self, key: str, default_value: Optional[T] = None) -> Any:
         self._raise_if_not_initialized()
 
         key_value_store = await self.open_key_value_store()
-        value = await key_value_store.get_value(key)
+        value = await key_value_store.get_value(key, default_value)
         return value
 
     @classmethod
@@ -1147,10 +1149,8 @@ class Actor(metaclass=_ActorContextManager):
 
         await self._event_manager.close(event_listeners_timeout_secs=event_listeners_timeout_secs)
 
-        # If is_at_home() is True, config.actor_id is always set
-        assert self._config.actor_id is not None
-
-        await self._apify_client.run(self._config.actor_id).reboot()
+        assert self._config.actor_run_id is not None
+        await self._apify_client.run(self._config.actor_run_id).reboot()
 
         if custom_after_sleep_millis:
             await asyncio.sleep(custom_after_sleep_millis / 1000)

--- a/src/apify/actor.py
+++ b/src/apify/actor.py
@@ -1118,7 +1118,7 @@ class Actor(metaclass=_ActorContextManager):
 
         Args:
             event_listeners_timeout_secs (int, optional): How long should the actor wait for actor event listeners to finish before exiting
-            custom_after_sleep_millis (int, optional): How long to sleep for after the metamorph, to wait for the container to be stopped.
+            custom_after_sleep_millis (int, optional): How long to sleep for after the reboot, to wait for the container to be stopped.
         """
         return await cls._get_default_instance().reboot(
             event_listeners_timeout_secs=event_listeners_timeout_secs,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,7 +15,7 @@ from apify.config import Configuration
 from apify.storages import Dataset, KeyValueStore, RequestQueue, StorageClientManager
 from apify_client import ApifyClientAsync
 from apify_client.clients.resource_clients import ActorClientAsync
-from apify_client.consts import ActorJobStatus, ActorSourceType
+from apify_shared.consts import ActorJobStatus, ActorSourceType
 
 from ._utils import generate_unique_resource_name
 

--- a/tests/integration/test_actor_api_helpers.py
+++ b/tests/integration/test_actor_api_helpers.py
@@ -328,13 +328,11 @@ class TestActorReboot:
         async def main() -> None:
             async with Actor:
                 print('Starting...')
-                input = await Actor.get_input() or {}
-                counter_key = input.get('counter_key')
-                cnt = await Actor.get_value(counter_key, 0)  # type: ignore
+                cnt = await Actor.get_value('reboot_counter', 0)
 
                 if cnt < 2:
                     print(f'Rebooting (cnt = {cnt})...')
-                    await Actor.set_value(counter_key, cnt + 1)  # type: ignore
+                    await Actor.set_value('reboot_counter', cnt + 1)
                     await Actor.reboot()
                     await Actor.set_value('THIS_KEY_SHOULD_NOT_BE_WRITTEN', 'XXX')
 
@@ -343,14 +341,15 @@ class TestActorReboot:
         actor = await make_actor('actor_rebooter', main_func=main)
         run_result = await actor.call(run_input={'counter_key': 'reboot_counter'})
 
+        assert run_result is not None
+        assert run_result['status'] == 'SUCCEEDED'
+
         not_written_value = await actor.last_run().key_value_store().get_record('THIS_KEY_SHOULD_NOT_BE_WRITTEN')
         assert not_written_value is None
 
         reboot_counter = await actor.last_run().key_value_store().get_record('reboot_counter')
-        assert reboot_counter['value'] == 2  # type: ignore
-
-        assert run_result is not None
-        assert run_result['status'] == 'SUCCEEDED'
+        assert reboot_counter is not None
+        assert reboot_counter['value'] == 2
 
 
 class TestActorAddWebhook:


### PR DESCRIPTION
### Issue

- Closes #101 

### Description

- `Actor.reboot` method uses the new reboot endpoint which was integrated into `apify_client` in https://github.com/apify/apify-client-python/issues/137 .

### Test plan

- Reboot functionality cannot be tested locally, so it will have to be tested on the platform. I'll create some testing Actor and use the beta release of SDK once this PR is merged.