### PR TITLE
Update log integration tests after logging change on platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+[1.1.4](../../releases/tag/v1.1.4) - Unreleased
+-----------------------------------------------
+
+### Internal changes
+
+- Fixed integration tests for Actor logger
+
+
 [1.1.3](../../releases/tag/v1.1.3) - 2023-08-25
 -----------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apify"
-version = "1.1.3"
+version = "1.1.4"
 description = "Apify SDK for Python"
 readme = "README.md"
 license = {text = "Apache Software License"}

--- a/tests/integration/test_actor_log.py
+++ b/tests/integration/test_actor_log.py
@@ -64,7 +64,7 @@ class TestActorLog:
         run_log_lines = [line[25:] for line in run_log_lines]
 
         # This might be way too specific and easy to break, but let's hope not
-        assert run_log_lines.pop(0) == 'ACTOR: Pulling Docker image from repository.'
+        assert run_log_lines.pop(0).startswith('ACTOR: Pulling Docker image')
         assert run_log_lines.pop(0) == 'ACTOR: Creating Docker container.'
         assert run_log_lines.pop(0) == 'ACTOR: Starting Docker container.'
         assert run_log_lines.pop(0) == 'INFO  Initializing actor...'


### PR DESCRIPTION
We're changing the logging during Actor startup to also include the build ID, and this change would break the log test. This adjusts the test so that it won't fail when the platform change is released.