### PR TITLE
Do not close `nested_event_loop` in the `Scheduler.__del__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal changes
 
 - Allowed running integration tests from PRs from forks, after maintainer approval
+- Do not close `nested_event_loop` in the `Scheduler.__del__`.
 
 ## [1.5.0](../../releases/tag/v1.5.0) - 2024-01-03
 

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -49,16 +49,6 @@ class ApifyScheduler(BaseScheduler):
             traceback.print_exc()
             raise
 
-    def close(self: ApifyScheduler, reason: str) -> None:
-        """Close the scheduler.
-
-        Args:
-            reason: The reason for closing the scheduler.
-        """
-        Actor.log.debug(f'ApifyScheduler.close was called (reason={reason})...')
-        nested_event_loop.stop()
-        nested_event_loop.close()
-
     def has_pending_requests(self: ApifyScheduler) -> bool:
         """Check if the scheduler has any pending requests.
 


### PR DESCRIPTION
### Description

- Do not close `nested_event_loop` in the `Scheduler.__del__`.

### Ticket

- Related to the https://github.com/apify/actor-templates/issues/202.
