### PR TITLE
Add comment why not to use `~=` clause in deps definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## [1.4.1](../../releases/tag/v1.4.1) - Unreleased
 
-### Internal changes
-
-- Use compatible release clause in dependencies definition
+...
 
 ## [1.4.0](../../releases/tag/v1.4.0) - 2023-12-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [1.4.1](../../releases/tag/v1.4.1) - Unreleased
 
-...
+### Internal changes
+
+- Use compatible release clause in dependencies definition
 
 ## [1.4.0](../../releases/tag/v1.4.0) - 2023-12-05
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,18 +22,18 @@ classifiers = [
 
 requires-python = ">=3.8"
 dependencies = [
-    "aiofiles >= 22.1.0",
-    "aioshutil >= 1.0",
+    "aiofiles ~= 23.2.1",
+    "aioshutil ~= 1.3",
     "apify-client ~= 1.6.0",
     "apify-shared ~= 1.1.0",
-    "colorama >= 0.4.6",
-    "cryptography >= 39.0.0",
-    "httpx >= 0.24.1",
-    "psutil >= 5.9.5",
-    "pyee >= 11.0.1",
-    "sortedcollections >= 2.0.1",
-    "typing-extensions >= 4.1.0",
-    "websockets >= 10.1",
+    "colorama ~= 0.4.6",
+    "cryptography ~= 41.0.7",
+    "httpx ~= 0.25.2",
+    "psutil ~= 5.9.6",
+    "pyee ~= 11.1.0",
+    "sortedcollections ~= 2.1.0",
+    "typing-extensions ~= 4.6.3",
+    "websockets ~= 12.0",
 ]
 
 [project.optional-dependencies]
@@ -52,8 +52,8 @@ dev = [
     "ruff ~= 0.1.6",
     "twine ~= 4.0.2",
     "types-aiofiles ~= 23.2.0.0",
-    "types-colorama ~= 0.4.15.11",
-    "types-psutil ~= 5.9.5.12",
+    "types-colorama ~= 0.4.15.12",
+    "types-psutil ~= 5.9.5.17",
 ]
 scrapy = [
     "scrapy ~= 2.11.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,19 +21,23 @@ classifiers = [
 ]
 
 requires-python = ">=3.8"
+
+# We use inclusive ordered comparison clause for non-Apify packages intentionally in order to enhance the Apify SDK's
+# compatibility with a wide range of external packages. This decision was discussed in detail in the following PR:
+# https://github.com/apify/apify-sdk-python/pull/154
 dependencies = [
-    "aiofiles ~= 23.2.1",
-    "aioshutil ~= 1.3",
     "apify-client ~= 1.6.0",
     "apify-shared ~= 1.1.0",
-    "colorama ~= 0.4.6",
-    "cryptography ~= 41.0.7",
-    "httpx ~= 0.25.2",
-    "psutil ~= 5.9.6",
-    "pyee ~= 11.1.0",
-    "sortedcollections ~= 2.1.0",
-    "typing-extensions ~= 4.6.3",
-    "websockets ~= 12.0",
+    "aiofiles >= 22.1.0",
+    "aioshutil >= 1.0",
+    "colorama >= 0.4.6",
+    "cryptography >= 39.0.0",
+    "httpx >= 0.24.1",
+    "psutil >= 5.9.5",
+    "pyee >= 11.0.1",
+    "sortedcollections >= 2.0.1",
+    "typing-extensions >= 4.1.0",
+    "websockets >= 10.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
     "types-psutil ~= 5.9.5.17",
 ]
 scrapy = [
-    "scrapy ~= 2.11.0",
+    "scrapy >= 2.11.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Currently, we use the [inclusive ordered comparison clause](https://peps.python.org/pep-0440/#version-specifiers) in our dependency requirements (except the apify packages). 

I suggest playing safely by using a more strict [compatible release clause](https://peps.python.org/pep-0440/#version-specifiers) as we use it for the dev dependencies or dependencies in the Apify Client.

I install the dependencies using `make install-dev`, then use `pip freeze` and copy the package versions it installed - the current versions we use.
