### PR TITLE
Add `apply_apify_settings` to Scrapy subpackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [1.5.3](../../releases/tag/v1.5.3) - Unreleased
 
-...
+### Added
+
+- Add `apply_apify_settings` function to Scrapy subpackage
 
 ## [1.5.2](../../releases/tag/v1.5.2) - 2024-01-19
 

--- a/tests/unit/scrapy/utils/test_apply_apify_settings.py
+++ b/tests/unit/scrapy/utils/test_apply_apify_settings.py
@@ -1,107 +1,62 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-import pytest
 from scrapy.settings import Settings
 
 from apify.scrapy.utils import apply_apify_settings
 
 
-@dataclass(frozen=True)
-class TestCase:
-    settings: Settings
-    proxy_config: dict | None
-    expected_output: Settings
+def test__apply_apify_settings__overrides_scheduler() -> None:
+    settings = Settings()
+    new_settings = apply_apify_settings(settings=settings)
+
+    assert new_settings.get('SCHEDULER') == 'apify.scrapy.scheduler.ApifyScheduler'
 
 
-test_cases = [
-    # Test case with default settings and no proxy configuration
-    TestCase(
-        settings=Settings(),
-        proxy_config=None,
-        expected_output=Settings(
-            {
-                'SCHEDULER': 'apify.scrapy.scheduler.ApifyScheduler',
-                'ITEM_PIPELINES': {
-                    'apify.scrapy.pipelines.ActorDatasetPushPipeline': 1000,
-                },
-                'DOWNLOADER_MIDDLEWARES': {
-                    'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': None,
-                    'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': None,
-                    'scrapy.downloadermiddlewares.retry.RetryMiddleware': None,
-                    'apify.scrapy.middlewares.ApifyHttpProxyMiddleware': 950,
-                    'apify.scrapy.middlewares.ApifyRetryMiddleware': 1000,
-                },
-                'APIFY_PROXY_SETTINGS': None,
+def test__apply_apify_settings__update_item_pipelines() -> None:
+    settings = Settings(
+        {
+            'ITEM_PIPELINES': {
+                'scrapy.pipelines.files.FilesPipeline': 1,
             }
-        ),
-    ),
-    # Test case with default settings and proxy configuration
-    TestCase(
-        settings=Settings(),
-        proxy_config={'useApifyProxy': True, 'apifyProxyGroups': []},
-        expected_output=Settings(
-            {
-                'SCHEDULER': 'apify.scrapy.scheduler.ApifyScheduler',
-                'ITEM_PIPELINES': {
-                    'apify.scrapy.pipelines.ActorDatasetPushPipeline': 1000,
-                },
-                'DOWNLOADER_MIDDLEWARES': {
-                    'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': None,
-                    'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': None,
-                    'scrapy.downloadermiddlewares.retry.RetryMiddleware': None,
-                    'apify.scrapy.middlewares.ApifyHttpProxyMiddleware': 950,
-                    'apify.scrapy.middlewares.ApifyRetryMiddleware': 1000,
-                },
-                'APIFY_PROXY_SETTINGS': {'useApifyProxy': True, 'apifyProxyGroups': []},
-            }
-        ),
-    ),
-    # Test case with custom settings and proxy configuration
-    TestCase(
-        settings=Settings(
-            {
-                'SCHEDULER': 'scrapy.core.scheduler.Scheduler',
-                'ITEM_PIPELINES': {
-                    'scrapy.pipelines.files.FilesPipeline': 1,
-                },
-                'DOWNLOADER_MIDDLEWARES': {
-                    'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': 123,
-                    'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': 234,
-                    'scrapy.downloadermiddlewares.retry.RetryMiddleware': 345,
-                    'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 543,
-                },
-            }
-        ),
-        proxy_config={'useApifyProxy': True, 'apifyProxyGroups': []},
-        expected_output=Settings(
-            {
-                'SCHEDULER': 'apify.scrapy.scheduler.ApifyScheduler',
-                'ITEM_PIPELINES': {
-                    'scrapy.pipelines.files.FilesPipeline': 1,
-                    'apify.scrapy.pipelines.ActorDatasetPushPipeline': 1000,
-                },
-                'DOWNLOADER_MIDDLEWARES': {
-                    'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': None,
-                    'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': None,
-                    'scrapy.downloadermiddlewares.retry.RetryMiddleware': None,
-                    'apify.scrapy.middlewares.ApifyHttpProxyMiddleware': 950,
-                    'apify.scrapy.middlewares.ApifyRetryMiddleware': 1000,
-                    'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 543,
-                },
-                'APIFY_PROXY_SETTINGS': {'useApifyProxy': True, 'apifyProxyGroups': []},
-            }
-        ),
-    ),
-]
+        }
+    )
+    new_settings = apply_apify_settings(settings=settings)
+
+    assert new_settings.get('ITEM_PIPELINES') == {
+        'scrapy.pipelines.files.FilesPipeline': 1,
+        'apify.scrapy.pipelines.ActorDatasetPushPipeline': 1000,
+    }
 
 
-@pytest.mark.parametrize('tc', test_cases)
-def test_apply_apify_settings(tc: TestCase) -> None:
-    output_settings = apply_apify_settings(settings=tc.settings, proxy_config=tc.proxy_config)
+def test__apply_apify_settings__update_downloader_middlewares() -> None:
+    settings = Settings(
+        {
+            'DOWNLOADER_MIDDLEWARES': {
+                'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': 123,
+                'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': 234,
+                'scrapy.downloadermiddlewares.retry.RetryMiddleware': 345,
+                'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 543,
+            },
+        }
+    )
+    new_settings = apply_apify_settings(settings=settings)
 
-    assert output_settings['SCHEDULER'] == tc.expected_output['SCHEDULER']
-    assert output_settings['ITEM_PIPELINES'] == tc.expected_output['ITEM_PIPELINES']
-    assert output_settings['DOWNLOADER_MIDDLEWARES'] == tc.expected_output['DOWNLOADER_MIDDLEWARES']
-    assert output_settings['APIFY_PROXY_SETTINGS'] == tc.expected_output['APIFY_PROXY_SETTINGS']
+    assert new_settings.get('DOWNLOADER_MIDDLEWARES') == {
+        'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': None,
+        'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': None,
+        'scrapy.downloadermiddlewares.retry.RetryMiddleware': None,
+        'apify.scrapy.middlewares.ApifyHttpProxyMiddleware': 950,
+        'apify.scrapy.middlewares.ApifyRetryMiddleware': 1000,
+        'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 543,
+    }
+
+
+def test__apply_apify_settings__add_proxy_config() -> None:
+    settings = Settings()
+    new_settings = apply_apify_settings(settings=settings)
+    assert new_settings.get('APIFY_PROXY_SETTINGS') is None
+
+    settings = Settings()
+    proxy_config = {'useApifyProxy': True, 'apifyProxyGroups': []}
+    new_settings = apply_apify_settings(settings=settings, proxy_config=proxy_config)
+    assert new_settings.get('APIFY_PROXY_SETTINGS') == {'useApifyProxy': True, 'apifyProxyGroups': []}

--- a/tests/unit/scrapy/utils/test_apply_apify_settings.py
+++ b/tests/unit/scrapy/utils/test_apply_apify_settings.py
@@ -98,10 +98,8 @@ test_cases = [
 
 
 @pytest.mark.parametrize('tc', test_cases)
-@pytest.mark.only()
 def test_apply_apify_settings(tc: TestCase) -> None:
     output_settings = apply_apify_settings(settings=tc.settings, proxy_config=tc.proxy_config)
-    print(dict(output_settings))
 
     assert output_settings['SCHEDULER'] == tc.expected_output['SCHEDULER']
     assert output_settings['ITEM_PIPELINES'] == tc.expected_output['ITEM_PIPELINES']

--- a/tests/unit/scrapy/utils/test_apply_apify_settings.py
+++ b/tests/unit/scrapy/utils/test_apply_apify_settings.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from scrapy.settings import Settings
+
+from apify.scrapy.utils import apply_apify_settings
+
+
+@dataclass(frozen=True)
+class TestCase:
+    settings: Settings
+    proxy_config: dict | None
+    expected_output: Settings
+
+
+test_cases = [
+    # Test case with default settings and no proxy configuration
+    TestCase(
+        settings=Settings(),
+        proxy_config=None,
+        expected_output=Settings(
+            {
+                'SCHEDULER': 'apify.scrapy.scheduler.ApifyScheduler',
+                'ITEM_PIPELINES': {
+                    'apify.scrapy.pipelines.ActorDatasetPushPipeline': 1000,
+                },
+                'DOWNLOADER_MIDDLEWARES': {
+                    'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': None,
+                    'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': None,
+                    'scrapy.downloadermiddlewares.retry.RetryMiddleware': None,
+                    'apify.scrapy.middlewares.ApifyHttpProxyMiddleware': 950,
+                    'apify.scrapy.middlewares.ApifyRetryMiddleware': 1000,
+                },
+                'APIFY_PROXY_SETTINGS': None,
+            }
+        ),
+    ),
+    # Test case with default settings and proxy configuration
+    TestCase(
+        settings=Settings(),
+        proxy_config={'useApifyProxy': True, 'apifyProxyGroups': []},
+        expected_output=Settings(
+            {
+                'SCHEDULER': 'apify.scrapy.scheduler.ApifyScheduler',
+                'ITEM_PIPELINES': {
+                    'apify.scrapy.pipelines.ActorDatasetPushPipeline': 1000,
+                },
+                'DOWNLOADER_MIDDLEWARES': {
+                    'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': None,
+                    'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': None,
+                    'scrapy.downloadermiddlewares.retry.RetryMiddleware': None,
+                    'apify.scrapy.middlewares.ApifyHttpProxyMiddleware': 950,
+                    'apify.scrapy.middlewares.ApifyRetryMiddleware': 1000,
+                },
+                'APIFY_PROXY_SETTINGS': {'useApifyProxy': True, 'apifyProxyGroups': []},
+            }
+        ),
+    ),
+    # Test case with custom settings and proxy configuration
+    TestCase(
+        settings=Settings(
+            {
+                'SCHEDULER': 'scrapy.core.scheduler.Scheduler',
+                'ITEM_PIPELINES': {
+                    'scrapy.pipelines.files.FilesPipeline': 1,
+                },
+                'DOWNLOADER_MIDDLEWARES': {
+                    'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': 123,
+                    'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': 234,
+                    'scrapy.downloadermiddlewares.retry.RetryMiddleware': 345,
+                    'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 543,
+                },
+            }
+        ),
+        proxy_config={'useApifyProxy': True, 'apifyProxyGroups': []},
+        expected_output=Settings(
+            {
+                'SCHEDULER': 'apify.scrapy.scheduler.ApifyScheduler',
+                'ITEM_PIPELINES': {
+                    'scrapy.pipelines.files.FilesPipeline': 1,
+                    'apify.scrapy.pipelines.ActorDatasetPushPipeline': 1000,
+                },
+                'DOWNLOADER_MIDDLEWARES': {
+                    'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': None,
+                    'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': None,
+                    'scrapy.downloadermiddlewares.retry.RetryMiddleware': None,
+                    'apify.scrapy.middlewares.ApifyHttpProxyMiddleware': 950,
+                    'apify.scrapy.middlewares.ApifyRetryMiddleware': 1000,
+                    'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 543,
+                },
+                'APIFY_PROXY_SETTINGS': {'useApifyProxy': True, 'apifyProxyGroups': []},
+            }
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize('tc', test_cases)
+@pytest.mark.only()
+def test_apply_apify_settings(tc: TestCase) -> None:
+    output_settings = apply_apify_settings(settings=tc.settings, proxy_config=tc.proxy_config)
+    print(dict(output_settings))
+
+    assert output_settings['SCHEDULER'] == tc.expected_output['SCHEDULER']
+    assert output_settings['ITEM_PIPELINES'] == tc.expected_output['ITEM_PIPELINES']
+    assert output_settings['DOWNLOADER_MIDDLEWARES'] == tc.expected_output['DOWNLOADER_MIDDLEWARES']
+    assert output_settings['APIFY_PROXY_SETTINGS'] == tc.expected_output['APIFY_PROXY_SETTINGS']


### PR DESCRIPTION
### Issue

- Related to the https://github.com/apify/apify-sdk-python/issues/176, but not solving it as a whole.

### Description

- This PR moves just a single function from a template to SDK - `apply_apify_settings`.
- The rest of the suggested changes are related to the logging. I was not able to make them work at first try. So for now let's solve it just for the settings-related helper function, and the rest will be done later.

### Testing

- The changes were tested both locally and on the platform. 
- Unit tests are ready as well.