### PR TITLE
Add option to run integration tests from PRs from forks

### DIFF
--- a/.github/workflows/check_version_availability.yaml
+++ b/.github/workflows/check_version_availability.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha) || '' }}"
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/check_version_availability.yaml
+++ b/.github/workflows/check_version_availability.yaml
@@ -10,12 +10,12 @@ jobs:
     if: (!startsWith(github.event.pull_request.title, 'docs:'))
 
     steps:
-      # We need to check out the head commit in case of PRs from forks,
+      # We need to check out the head commit in case of PRs,
       # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.owner != 'apify' && github.event.pull_request.head.sha || '' }}"
+          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}"
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/check_version_availability.yaml
+++ b/.github/workflows/check_version_availability.yaml
@@ -10,6 +10,8 @@ jobs:
     if: (!startsWith(github.event.pull_request.title, 'docs:'))
 
     steps:
+      # We need to check out the merge commit in case of pull requests,
+      # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/check_version_availability.yaml
+++ b/.github/workflows/check_version_availability.yaml
@@ -10,12 +10,12 @@ jobs:
     if: (!startsWith(github.event.pull_request.title, 'docs:'))
 
     steps:
-      # We need to check out the merge commit in case of pull requests,
+      # We need to check out the head commit in case of PRs from forks,
       # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha) || '' }}"
+          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.owner != 'apify' && github.event.pull_request.head.sha || '' }}"
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha) || '' }}"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -20,12 +20,12 @@ jobs:
       max-parallel: 1 # no concurrency on this level, to not overshoot the test user limits
 
     steps:
-      # We need to check out the merge commit in case of pull requests,
+      # We need to check out the head commit in case of PRs from forks,
       # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha) || '' }}"
+          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.owner != 'apify' && github.event.pull_request.head.sha || '' }}"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -20,12 +20,12 @@ jobs:
       max-parallel: 1 # no concurrency on this level, to not overshoot the test user limits
 
     steps:
-      # We need to check out the head commit in case of PRs from forks,
+      # We need to check out the head commit in case of PRs,
       # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.owner != 'apify' && github.event.pull_request.head.sha || '' }}"
+          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -20,6 +20,8 @@ jobs:
       max-parallel: 1 # no concurrency on this level, to not overshoot the test user limits
 
     steps:
+      # We need to check out the merge commit in case of pull requests,
+      # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint_and_type_checks.yaml
+++ b/.github/workflows/lint_and_type_checks.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha) || '' }}"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/lint_and_type_checks.yaml
+++ b/.github/workflows/lint_and_type_checks.yaml
@@ -12,12 +12,12 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      # We need to check out the head commit in case of PRs from forks,
+      # We need to check out the head commit in case of PRs,
       # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.owner != 'apify' && github.event.pull_request.head.sha || '' }}"
+          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/lint_and_type_checks.yaml
+++ b/.github/workflows/lint_and_type_checks.yaml
@@ -12,6 +12,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
+      - name: Dummy step
+        run: echo "${{ github.event_name }}"
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint_and_type_checks.yaml
+++ b/.github/workflows/lint_and_type_checks.yaml
@@ -12,12 +12,12 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      # We need to check out the merge commit in case of pull requests,
+      # We need to check out the head commit in case of PRs from forks,
       # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha) || '' }}"
+          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.owner != 'apify' && github.event.pull_request.head.sha || '' }}"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/lint_and_type_checks.yaml
+++ b/.github/workflows/lint_and_type_checks.yaml
@@ -12,9 +12,8 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - name: Dummy step
-        run: echo "${{ github.event_name }}"
-
+      # We need to check out the merge commit in case of pull requests,
+      # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -17,6 +17,7 @@ jobs:
     needs: [lint_and_type_checks]
     uses: ./.github/workflows/unit_tests.yaml
 
+  # If the PR comes from the main repo, run integration tests directly
   integration_tests:
     if: github.event.pull_request.base.repo.owner == 'apify'
     name: Run integration tests
@@ -24,6 +25,12 @@ jobs:
     uses: ./.github/workflows/integration_tests.yaml
     secrets: inherit
 
+  # If the PR comes from a fork,
+  # we need to approve running the workflow first before allowing it to run,
+  # so that we can check for any unauthorized access to our secrets.
+  # We need two workflow jobs for that,
+  # because jobs calling reusable workflows can't use an environment.
+  # The first job is a dummy job that just asks for approval to use the `fork-worklows` environment.
   integration_tests_fork_approve:
     if: github.event.pull_request.base.repo.owner != 'apify'
     name: Approve integration tests from fork
@@ -34,6 +41,7 @@ jobs:
       - name: Dummy step
         run: true
 
+  # The second job is the actual integration tests job.
   integration_tests_fork:
     name: Run integration tests from fork
     needs: [integration_tests_fork_approve]

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -1,7 +1,7 @@
 name: Code quality checks
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   check_version_availability:
@@ -18,7 +18,24 @@ jobs:
     uses: ./.github/workflows/unit_tests.yaml
 
   integration_tests:
+    if: github.event.pull_request.base.repo.owner == 'apify'
     name: Run integration tests
     needs: [lint_and_type_checks, unit_tests]
+    uses: ./.github/workflows/integration_tests.yaml
+    secrets: inherit
+
+  integration_tests_fork_approve:
+    if: github.event.pull_request.base.repo.owner != 'apify'
+    name: Approve integration tests from fork
+    needs: [lint_and_type_checks, unit_tests]
+    environment: fork-workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dummy step
+        run: true
+
+  integration_tests_fork:
+    name: Run integration tests from fork
+    needs: [integration_tests_fork_approve]
     uses: ./.github/workflows/integration_tests.yaml
     secrets: inherit

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -35,7 +35,7 @@ jobs:
     if: github.event.pull_request.base.repo.owner != 'apify'
     name: Approve integration tests from fork
     needs: [lint_and_type_checks, unit_tests]
-    environment: fork-workflows
+    environment: fork-pr-integration-tests
     runs-on: ubuntu-latest
     steps:
       - name: Dummy step

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      # We need to check out the merge commit in case of pull requests,
+      # We need to check out the head commit in case of PRs from forks,
       # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha) || '' }}"
+          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.owner != 'apify' && github.event.pull_request.head.sha || '' }}"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.owner != 'apify' && github.event.pull_request.head.sha || '' }}"
+          ref: "${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      # We need to check out the head commit in case of PRs from forks,
+      # We need to check out the head commit in case of PRs,
       # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha) || '' }}"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      # We need to check out the merge commit in case of pull requests,
+      # and the default ref otherwise (during release).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [1.5.1](../../releases/tag/v1.5.1) - Unreleased
 
-...
+### Internal changes
+
+- Allowed running integration tests from PRs from forks, after maintainer approval
 
 ## [1.5.0](../../releases/tag/v1.5.0) - 2024-01-03
 


### PR DESCRIPTION
With our [first community PR](https://github.com/apify/apify-sdk-python/pull/161) (🎉 ), there was an issue that the integration tests for the PR did not run since they could not access the API token for the test user from the repo secrets.

This changes the check workflows so that the tests run on the `pull_request_target` event, not on the `pull_request` event, which allows passing the secrets to the workflow even in case of forks. To prevent leaking the secrets, running the workflows on a PR from a fork requires approving the workflow run by a maintainer via an environment protection rule. I've put @vdusek, @janbuchar, @jirimoravcik and me as maintainers of that environment, so that we get notified in case of a fork PR and can approve the workflow runs.

The `pull_request_target` event runs in the context of the PR base branch, not the head branch, for security reasons, so to run the tests against the PR code, we have to check it out explicitly instead of checking out the default ref.