### PR TITLE
Stop using `pytest-randomly` in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 ### Internal changes
 
 - Fixed integration tests for Actor logger
+- Removed `pytest-randomly` Pytest plugin
 
 
 [1.1.3](../../releases/tag/v1.1.3) - 2023-08-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+[1.1.4](../../releases/tag/v1.1.4) - Unreleased
+-----------------------------------------------
+
+### Internal changes
+
+- Fixed integration tests for Actor logger
+
+
 [1.1.3](../../releases/tag/v1.1.3) - 2023-08-25
 -----------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ dev = [
     "pytest ~= 7.3.1",
     "pytest-asyncio ~= 0.21.0",
     "pytest-only ~= 2.0.0",
-    "pytest-randomly ~= 3.12.0",
     "pytest-timeout ~= 2.1.0",
     "pytest-xdist ~= 3.3.1",
     "respx ~= 0.20.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apify"
-version = "1.1.3"
+version = "1.1.4"
 description = "Apify SDK for Python"
 readme = "README.md"
 license = {text = "Apache Software License"}

--- a/tests/integration/test_actor_log.py
+++ b/tests/integration/test_actor_log.py
@@ -64,7 +64,7 @@ class TestActorLog:
         run_log_lines = [line[25:] for line in run_log_lines]
 
         # This might be way too specific and easy to break, but let's hope not
-        assert run_log_lines.pop(0) == 'ACTOR: Pulling Docker image from repository.'
+        assert run_log_lines.pop(0).startswith('ACTOR: Pulling Docker image')
         assert run_log_lines.pop(0) == 'ACTOR: Creating Docker container.'
         assert run_log_lines.pop(0) == 'ACTOR: Starting Docker container.'
         assert run_log_lines.pop(0) == 'INFO  Initializing actor...'


### PR DESCRIPTION
This removes the `pytest-randomly` Pytest plugin, as it doesn't play nice with `pytest-xdist`.

`pytest-randomly` (among other things) sets the random seed in the beginning of the tests to the current datetime. `pytest-xdist` runs the tests in parallel in multiple runners. When you use these two together, it happens that all of the runners have the same random seed, so if you e.g. [generate random resource names](https://github.com/apify/apify-client-python/blob/13c029e82731138cf67912fe6b375ab61846d4c5/tests/integration/test_request_queue.py#L7-L12), all runners will generate the same ones, leading to conflicts.

The other feature of `pytest-randomly`, running the tests in random order to ensure that the tests are not passing just because of some side effects caused by running in a specific order, does not work with `pytest-xdist` at all, so there are zero benefits of using `pytest-randomly` at all.