### PR TITLE
Fix issue with querying request queue head multiple times in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 [1.1.4](../../releases/tag/v1.1.4) - Unreleased
 -----------------------------------------------
 
+### Fixes
+
+- resolved issue with querying request queue head multiple times in parallel
+
 ### Internal changes
 
 - Fixed integration tests for Actor logger


### PR DESCRIPTION
When calling `_ensure_head_is_non_empty` on `RequestQueue`, the call to query the RQ head is cached (as an optimization) so that multiple parallel calls to the storage are not made, and in each call of `_ensure_head_is_non_empty` the cached call is then awaited.

In Python (unlike JavaScript), you can't await the result of an async function multiple times, it leads to an error. To get around that, you can wrap the result of the coroutine into an `asyncio.Task`, and that you can await multiple times (`asyncio.Task` behaves sort of like a JS `Promise` in this regard).