### PR TITLE
Use absolute imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,8 @@ docstring-quotes = "double"
 inline-quotes = "single"
 
 [tool.ruff.lint.isort]
-known-first-party = ["apify", "apify_client", "apify_shared"]
+known-first-party = ["apify_client", "apify_shared"]
+known-local-folder = ["apify"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/apify/__init__.py
+++ b/src/apify/__init__.py
@@ -1,8 +1,8 @@
 from importlib import metadata
 
-from .actor import Actor
-from .config import Configuration
-from .proxy_configuration import ProxyConfiguration, ProxyInfo
+from apify.actor import Actor
+from apify.config import Configuration
+from apify.proxy_configuration import ProxyConfiguration, ProxyInfo
 
 __version__ = metadata.version('apify')
 

--- a/src/apify/_crypto.py
+++ b/src/apify/_crypto.py
@@ -9,8 +9,9 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-from apify.consts import ENCRYPTED_INPUT_VALUE_REGEXP
 from apify_shared.utils import ignore_docs
+
+from apify.consts import ENCRYPTED_INPUT_VALUE_REGEXP
 
 ENCRYPTION_KEY_LENGTH = 32
 ENCRYPTION_IV_LENGTH = 16

--- a/src/apify/_crypto.py
+++ b/src/apify/_crypto.py
@@ -9,9 +9,8 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-from apify_shared.utils import ignore_docs
-
 from apify.consts import ENCRYPTED_INPUT_VALUE_REGEXP
+from apify_shared.utils import ignore_docs
 
 ENCRYPTION_KEY_LENGTH = 32
 ENCRYPTION_IV_LENGTH = 16

--- a/src/apify/_crypto.py
+++ b/src/apify/_crypto.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from apify_shared.utils import ignore_docs
 
-from .consts import ENCRYPTED_INPUT_VALUE_REGEXP
+from apify.consts import ENCRYPTED_INPUT_VALUE_REGEXP
 
 ENCRYPTION_KEY_LENGTH = 32
 ENCRYPTION_IV_LENGTH = 16

--- a/src/apify/_memory_storage/__init__.py
+++ b/src/apify/_memory_storage/__init__.py
@@ -1,3 +1,3 @@
-from .memory_storage_client import MemoryStorageClient
+from apify._memory_storage.memory_storage_client import MemoryStorageClient
 
 __all__ = ['MemoryStorageClient']

--- a/src/apify/_memory_storage/file_storage_utils.py
+++ b/src/apify/_memory_storage/file_storage_utils.py
@@ -7,7 +7,7 @@ from aiofiles.os import makedirs
 
 from apify_shared.utils import json_dumps
 
-from .._utils import force_remove
+from apify._utils import force_remove
 
 
 async def update_metadata(*, data: dict, entity_directory: str, write_metadata: bool) -> None:

--- a/src/apify/_memory_storage/file_storage_utils.py
+++ b/src/apify/_memory_storage/file_storage_utils.py
@@ -5,8 +5,9 @@ import os
 import aiofiles
 from aiofiles.os import makedirs
 
-from apify._utils import force_remove
 from apify_shared.utils import json_dumps
+
+from apify._utils import force_remove
 
 
 async def update_metadata(*, data: dict, entity_directory: str, write_metadata: bool) -> None:

--- a/src/apify/_memory_storage/file_storage_utils.py
+++ b/src/apify/_memory_storage/file_storage_utils.py
@@ -5,9 +5,8 @@ import os
 import aiofiles
 from aiofiles.os import makedirs
 
-from apify_shared.utils import json_dumps
-
 from apify._utils import force_remove
+from apify_shared.utils import json_dumps
 
 
 async def update_metadata(*, data: dict, entity_directory: str, write_metadata: bool) -> None:

--- a/src/apify/_memory_storage/memory_storage_client.py
+++ b/src/apify/_memory_storage/memory_storage_client.py
@@ -9,16 +9,15 @@ import aioshutil
 from aiofiles import ospath
 from aiofiles.os import rename, scandir
 
-from apify_shared.consts import ApifyEnvVars
-from apify_shared.utils import ignore_docs
-
-from apify._utils import maybe_parse_bool
 from apify._memory_storage.resource_clients.dataset import DatasetClient
 from apify._memory_storage.resource_clients.dataset_collection import DatasetCollectionClient
 from apify._memory_storage.resource_clients.key_value_store import KeyValueStoreClient
 from apify._memory_storage.resource_clients.key_value_store_collection import KeyValueStoreCollectionClient
 from apify._memory_storage.resource_clients.request_queue import RequestQueueClient
 from apify._memory_storage.resource_clients.request_queue_collection import RequestQueueCollectionClient
+from apify._utils import maybe_parse_bool
+from apify_shared.consts import ApifyEnvVars
+from apify_shared.utils import ignore_docs
 
 """
 Memory storage emulates data storages that are available on the Apify platform.

--- a/src/apify/_memory_storage/memory_storage_client.py
+++ b/src/apify/_memory_storage/memory_storage_client.py
@@ -12,13 +12,13 @@ from aiofiles.os import rename, scandir
 from apify_shared.consts import ApifyEnvVars
 from apify_shared.utils import ignore_docs
 
-from .._utils import maybe_parse_bool
-from .resource_clients.dataset import DatasetClient
-from .resource_clients.dataset_collection import DatasetCollectionClient
-from .resource_clients.key_value_store import KeyValueStoreClient
-from .resource_clients.key_value_store_collection import KeyValueStoreCollectionClient
-from .resource_clients.request_queue import RequestQueueClient
-from .resource_clients.request_queue_collection import RequestQueueCollectionClient
+from apify._utils import maybe_parse_bool
+from apify._memory_storage.resource_clients.dataset import DatasetClient
+from apify._memory_storage.resource_clients.dataset_collection import DatasetCollectionClient
+from apify._memory_storage.resource_clients.key_value_store import KeyValueStoreClient
+from apify._memory_storage.resource_clients.key_value_store_collection import KeyValueStoreCollectionClient
+from apify._memory_storage.resource_clients.request_queue import RequestQueueClient
+from apify._memory_storage.resource_clients.request_queue_collection import RequestQueueCollectionClient
 
 """
 Memory storage emulates data storages that are available on the Apify platform.

--- a/src/apify/_memory_storage/memory_storage_client.py
+++ b/src/apify/_memory_storage/memory_storage_client.py
@@ -9,6 +9,9 @@ import aioshutil
 from aiofiles import ospath
 from aiofiles.os import rename, scandir
 
+from apify_shared.consts import ApifyEnvVars
+from apify_shared.utils import ignore_docs
+
 from apify._memory_storage.resource_clients.dataset import DatasetClient
 from apify._memory_storage.resource_clients.dataset_collection import DatasetCollectionClient
 from apify._memory_storage.resource_clients.key_value_store import KeyValueStoreClient
@@ -16,8 +19,6 @@ from apify._memory_storage.resource_clients.key_value_store_collection import Ke
 from apify._memory_storage.resource_clients.request_queue import RequestQueueClient
 from apify._memory_storage.resource_clients.request_queue_collection import RequestQueueCollectionClient
 from apify._utils import maybe_parse_bool
-from apify_shared.consts import ApifyEnvVars
-from apify_shared.utils import ignore_docs
 
 """
 Memory storage emulates data storages that are available on the Apify platform.

--- a/src/apify/_memory_storage/resource_clients/__init__.py
+++ b/src/apify/_memory_storage/resource_clients/__init__.py
@@ -1,11 +1,11 @@
-from .base_resource_client import BaseResourceClient
-from .base_resource_collection_client import BaseResourceCollectionClient
-from .dataset import DatasetClient
-from .dataset_collection import DatasetCollectionClient
-from .key_value_store import KeyValueStoreClient
-from .key_value_store_collection import KeyValueStoreCollectionClient
-from .request_queue import RequestQueueClient
-from .request_queue_collection import RequestQueueCollectionClient
+from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
+from apify._memory_storage.resource_clients.base_resource_collection_client import BaseResourceCollectionClient
+from apify._memory_storage.resource_clients.dataset import DatasetClient
+from apify._memory_storage.resource_clients.dataset_collection import DatasetCollectionClient
+from apify._memory_storage.resource_clients.key_value_store import KeyValueStoreClient
+from apify._memory_storage.resource_clients.key_value_store_collection import KeyValueStoreCollectionClient
+from apify._memory_storage.resource_clients.request_queue import RequestQueueClient
+from apify._memory_storage.resource_clients.request_queue_collection import RequestQueueCollectionClient
 
 __all__ = [
     'BaseResourceClient',

--- a/src/apify/_memory_storage/resource_clients/base_resource_client.py
+++ b/src/apify/_memory_storage/resource_clients/base_resource_client.py
@@ -10,7 +10,7 @@ from apify_shared.utils import ignore_docs
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-    from ..memory_storage_client import MemoryStorageClient
+    from apify._memory_storage.memory_storage_client import MemoryStorageClient
 
 
 @ignore_docs

--- a/src/apify/_memory_storage/resource_clients/base_resource_collection_client.py
+++ b/src/apify/_memory_storage/resource_clients/base_resource_collection_client.py
@@ -4,11 +4,10 @@ from abc import ABC, abstractmethod
 from operator import itemgetter
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
-from apify_shared.models import ListPage
-from apify_shared.utils import ignore_docs
-
 from apify._memory_storage.file_storage_utils import update_metadata
 from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
+from apify_shared.models import ListPage
+from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from apify._memory_storage.memory_storage_client import MemoryStorageClient

--- a/src/apify/_memory_storage/resource_clients/base_resource_collection_client.py
+++ b/src/apify/_memory_storage/resource_clients/base_resource_collection_client.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING, Generic, TypeVar, cast
 from apify_shared.models import ListPage
 from apify_shared.utils import ignore_docs
 
-from ..file_storage_utils import update_metadata
-from .base_resource_client import BaseResourceClient
+from apify._memory_storage.file_storage_utils import update_metadata
+from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
 
 if TYPE_CHECKING:
-    from ..memory_storage_client import MemoryStorageClient
+    from apify._memory_storage.memory_storage_client import MemoryStorageClient
 
 
 ResourceClientType = TypeVar('ResourceClientType', bound=BaseResourceClient, contravariant=True)  # noqa: PLC0105

--- a/src/apify/_memory_storage/resource_clients/base_resource_collection_client.py
+++ b/src/apify/_memory_storage/resource_clients/base_resource_collection_client.py
@@ -4,10 +4,11 @@ from abc import ABC, abstractmethod
 from operator import itemgetter
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
-from apify._memory_storage.file_storage_utils import update_metadata
-from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
 from apify_shared.models import ListPage
 from apify_shared.utils import ignore_docs
+
+from apify._memory_storage.file_storage_utils import update_metadata
+from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
 
 if TYPE_CHECKING:
     from apify._memory_storage.memory_storage_client import MemoryStorageClient

--- a/src/apify/_memory_storage/resource_clients/dataset.py
+++ b/src/apify/_memory_storage/resource_clients/dataset.py
@@ -8,17 +8,19 @@ from typing import TYPE_CHECKING, Any, AsyncIterator
 
 import aioshutil
 
+from apify_shared.models import ListPage
+from apify_shared.utils import ignore_docs
+
 from apify._crypto import crypto_random_object_id
 from apify._memory_storage.file_storage_utils import _update_dataset_items, update_metadata
 from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
 from apify._utils import force_rename, raise_on_duplicate_storage, raise_on_non_existing_storage
 from apify.consts import StorageTypes
-from apify_shared.models import ListPage
-from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
-    from apify._memory_storage.memory_storage_client import MemoryStorageClient
     from apify_shared.types import JSONSerializable
+
+    from apify._memory_storage.memory_storage_client import MemoryStorageClient
 
 # This is what API returns in the x-apify-pagination-limit
 # header when no limit query parameter is used.

--- a/src/apify/_memory_storage/resource_clients/dataset.py
+++ b/src/apify/_memory_storage/resource_clients/dataset.py
@@ -11,16 +11,16 @@ import aioshutil
 from apify_shared.models import ListPage
 from apify_shared.utils import ignore_docs
 
-from ..._crypto import crypto_random_object_id
-from ..._utils import force_rename, raise_on_duplicate_storage, raise_on_non_existing_storage
-from ...consts import StorageTypes
-from ..file_storage_utils import _update_dataset_items, update_metadata
-from .base_resource_client import BaseResourceClient
+from apify._crypto import crypto_random_object_id
+from apify._utils import force_rename, raise_on_duplicate_storage, raise_on_non_existing_storage
+from apify.consts import StorageTypes
+from apify._memory_storage.file_storage_utils import _update_dataset_items, update_metadata
+from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
 
 if TYPE_CHECKING:
     from apify_shared.types import JSONSerializable
 
-    from ..memory_storage_client import MemoryStorageClient
+    from apify._memory_storage.memory_storage_client import MemoryStorageClient
 
 # This is what API returns in the x-apify-pagination-limit
 # header when no limit query parameter is used.

--- a/src/apify/_memory_storage/resource_clients/dataset.py
+++ b/src/apify/_memory_storage/resource_clients/dataset.py
@@ -8,19 +8,17 @@ from typing import TYPE_CHECKING, Any, AsyncIterator
 
 import aioshutil
 
+from apify._crypto import crypto_random_object_id
+from apify._memory_storage.file_storage_utils import _update_dataset_items, update_metadata
+from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
+from apify._utils import force_rename, raise_on_duplicate_storage, raise_on_non_existing_storage
+from apify.consts import StorageTypes
 from apify_shared.models import ListPage
 from apify_shared.utils import ignore_docs
 
-from apify._crypto import crypto_random_object_id
-from apify._utils import force_rename, raise_on_duplicate_storage, raise_on_non_existing_storage
-from apify.consts import StorageTypes
-from apify._memory_storage.file_storage_utils import _update_dataset_items, update_metadata
-from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
-
 if TYPE_CHECKING:
-    from apify_shared.types import JSONSerializable
-
     from apify._memory_storage.memory_storage_client import MemoryStorageClient
+    from apify_shared.types import JSONSerializable
 
 # This is what API returns in the x-apify-pagination-limit
 # header when no limit query parameter is used.

--- a/src/apify/_memory_storage/resource_clients/dataset_collection.py
+++ b/src/apify/_memory_storage/resource_clients/dataset_collection.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from apify_shared.utils import ignore_docs
-
 from apify._memory_storage.resource_clients.base_resource_collection_client import BaseResourceCollectionClient
 from apify._memory_storage.resource_clients.dataset import DatasetClient
+from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify/_memory_storage/resource_clients/dataset_collection.py
+++ b/src/apify/_memory_storage/resource_clients/dataset_collection.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 
 from apify_shared.utils import ignore_docs
 
-from .base_resource_collection_client import BaseResourceCollectionClient
-from .dataset import DatasetClient
+from apify._memory_storage.resource_clients.base_resource_collection_client import BaseResourceCollectionClient
+from apify._memory_storage.resource_clients.dataset import DatasetClient
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify/_memory_storage/resource_clients/dataset_collection.py
+++ b/src/apify/_memory_storage/resource_clients/dataset_collection.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from apify_shared.utils import ignore_docs
+
 from apify._memory_storage.resource_clients.base_resource_collection_client import BaseResourceCollectionClient
 from apify._memory_storage.resource_clients.dataset import DatasetClient
-from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify/_memory_storage/resource_clients/key_value_store.py
+++ b/src/apify/_memory_storage/resource_clients/key_value_store.py
@@ -14,9 +14,9 @@ import aiofiles
 import aioshutil
 from aiofiles.os import makedirs
 
-from apify_shared.utils import ignore_docs, is_file_or_bytes, json_dumps
-
 from apify._crypto import crypto_random_object_id
+from apify._memory_storage.file_storage_utils import update_metadata
+from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
 from apify._utils import (
     force_remove,
     force_rename,
@@ -27,8 +27,7 @@ from apify._utils import (
 )
 from apify.consts import DEFAULT_API_PARAM_LIMIT, StorageTypes
 from apify.log import logger
-from apify._memory_storage.file_storage_utils import update_metadata
-from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
+from apify_shared.utils import ignore_docs, is_file_or_bytes, json_dumps
 
 if TYPE_CHECKING:
     from typing_extensions import NotRequired

--- a/src/apify/_memory_storage/resource_clients/key_value_store.py
+++ b/src/apify/_memory_storage/resource_clients/key_value_store.py
@@ -16,8 +16,8 @@ from aiofiles.os import makedirs
 
 from apify_shared.utils import ignore_docs, is_file_or_bytes, json_dumps
 
-from ..._crypto import crypto_random_object_id
-from ..._utils import (
+from apify._crypto import crypto_random_object_id
+from apify._utils import (
     force_remove,
     force_rename,
     guess_file_extension,
@@ -25,15 +25,15 @@ from ..._utils import (
     raise_on_duplicate_storage,
     raise_on_non_existing_storage,
 )
-from ...consts import DEFAULT_API_PARAM_LIMIT, StorageTypes
-from ...log import logger
-from ..file_storage_utils import update_metadata
-from .base_resource_client import BaseResourceClient
+from apify.consts import DEFAULT_API_PARAM_LIMIT, StorageTypes
+from apify.log import logger
+from apify._memory_storage.file_storage_utils import update_metadata
+from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
 
 if TYPE_CHECKING:
     from typing_extensions import NotRequired
 
-    from ..memory_storage_client import MemoryStorageClient
+    from apify._memory_storage.memory_storage_client import MemoryStorageClient
 
 
 class KeyValueStoreRecord(TypedDict):

--- a/src/apify/_memory_storage/resource_clients/key_value_store.py
+++ b/src/apify/_memory_storage/resource_clients/key_value_store.py
@@ -14,6 +14,8 @@ import aiofiles
 import aioshutil
 from aiofiles.os import makedirs
 
+from apify_shared.utils import ignore_docs, is_file_or_bytes, json_dumps
+
 from apify._crypto import crypto_random_object_id
 from apify._memory_storage.file_storage_utils import update_metadata
 from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
@@ -27,7 +29,6 @@ from apify._utils import (
 )
 from apify.consts import DEFAULT_API_PARAM_LIMIT, StorageTypes
 from apify.log import logger
-from apify_shared.utils import ignore_docs, is_file_or_bytes, json_dumps
 
 if TYPE_CHECKING:
     from typing_extensions import NotRequired

--- a/src/apify/_memory_storage/resource_clients/key_value_store_collection.py
+++ b/src/apify/_memory_storage/resource_clients/key_value_store_collection.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from apify_shared.utils import ignore_docs
-
 from apify._memory_storage.resource_clients.base_resource_collection_client import BaseResourceCollectionClient
 from apify._memory_storage.resource_clients.key_value_store import KeyValueStoreClient
+from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify/_memory_storage/resource_clients/key_value_store_collection.py
+++ b/src/apify/_memory_storage/resource_clients/key_value_store_collection.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 
 from apify_shared.utils import ignore_docs
 
-from .base_resource_collection_client import BaseResourceCollectionClient
-from .key_value_store import KeyValueStoreClient
+from apify._memory_storage.resource_clients.base_resource_collection_client import BaseResourceCollectionClient
+from apify._memory_storage.resource_clients.key_value_store import KeyValueStoreClient
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify/_memory_storage/resource_clients/key_value_store_collection.py
+++ b/src/apify/_memory_storage/resource_clients/key_value_store_collection.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from apify_shared.utils import ignore_docs
+
 from apify._memory_storage.resource_clients.base_resource_collection_client import BaseResourceCollectionClient
 from apify._memory_storage.resource_clients.key_value_store import KeyValueStoreClient
-from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify/_memory_storage/resource_clients/request_queue.py
+++ b/src/apify/_memory_storage/resource_clients/request_queue.py
@@ -10,13 +10,12 @@ from typing import TYPE_CHECKING
 import aioshutil
 from sortedcollections import ValueSortedDict
 
-from apify_shared.utils import filter_out_none_values_recursively, ignore_docs, json_dumps
-
 from apify._crypto import crypto_random_object_id
-from apify._utils import force_rename, raise_on_duplicate_storage, raise_on_non_existing_storage, unique_key_to_request_id
-from apify.consts import StorageTypes
 from apify._memory_storage.file_storage_utils import delete_request, update_metadata, update_request_queue_item
 from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
+from apify._utils import force_rename, raise_on_duplicate_storage, raise_on_non_existing_storage, unique_key_to_request_id
+from apify.consts import StorageTypes
+from apify_shared.utils import filter_out_none_values_recursively, ignore_docs, json_dumps
 
 if TYPE_CHECKING:
     from apify._memory_storage.memory_storage_client import MemoryStorageClient

--- a/src/apify/_memory_storage/resource_clients/request_queue.py
+++ b/src/apify/_memory_storage/resource_clients/request_queue.py
@@ -10,12 +10,13 @@ from typing import TYPE_CHECKING
 import aioshutil
 from sortedcollections import ValueSortedDict
 
+from apify_shared.utils import filter_out_none_values_recursively, ignore_docs, json_dumps
+
 from apify._crypto import crypto_random_object_id
 from apify._memory_storage.file_storage_utils import delete_request, update_metadata, update_request_queue_item
 from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
 from apify._utils import force_rename, raise_on_duplicate_storage, raise_on_non_existing_storage, unique_key_to_request_id
 from apify.consts import StorageTypes
-from apify_shared.utils import filter_out_none_values_recursively, ignore_docs, json_dumps
 
 if TYPE_CHECKING:
     from apify._memory_storage.memory_storage_client import MemoryStorageClient

--- a/src/apify/_memory_storage/resource_clients/request_queue.py
+++ b/src/apify/_memory_storage/resource_clients/request_queue.py
@@ -12,14 +12,14 @@ from sortedcollections import ValueSortedDict
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs, json_dumps
 
-from ..._crypto import crypto_random_object_id
-from ..._utils import force_rename, raise_on_duplicate_storage, raise_on_non_existing_storage, unique_key_to_request_id
-from ...consts import StorageTypes
-from ..file_storage_utils import delete_request, update_metadata, update_request_queue_item
-from .base_resource_client import BaseResourceClient
+from apify._crypto import crypto_random_object_id
+from apify._utils import force_rename, raise_on_duplicate_storage, raise_on_non_existing_storage, unique_key_to_request_id
+from apify.consts import StorageTypes
+from apify._memory_storage.file_storage_utils import delete_request, update_metadata, update_request_queue_item
+from apify._memory_storage.resource_clients.base_resource_client import BaseResourceClient
 
 if TYPE_CHECKING:
-    from ..memory_storage_client import MemoryStorageClient
+    from apify._memory_storage.memory_storage_client import MemoryStorageClient
 
 
 @ignore_docs

--- a/src/apify/_memory_storage/resource_clients/request_queue_collection.py
+++ b/src/apify/_memory_storage/resource_clients/request_queue_collection.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from apify_shared.utils import ignore_docs
-
 from apify._memory_storage.resource_clients.base_resource_collection_client import BaseResourceCollectionClient
 from apify._memory_storage.resource_clients.request_queue import RequestQueueClient
+from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify/_memory_storage/resource_clients/request_queue_collection.py
+++ b/src/apify/_memory_storage/resource_clients/request_queue_collection.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from apify_shared.utils import ignore_docs
+
 from apify._memory_storage.resource_clients.base_resource_collection_client import BaseResourceCollectionClient
 from apify._memory_storage.resource_clients.request_queue import RequestQueueClient
-from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify/_memory_storage/resource_clients/request_queue_collection.py
+++ b/src/apify/_memory_storage/resource_clients/request_queue_collection.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 
 from apify_shared.utils import ignore_docs
 
-from .base_resource_collection_client import BaseResourceCollectionClient
-from .request_queue import RequestQueueClient
+from apify._memory_storage.resource_clients.base_resource_collection_client import BaseResourceCollectionClient
+from apify._memory_storage.resource_clients.request_queue import RequestQueueClient
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -36,6 +36,7 @@ import psutil
 from aiofiles import ospath
 from aiofiles.os import remove, rename
 
+from apify.consts import REQUEST_ID_LENGTH, StorageTypes
 from apify_shared.consts import (
     BOOL_ENV_VARS,
     BOOL_ENV_VARS_TYPE,
@@ -56,8 +57,6 @@ from apify_shared.utils import (
     is_content_type_xml,
     maybe_extract_enum_member_value,
 )
-
-from apify.consts import REQUEST_ID_LENGTH, StorageTypes
 
 T = TypeVar('T')
 

--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -57,7 +57,7 @@ from apify_shared.utils import (
     maybe_extract_enum_member_value,
 )
 
-from .consts import REQUEST_ID_LENGTH, StorageTypes
+from apify.consts import REQUEST_ID_LENGTH, StorageTypes
 
 T = TypeVar('T')
 

--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -36,7 +36,6 @@ import psutil
 from aiofiles import ospath
 from aiofiles.os import remove, rename
 
-from apify.consts import REQUEST_ID_LENGTH, StorageTypes
 from apify_shared.consts import (
     BOOL_ENV_VARS,
     BOOL_ENV_VARS_TYPE,
@@ -57,6 +56,8 @@ from apify_shared.utils import (
     is_content_type_xml,
     maybe_extract_enum_member_value,
 )
+
+from apify.consts import REQUEST_ID_LENGTH, StorageTypes
 
 T = TypeVar('T')
 

--- a/src/apify/actor.py
+++ b/src/apify/actor.py
@@ -8,6 +8,10 @@ import sys
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, TypeVar, cast
 
+from apify_client import ApifyClientAsync
+from apify_shared.consts import ActorEnvVars, ActorEventTypes, ActorExitCodes, ApifyEnvVars, WebhookEventType
+from apify_shared.utils import ignore_docs, maybe_extract_enum_member_value
+
 from apify._crypto import decrypt_input_secrets, load_private_key
 from apify._utils import (
     dualproperty,
@@ -25,9 +29,6 @@ from apify.event_manager import EventManager
 from apify.log import logger
 from apify.proxy_configuration import ProxyConfiguration
 from apify.storages import Dataset, KeyValueStore, RequestQueue, StorageClientManager
-from apify_client import ApifyClientAsync
-from apify_shared.consts import ActorEnvVars, ActorEventTypes, ActorExitCodes, ApifyEnvVars, WebhookEventType
-from apify_shared.utils import ignore_docs, maybe_extract_enum_member_value
 
 if TYPE_CHECKING:
     import logging

--- a/src/apify/actor.py
+++ b/src/apify/actor.py
@@ -8,10 +8,6 @@ import sys
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, TypeVar, cast
 
-from apify_client import ApifyClientAsync
-from apify_shared.consts import ActorEnvVars, ActorEventTypes, ActorExitCodes, ApifyEnvVars, WebhookEventType
-from apify_shared.utils import ignore_docs, maybe_extract_enum_member_value
-
 from apify._crypto import decrypt_input_secrets, load_private_key
 from apify._utils import (
     dualproperty,
@@ -29,6 +25,9 @@ from apify.event_manager import EventManager
 from apify.log import logger
 from apify.proxy_configuration import ProxyConfiguration
 from apify.storages import Dataset, KeyValueStore, RequestQueue, StorageClientManager
+from apify_client import ApifyClientAsync
+from apify_shared.consts import ActorEnvVars, ActorEventTypes, ActorExitCodes, ApifyEnvVars, WebhookEventType
+from apify_shared.utils import ignore_docs, maybe_extract_enum_member_value
 
 if TYPE_CHECKING:
     import logging

--- a/src/apify/actor.py
+++ b/src/apify/actor.py
@@ -12,8 +12,8 @@ from apify_client import ApifyClientAsync
 from apify_shared.consts import ActorEnvVars, ActorEventTypes, ActorExitCodes, ApifyEnvVars, WebhookEventType
 from apify_shared.utils import ignore_docs, maybe_extract_enum_member_value
 
-from ._crypto import decrypt_input_secrets, load_private_key
-from ._utils import (
+from apify._crypto import decrypt_input_secrets, load_private_key
+from apify._utils import (
     dualproperty,
     fetch_and_parse_env_var,
     get_cpu_usage_percent,
@@ -23,18 +23,18 @@ from ._utils import (
     run_func_at_interval_async,
     wrap_internal,
 )
-from .config import Configuration
-from .consts import EVENT_LISTENERS_TIMEOUT_SECS
-from .event_manager import EventManager
-from .log import logger
-from .proxy_configuration import ProxyConfiguration
-from .storages import Dataset, KeyValueStore, RequestQueue, StorageClientManager
+from apify.config import Configuration
+from apify.consts import EVENT_LISTENERS_TIMEOUT_SECS
+from apify.event_manager import EventManager
+from apify.log import logger
+from apify.proxy_configuration import ProxyConfiguration
+from apify.storages import Dataset, KeyValueStore, RequestQueue, StorageClientManager
 
 if TYPE_CHECKING:
     import logging
     from types import TracebackType
 
-    from ._memory_storage import MemoryStorageClient
+    from apify._memory_storage import MemoryStorageClient
 
 T = TypeVar('T')
 MainReturnType = TypeVar('MainReturnType')

--- a/src/apify/config.py
+++ b/src/apify/config.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from apify._utils import fetch_and_parse_env_var
 from apify_shared.consts import ActorEnvVars, ApifyEnvVars
+
+from apify._utils import fetch_and_parse_env_var
 
 
 class Configuration:

--- a/src/apify/config.py
+++ b/src/apify/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from apify_shared.consts import ActorEnvVars, ApifyEnvVars
 
-from ._utils import fetch_and_parse_env_var
+from apify._utils import fetch_and_parse_env_var
 
 
 class Configuration:

--- a/src/apify/config.py
+++ b/src/apify/config.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from apify_shared.consts import ActorEnvVars, ApifyEnvVars
-
 from apify._utils import fetch_and_parse_env_var
+from apify_shared.consts import ActorEnvVars, ApifyEnvVars
 
 
 class Configuration:

--- a/src/apify/event_manager.py
+++ b/src/apify/event_manager.py
@@ -12,12 +12,12 @@ from pyee.asyncio import AsyncIOEventEmitter
 
 from apify_shared.utils import ignore_docs, maybe_extract_enum_member_value, parse_date_fields
 
-from .log import logger
+from apify.log import logger
 
 if TYPE_CHECKING:
     from apify_shared.consts import ActorEventTypes
 
-    from .config import Configuration
+    from apify.config import Configuration
 
 ListenerType = Union[Callable[[], None], Callable[[Any], None], Callable[[], Coroutine[Any, Any, None]], Callable[[Any], Coroutine[Any, Any, None]]]
 

--- a/src/apify/event_manager.py
+++ b/src/apify/event_manager.py
@@ -10,12 +10,14 @@ from typing import TYPE_CHECKING, Any, Callable, Coroutine, Union
 import websockets.client
 from pyee.asyncio import AsyncIOEventEmitter
 
-from apify.log import logger
 from apify_shared.utils import ignore_docs, maybe_extract_enum_member_value, parse_date_fields
 
+from apify.log import logger
+
 if TYPE_CHECKING:
-    from apify.config import Configuration
     from apify_shared.consts import ActorEventTypes
+
+    from apify.config import Configuration
 
 ListenerType = Union[Callable[[], None], Callable[[Any], None], Callable[[], Coroutine[Any, Any, None]], Callable[[Any], Coroutine[Any, Any, None]]]
 

--- a/src/apify/event_manager.py
+++ b/src/apify/event_manager.py
@@ -10,14 +10,12 @@ from typing import TYPE_CHECKING, Any, Callable, Coroutine, Union
 import websockets.client
 from pyee.asyncio import AsyncIOEventEmitter
 
+from apify.log import logger
 from apify_shared.utils import ignore_docs, maybe_extract_enum_member_value, parse_date_fields
 
-from apify.log import logger
-
 if TYPE_CHECKING:
-    from apify_shared.consts import ActorEventTypes
-
     from apify.config import Configuration
+    from apify_shared.consts import ActorEventTypes
 
 ListenerType = Union[Callable[[], None], Callable[[Any], None], Callable[[], Coroutine[Any, Any, None]], Callable[[Any], Coroutine[Any, Any, None]]]
 

--- a/src/apify/proxy_configuration.py
+++ b/src/apify/proxy_configuration.py
@@ -8,11 +8,10 @@ from urllib.parse import urljoin, urlparse
 
 import httpx
 
-from apify_shared.consts import ApifyEnvVars
-from apify_shared.utils import ignore_docs
-
 from apify.config import Configuration
 from apify.log import logger
+from apify_shared.consts import ApifyEnvVars
+from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from typing_extensions import NotRequired

--- a/src/apify/proxy_configuration.py
+++ b/src/apify/proxy_configuration.py
@@ -11,8 +11,8 @@ import httpx
 from apify_shared.consts import ApifyEnvVars
 from apify_shared.utils import ignore_docs
 
-from .config import Configuration
-from .log import logger
+from apify.config import Configuration
+from apify.log import logger
 
 if TYPE_CHECKING:
     from typing_extensions import NotRequired

--- a/src/apify/proxy_configuration.py
+++ b/src/apify/proxy_configuration.py
@@ -8,10 +8,11 @@ from urllib.parse import urljoin, urlparse
 
 import httpx
 
-from apify.config import Configuration
-from apify.log import logger
 from apify_shared.consts import ApifyEnvVars
 from apify_shared.utils import ignore_docs
+
+from apify.config import Configuration
+from apify.log import logger
 
 if TYPE_CHECKING:
     from typing_extensions import NotRequired

--- a/src/apify/scrapy/__init__.py
+++ b/src/apify/scrapy/__init__.py
@@ -1,3 +1,3 @@
-from .pipelines import ActorDatasetPushPipeline
-from .scheduler import ApifyScheduler
-from .utils import get_basic_auth_header, get_running_event_loop_id, open_queue_with_custom_client, to_apify_request, to_scrapy_request
+from apify.scrapy.pipelines import ActorDatasetPushPipeline
+from apify.scrapy.scheduler import ApifyScheduler
+from apify.scrapy.utils import get_basic_auth_header, get_running_event_loop_id, open_queue_with_custom_client, to_apify_request, to_scrapy_request

--- a/src/apify/scrapy/middlewares/__init__.py
+++ b/src/apify/scrapy/middlewares/__init__.py
@@ -1,2 +1,2 @@
-from .apify_proxy import ApifyHttpProxyMiddleware
-from .apify_retry import ApifyRetryMiddleware
+from apify.scrapy.middlewares.apify_proxy import ApifyHttpProxyMiddleware
+from apify.scrapy.middlewares.apify_retry import ApifyRetryMiddleware

--- a/src/apify/scrapy/middlewares/apify_proxy.py
+++ b/src/apify/scrapy/middlewares/apify_proxy.py
@@ -6,9 +6,9 @@ from urllib.parse import ParseResult, urlparse
 from scrapy.core.downloader.handlers.http11 import TunnelError
 from scrapy.exceptions import NotConfigured
 
-from ...actor import Actor
-from ...proxy_configuration import ProxyConfiguration
-from ..utils import get_basic_auth_header
+from apify.actor import Actor
+from apify.proxy_configuration import ProxyConfiguration
+from apify.scrapy.utils import get_basic_auth_header
 
 if TYPE_CHECKING:
     from scrapy import Request, Spider

--- a/src/apify/scrapy/middlewares/apify_retry.py
+++ b/src/apify/scrapy/middlewares/apify_retry.py
@@ -11,14 +11,14 @@ except ImportError as exc:
         'To use this module, you need to install the "scrapy" extra. Run "pip install apify[scrapy]".',
     ) from exc
 
-from ...actor import Actor
-from ..utils import nested_event_loop, open_queue_with_custom_client, to_apify_request
+from apify.actor import Actor
+from apify.scrapy.utils import nested_event_loop, open_queue_with_custom_client, to_apify_request
 
 if TYPE_CHECKING:
     from scrapy import Spider
     from scrapy.http import Request, Response
 
-    from ...storages import RequestQueue
+    from apify.storages import RequestQueue
 
 
 class ApifyRetryMiddleware(RetryMiddleware):

--- a/src/apify/scrapy/pipelines.py
+++ b/src/apify/scrapy/pipelines.py
@@ -9,7 +9,7 @@ except ImportError as exc:
         'To use this module, you need to install the "scrapy" extra. Run "pip install apify[scrapy]".',
     ) from exc
 
-from ..actor import Actor
+from apify.actor import Actor
 
 
 class ActorDatasetPushPipeline:

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -14,8 +14,8 @@ except ImportError as exc:
 
 from apify._crypto import crypto_random_object_id
 from apify.actor import Actor
-from apify.storages import RequestQueue
 from apify.scrapy.utils import nested_event_loop, open_queue_with_custom_client, to_apify_request, to_scrapy_request
+from apify.storages import RequestQueue
 
 
 class ApifyScheduler(BaseScheduler):

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -12,10 +12,10 @@ except ImportError as exc:
         'To use this module, you need to install the "scrapy" extra. Run "pip install apify[scrapy]".',
     ) from exc
 
-from .._crypto import crypto_random_object_id
-from ..actor import Actor
-from ..storages import RequestQueue
-from .utils import nested_event_loop, open_queue_with_custom_client, to_apify_request, to_scrapy_request
+from apify._crypto import crypto_random_object_id
+from apify.actor import Actor
+from apify.storages import RequestQueue
+from apify.scrapy.utils import nested_event_loop, open_queue_with_custom_client, to_apify_request, to_scrapy_request
 
 
 class ApifyScheduler(BaseScheduler):

--- a/src/apify/scrapy/utils.py
+++ b/src/apify/scrapy/utils.py
@@ -16,9 +16,9 @@ except ImportError as exc:
         'To use this module, you need to install the "scrapy" extra. Run "pip install apify[scrapy]".',
     ) from exc
 
-from .._crypto import crypto_random_object_id
-from ..actor import Actor
-from ..storages import RequestQueue, StorageClientManager
+from apify._crypto import crypto_random_object_id
+from apify.actor import Actor
+from apify.storages import RequestQueue, StorageClientManager
 
 nested_event_loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
 

--- a/src/apify/storages/__init__.py
+++ b/src/apify/storages/__init__.py
@@ -1,7 +1,7 @@
-from .dataset import Dataset
-from .key_value_store import KeyValueStore
-from .request_queue import RequestQueue
-from .storage_client_manager import StorageClientManager
+from apify.storages.dataset import Dataset
+from apify.storages.key_value_store import KeyValueStore
+from apify.storages.request_queue import RequestQueue
+from apify.storages.storage_client_manager import StorageClientManager
 
 __all__ = [
     'Dataset',

--- a/src/apify/storages/base_storage.py
+++ b/src/apify/storages/base_storage.py
@@ -4,11 +4,12 @@ import asyncio
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
+from apify_shared.utils import ignore_docs
+
 from apify._memory_storage import MemoryStorageClient
 from apify._memory_storage.resource_clients import BaseResourceClient, BaseResourceCollectionClient
 from apify.config import Configuration
 from apify.storages.storage_client_manager import StorageClientManager
-from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from apify_client import ApifyClientAsync

--- a/src/apify/storages/base_storage.py
+++ b/src/apify/storages/base_storage.py
@@ -4,12 +4,11 @@ import asyncio
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
-from apify_shared.utils import ignore_docs
-
 from apify._memory_storage import MemoryStorageClient
 from apify._memory_storage.resource_clients import BaseResourceClient, BaseResourceCollectionClient
 from apify.config import Configuration
 from apify.storages.storage_client_manager import StorageClientManager
+from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from apify_client import ApifyClientAsync

--- a/src/apify/storages/base_storage.py
+++ b/src/apify/storages/base_storage.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
 from apify_shared.utils import ignore_docs
 
-from .._memory_storage import MemoryStorageClient
-from .._memory_storage.resource_clients import BaseResourceClient, BaseResourceCollectionClient
-from ..config import Configuration
-from .storage_client_manager import StorageClientManager
+from apify._memory_storage import MemoryStorageClient
+from apify._memory_storage.resource_clients import BaseResourceClient, BaseResourceCollectionClient
+from apify.config import Configuration
+from apify.storages.storage_client_manager import StorageClientManager
 
 if TYPE_CHECKING:
     from apify_client import ApifyClientAsync

--- a/src/apify/storages/dataset.py
+++ b/src/apify/storages/dataset.py
@@ -5,22 +5,20 @@ import io
 import math
 from typing import TYPE_CHECKING, AsyncIterator, Iterable, Iterator
 
-from apify_shared.utils import ignore_docs, json_dumps
-
 from apify._utils import wrap_internal
 from apify.consts import MAX_PAYLOAD_SIZE_BYTES
 from apify.storages.base_storage import BaseStorage
 from apify.storages.key_value_store import KeyValueStore
+from apify_shared.utils import ignore_docs, json_dumps
 
 if TYPE_CHECKING:
+    from apify._memory_storage import MemoryStorageClient
+    from apify._memory_storage.resource_clients import DatasetClient, DatasetCollectionClient
+    from apify.config import Configuration
     from apify_client import ApifyClientAsync
     from apify_client.clients import DatasetClientAsync, DatasetCollectionClientAsync
     from apify_shared.models import ListPage
     from apify_shared.types import JSONSerializable
-
-    from apify._memory_storage import MemoryStorageClient
-    from apify._memory_storage.resource_clients import DatasetClient, DatasetCollectionClient
-    from apify.config import Configuration
 
 # 0.01%
 SAFETY_BUFFER_PERCENT = 0.01 / 100

--- a/src/apify/storages/dataset.py
+++ b/src/apify/storages/dataset.py
@@ -7,10 +7,10 @@ from typing import TYPE_CHECKING, AsyncIterator, Iterable, Iterator
 
 from apify_shared.utils import ignore_docs, json_dumps
 
-from .._utils import wrap_internal
-from ..consts import MAX_PAYLOAD_SIZE_BYTES
-from .base_storage import BaseStorage
-from .key_value_store import KeyValueStore
+from apify._utils import wrap_internal
+from apify.consts import MAX_PAYLOAD_SIZE_BYTES
+from apify.storages.base_storage import BaseStorage
+from apify.storages.key_value_store import KeyValueStore
 
 if TYPE_CHECKING:
     from apify_client import ApifyClientAsync
@@ -18,9 +18,9 @@ if TYPE_CHECKING:
     from apify_shared.models import ListPage
     from apify_shared.types import JSONSerializable
 
-    from .._memory_storage import MemoryStorageClient
-    from .._memory_storage.resource_clients import DatasetClient, DatasetCollectionClient
-    from ..config import Configuration
+    from apify._memory_storage import MemoryStorageClient
+    from apify._memory_storage.resource_clients import DatasetClient, DatasetCollectionClient
+    from apify.config import Configuration
 
 # 0.01%
 SAFETY_BUFFER_PERCENT = 0.01 / 100

--- a/src/apify/storages/dataset.py
+++ b/src/apify/storages/dataset.py
@@ -5,20 +5,22 @@ import io
 import math
 from typing import TYPE_CHECKING, AsyncIterator, Iterable, Iterator
 
+from apify_shared.utils import ignore_docs, json_dumps
+
 from apify._utils import wrap_internal
 from apify.consts import MAX_PAYLOAD_SIZE_BYTES
 from apify.storages.base_storage import BaseStorage
 from apify.storages.key_value_store import KeyValueStore
-from apify_shared.utils import ignore_docs, json_dumps
 
 if TYPE_CHECKING:
-    from apify._memory_storage import MemoryStorageClient
-    from apify._memory_storage.resource_clients import DatasetClient, DatasetCollectionClient
-    from apify.config import Configuration
     from apify_client import ApifyClientAsync
     from apify_client.clients import DatasetClientAsync, DatasetCollectionClientAsync
     from apify_shared.models import ListPage
     from apify_shared.types import JSONSerializable
+
+    from apify._memory_storage import MemoryStorageClient
+    from apify._memory_storage.resource_clients import DatasetClient, DatasetCollectionClient
+    from apify.config import Configuration
 
 # 0.01%
 SAFETY_BUFFER_PERCENT = 0.01 / 100

--- a/src/apify/storages/key_value_store.py
+++ b/src/apify/storages/key_value_store.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, AsyncIterator, NamedTuple, TypedDict, TypeVar, overload
 
-from apify._utils import wrap_internal
-from apify.storages.base_storage import BaseStorage
 from apify_client.clients import KeyValueStoreClientAsync, KeyValueStoreCollectionClientAsync
 from apify_shared.utils import ignore_docs
 
+from apify._utils import wrap_internal
+from apify.storages.base_storage import BaseStorage
+
 if TYPE_CHECKING:
+    from apify_client import ApifyClientAsync
+
     from apify._memory_storage import MemoryStorageClient
     from apify._memory_storage.resource_clients import KeyValueStoreClient, KeyValueStoreCollectionClient
     from apify.config import Configuration
-    from apify_client import ApifyClientAsync
 
 
 T = TypeVar('T')

--- a/src/apify/storages/key_value_store.py
+++ b/src/apify/storages/key_value_store.py
@@ -5,15 +5,15 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, NamedTuple, TypedDict, Typ
 from apify_client.clients import KeyValueStoreClientAsync, KeyValueStoreCollectionClientAsync
 from apify_shared.utils import ignore_docs
 
-from .._utils import wrap_internal
-from .base_storage import BaseStorage
+from apify._utils import wrap_internal
+from apify.storages.base_storage import BaseStorage
 
 if TYPE_CHECKING:
     from apify_client import ApifyClientAsync
 
-    from .._memory_storage import MemoryStorageClient
-    from .._memory_storage.resource_clients import KeyValueStoreClient, KeyValueStoreCollectionClient
-    from ..config import Configuration
+    from apify._memory_storage import MemoryStorageClient
+    from apify._memory_storage.resource_clients import KeyValueStoreClient, KeyValueStoreCollectionClient
+    from apify.config import Configuration
 
 
 T = TypeVar('T')

--- a/src/apify/storages/key_value_store.py
+++ b/src/apify/storages/key_value_store.py
@@ -2,18 +2,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, AsyncIterator, NamedTuple, TypedDict, TypeVar, overload
 
+from apify._utils import wrap_internal
+from apify.storages.base_storage import BaseStorage
 from apify_client.clients import KeyValueStoreClientAsync, KeyValueStoreCollectionClientAsync
 from apify_shared.utils import ignore_docs
 
-from apify._utils import wrap_internal
-from apify.storages.base_storage import BaseStorage
-
 if TYPE_CHECKING:
-    from apify_client import ApifyClientAsync
-
     from apify._memory_storage import MemoryStorageClient
     from apify._memory_storage.resource_clients import KeyValueStoreClient, KeyValueStoreCollectionClient
     from apify.config import Configuration
+    from apify_client import ApifyClientAsync
 
 
 T = TypeVar('T')

--- a/src/apify/storages/request_queue.py
+++ b/src/apify/storages/request_queue.py
@@ -6,21 +6,19 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from typing import OrderedDict as OrderedDictType
 
-from apify_shared.utils import ignore_docs
-
 from apify._crypto import crypto_random_object_id
 from apify._utils import LRUCache, budget_ow, unique_key_to_request_id
 from apify.consts import REQUEST_QUEUE_HEAD_MAX_LIMIT
 from apify.log import logger
 from apify.storages.base_storage import BaseStorage
+from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
-    from apify_client import ApifyClientAsync
-    from apify_client.clients import RequestQueueClientAsync, RequestQueueCollectionClientAsync
-
     from apify._memory_storage import MemoryStorageClient
     from apify._memory_storage.resource_clients import RequestQueueClient, RequestQueueCollectionClient
     from apify.config import Configuration
+    from apify_client import ApifyClientAsync
+    from apify_client.clients import RequestQueueClientAsync, RequestQueueCollectionClientAsync
 
 
 MAX_CACHED_REQUESTS = 1_000_000

--- a/src/apify/storages/request_queue.py
+++ b/src/apify/storages/request_queue.py
@@ -6,19 +6,21 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from typing import OrderedDict as OrderedDictType
 
+from apify_shared.utils import ignore_docs
+
 from apify._crypto import crypto_random_object_id
 from apify._utils import LRUCache, budget_ow, unique_key_to_request_id
 from apify.consts import REQUEST_QUEUE_HEAD_MAX_LIMIT
 from apify.log import logger
 from apify.storages.base_storage import BaseStorage
-from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
+    from apify_client import ApifyClientAsync
+    from apify_client.clients import RequestQueueClientAsync, RequestQueueCollectionClientAsync
+
     from apify._memory_storage import MemoryStorageClient
     from apify._memory_storage.resource_clients import RequestQueueClient, RequestQueueCollectionClient
     from apify.config import Configuration
-    from apify_client import ApifyClientAsync
-    from apify_client.clients import RequestQueueClientAsync, RequestQueueCollectionClientAsync
 
 
 MAX_CACHED_REQUESTS = 1_000_000

--- a/src/apify/storages/request_queue.py
+++ b/src/apify/storages/request_queue.py
@@ -8,19 +8,19 @@ from typing import OrderedDict as OrderedDictType
 
 from apify_shared.utils import ignore_docs
 
-from .._crypto import crypto_random_object_id
-from .._utils import LRUCache, budget_ow, unique_key_to_request_id
-from ..consts import REQUEST_QUEUE_HEAD_MAX_LIMIT
-from ..log import logger
-from .base_storage import BaseStorage
+from apify._crypto import crypto_random_object_id
+from apify._utils import LRUCache, budget_ow, unique_key_to_request_id
+from apify.consts import REQUEST_QUEUE_HEAD_MAX_LIMIT
+from apify.log import logger
+from apify.storages.base_storage import BaseStorage
 
 if TYPE_CHECKING:
     from apify_client import ApifyClientAsync
     from apify_client.clients import RequestQueueClientAsync, RequestQueueCollectionClientAsync
 
-    from .._memory_storage import MemoryStorageClient
-    from .._memory_storage.resource_clients import RequestQueueClient, RequestQueueCollectionClient
-    from ..config import Configuration
+    from apify._memory_storage import MemoryStorageClient
+    from apify._memory_storage.resource_clients import RequestQueueClient, RequestQueueCollectionClient
+    from apify.config import Configuration
 
 
 MAX_CACHED_REQUESTS = 1_000_000

--- a/src/apify/storages/storage_client_manager.py
+++ b/src/apify/storages/storage_client_manager.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from apify_shared.utils import ignore_docs
+
 from apify._memory_storage import MemoryStorageClient
 from apify.config import Configuration
-from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from apify_client import ApifyClientAsync

--- a/src/apify/storages/storage_client_manager.py
+++ b/src/apify/storages/storage_client_manager.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 
 from apify_shared.utils import ignore_docs
 
-from .._memory_storage import MemoryStorageClient
-from ..config import Configuration
+from apify._memory_storage import MemoryStorageClient
+from apify.config import Configuration
 
 if TYPE_CHECKING:
     from apify_client import ApifyClientAsync

--- a/src/apify/storages/storage_client_manager.py
+++ b/src/apify/storages/storage_client_manager.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from apify_shared.utils import ignore_docs
-
 from apify._memory_storage import MemoryStorageClient
 from apify.config import Configuration
+from apify_shared.utils import ignore_docs
 
 if TYPE_CHECKING:
     from apify_client import ApifyClientAsync

--- a/tests/integration/actor_source_base/src/__main__.py
+++ b/tests/integration/actor_source_base/src/__main__.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from apify.log import ActorLogFormatter
-
 from .main import main
+from apify.log import ActorLogFormatter
 
 handler = logging.StreamHandler()
 handler.setFormatter(ActorLogFormatter())

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,13 +12,13 @@ from typing import TYPE_CHECKING, AsyncIterator, Awaitable, Callable, Mapping, P
 import pytest
 from filelock import FileLock
 
-from apify import Actor
-from apify.config import Configuration
-from apify.storages import Dataset, KeyValueStore, RequestQueue, StorageClientManager
 from apify_client import ApifyClientAsync
 from apify_shared.consts import ActorJobStatus, ActorSourceType
 
 from ._utils import generate_unique_resource_name
+from apify import Actor
+from apify.config import Configuration
+from apify.storages import Dataset, KeyValueStore, RequestQueue, StorageClientManager
 
 if TYPE_CHECKING:
     from apify_client.clients.resource_clients import ActorClientAsync

--- a/tests/integration/test_actor_api_helpers.py
+++ b/tests/integration/test_actor_api_helpers.py
@@ -4,10 +4,9 @@ import asyncio
 import json
 from typing import TYPE_CHECKING
 
+from ._utils import generate_unique_resource_name
 from apify import Actor
 from apify._crypto import crypto_random_object_id
-
-from ._utils import generate_unique_resource_name
 
 if TYPE_CHECKING:
     from apify_client import ApifyClientAsync

--- a/tests/integration/test_actor_dataset.py
+++ b/tests/integration/test_actor_dataset.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from apify import Actor
 from apify_shared.consts import ApifyEnvVars
 
 from ._utils import generate_unique_resource_name
+from apify import Actor
 
 if TYPE_CHECKING:
     import pytest

--- a/tests/integration/test_actor_events.py
+++ b/tests/integration/test_actor_events.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
-from apify import Actor
 from apify_shared.consts import ActorEventTypes
+
+from apify import Actor
 
 if TYPE_CHECKING:
     from .conftest import ActorFactory

--- a/tests/integration/test_actor_key_value_store.py
+++ b/tests/integration/test_actor_key_value_store.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from apify import Actor
 from apify_shared.consts import ApifyEnvVars
 
 from ._utils import generate_unique_resource_name
+from apify import Actor
 
 if TYPE_CHECKING:
     import pytest

--- a/tests/integration/test_actor_request_queue.py
+++ b/tests/integration/test_actor_request_queue.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from apify import Actor
 from apify_shared.consts import ApifyEnvVars
 
 from ._utils import generate_unique_resource_name
+from apify import Actor
 
 if TYPE_CHECKING:
     import pytest

--- a/tests/unit/actor/test_actor_create_proxy_configuration.py
+++ b/tests/unit/actor/test_actor_create_proxy_configuration.py
@@ -5,9 +5,10 @@ from typing import TYPE_CHECKING
 import httpx
 import pytest
 
-from apify import Actor
 from apify_client import ApifyClientAsync
 from apify_shared.consts import ApifyEnvVars
+
+from apify import Actor
 
 if TYPE_CHECKING:
     from respx import MockRouter

--- a/tests/unit/actor/test_actor_dataset.py
+++ b/tests/unit/actor/test_actor_dataset.py
@@ -4,8 +4,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from apify import Actor
 from apify_shared.consts import ActorEnvVars
+
+from apify import Actor
 
 if TYPE_CHECKING:
     from apify._memory_storage import MemoryStorageClient

--- a/tests/unit/actor/test_actor_env_helpers.py
+++ b/tests/unit/actor/test_actor_env_helpers.py
@@ -5,8 +5,9 @@ import string
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
-from apify import Actor
 from apify_shared.consts import BOOL_ENV_VARS, DATETIME_ENV_VARS, FLOAT_ENV_VARS, INTEGER_ENV_VARS, STRING_ENV_VARS, ActorEnvVars, ApifyEnvVars
+
+from apify import Actor
 
 if TYPE_CHECKING:
     import pytest

--- a/tests/unit/actor/test_actor_helpers.py
+++ b/tests/unit/actor/test_actor_helpers.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from apify import Actor
 from apify_client import ApifyClientAsync
 from apify_shared.consts import ApifyEnvVars, WebhookEventType
+
+from apify import Actor
 
 if TYPE_CHECKING:
     import pytest

--- a/tests/unit/actor/test_actor_key_value_store.py
+++ b/tests/unit/actor/test_actor_key_value_store.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from apify import Actor
-from apify._crypto import public_encrypt
-from apify.consts import ENCRYPTED_INPUT_VALUE_PREFIX
 from apify_shared.consts import ApifyEnvVars
 from apify_shared.utils import json_dumps
 
 from ..test_crypto import PRIVATE_KEY_PASSWORD, PRIVATE_KEY_PEM_BASE64, PUBLIC_KEY
+from apify import Actor
+from apify._crypto import public_encrypt
+from apify.consts import ENCRYPTED_INPUT_VALUE_PREFIX
 
 if TYPE_CHECKING:
     from apify._memory_storage import MemoryStorageClient

--- a/tests/unit/actor/test_actor_lifecycle.py
+++ b/tests/unit/actor/test_actor_lifecycle.py
@@ -8,8 +8,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from apify import Actor
 from apify_shared.consts import ActorEventTypes, ApifyEnvVars
+
+from apify import Actor
 
 
 class TestActorInit:

--- a/tests/unit/actor/test_actor_log.py
+++ b/tests/unit/actor/test_actor_log.py
@@ -5,9 +5,10 @@ import logging
 import sys
 from typing import TYPE_CHECKING
 
+from apify_client import __version__ as apify_client_version
+
 from apify import Actor, __version__
 from apify.log import logger
-from apify_client import __version__ as apify_client_version
 
 if TYPE_CHECKING:
     import pytest

--- a/tests/unit/actor/test_actor_memory_storage_e2e.py
+++ b/tests/unit/actor/test_actor_memory_storage_e2e.py
@@ -5,9 +5,10 @@ from typing import Callable
 
 import pytest
 
+from apify_shared.consts import ApifyEnvVars
+
 from apify import Actor
 from apify.storages import StorageClientManager
-from apify_shared.consts import ApifyEnvVars
 
 
 @pytest.mark.parametrize('purge_on_start', [True, False])

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,12 +8,13 @@ from typing import TYPE_CHECKING, Any, Callable, get_type_hints
 
 import pytest
 
+from apify_client.client import ApifyClientAsync
+from apify_shared.consts import ApifyEnvVars
+
 from apify import Actor
 from apify._memory_storage import MemoryStorageClient
 from apify.config import Configuration
 from apify.storages import Dataset, KeyValueStore, RequestQueue, StorageClientManager
-from apify_client.client import ApifyClientAsync
-from apify_shared.consts import ApifyEnvVars
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/unit/memory_storage/resource_clients/test_key_value_store.py
+++ b/tests/unit/memory_storage/resource_clients/test_key_value_store.py
@@ -9,9 +9,10 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from apify_shared.utils import json_dumps
+
 from apify._crypto import crypto_random_object_id
 from apify._utils import maybe_parse_body
-from apify_shared.utils import json_dumps
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/unit/memory_storage/test_memory_storage.py
+++ b/tests/unit/memory_storage/test_memory_storage.py
@@ -5,8 +5,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from apify._memory_storage import MemoryStorageClient
 from apify_shared.consts import ApifyEnvVars
+
+from apify._memory_storage import MemoryStorageClient
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from apify.config import Configuration
 from apify_shared.consts import ActorEnvVars, ApifyEnvVars
+
+from apify.config import Configuration
 
 if TYPE_CHECKING:
     import pytest

--- a/tests/unit/test_event_manager.py
+++ b/tests/unit/test_event_manager.py
@@ -12,9 +12,10 @@ import pytest
 import websockets
 import websockets.server
 
+from apify_shared.consts import ActorEnvVars, ActorEventTypes
+
 from apify.config import Configuration
 from apify.event_manager import EventManager
-from apify_shared.consts import ActorEnvVars, ActorEventTypes
 
 
 class TestEventManagerLocal:

--- a/tests/unit/test_proxy_configuration.py
+++ b/tests/unit/test_proxy_configuration.py
@@ -7,9 +7,10 @@ from typing import TYPE_CHECKING
 import httpx
 import pytest
 
-from apify.proxy_configuration import ProxyConfiguration, is_url
 from apify_client import ApifyClientAsync
 from apify_shared.consts import ApifyEnvVars
+
+from apify.proxy_configuration import ProxyConfiguration, is_url
 
 if TYPE_CHECKING:
     from respx import MockRouter

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 import pytest
 from aiofiles.os import mkdir
 
+from apify_shared.consts import ActorEnvVars, ApifyEnvVars
+
 from apify._utils import (
     budget_ow,
     fetch_and_parse_env_var,
@@ -28,7 +30,6 @@ from apify._utils import (
     unique_key_to_request_id,
 )
 from apify.consts import StorageTypes
-from apify_shared.consts import ActorEnvVars, ApifyEnvVars
 
 if TYPE_CHECKING:
     from pathlib import Path


### PR DESCRIPTION
Implements https://github.com/apify/apify-sdk-python/issues/160, with exception of tests, where the relative imports make some sense and removing them would mean re-architecturing the tests.

I've ran `make check-code` and it did complain about `Import block is un-sorted or un-formatted` after my changes, so I've ran it with `--fix` and committed the changes, but then I've hit the following error caused by circular import:

```
Lint codebase.................................................................Passed
Type-check codebase...........................................................Passed
Run unit tests................................................................Failed
- hook id: unit-tests
- exit code: 2

python3 -m pytest -n auto -ra tests/unit --cov=src/apify
ImportError while loading conftest '/Users/honza/Projects/apify-sdk-python/tests/unit/conftest.py'.
tests/unit/conftest.py:11: in <module>
    from apify import Actor
src/apify/__init__.py:3: in <module>
    from apify.actor import Actor
src/apify/actor.py:27: in <module>
    from apify.storages import Dataset, KeyValueStore, RequestQueue, StorageClientManager
src/apify/storages/__init__.py:1: in <module>
    from apify.storages.dataset import Dataset
src/apify/storages/dataset.py:11: in <module>
    from apify.storages.key_value_store import KeyValueStore
src/apify/storages/key_value_store.py:7: in <module>
    from apify_client.clients import KeyValueStoreClientAsync, KeyValueStoreCollectionClientAsync
venv/lib/python3.11/site-packages/apify_client/__init__.py:3: in <module>
    from .client import ApifyClient, ApifyClientAsync
venv/lib/python3.11/site-packages/apify_client/client.py:6: in <module>
    from .clients import (
venv/lib/python3.11/site-packages/apify_client/clients/__init__.py:1: in <module>
    from .base import (
venv/lib/python3.11/site-packages/apify_client/clients/base/__init__.py:1: in <module>
    from .actor_job_base_client import ActorJobBaseClient, ActorJobBaseClientAsync
venv/lib/python3.11/site-packages/apify_client/clients/base/actor_job_base_client.py:11: in <module>
    from apify._errors import ApifyApiError
E   ModuleNotFoundError: No module named 'apify._errors'
```

I think the circular import wasn't there, but sorting the imports as required by `ruff` probably introduced it. I did not investigate further, as this was supposed to be just a small gift, not a all evening debugging session 😅

I intentionally committed both changes separately, so that you can cherry pick what you like and drop the rest.