### PR TITLE
Change 'input' as var name

### DIFF
--- a/docs/01-overview/01-introduction.mdx
+++ b/docs/01-overview/01-introduction.mdx
@@ -12,10 +12,10 @@ import requests
 
 async def main():
     async with Actor:
-        run_input = await Actor.get_input()
-        response = requests.get(run_input['url'])
+        actor_input = await Actor.get_input()
+        response = requests.get(actor_input['url'])
         soup = BeautifulSoup(response.content, 'html.parser')
-        await Actor.push_data({ 'url': run_input['url'], 'title': soup.title.string })
+        await Actor.push_data({ 'url': actor_input['url'], 'title': soup.title.string })
 ```
 
 ## What are Actors?

--- a/docs/01-overview/01-introduction.mdx
+++ b/docs/01-overview/01-introduction.mdx
@@ -12,10 +12,10 @@ import requests
 
 async def main():
     async with Actor:
-        input = await Actor.get_input()
-        response = requests.get(input['url'])
+        run_input = await Actor.get_input()
+        response = requests.get(run_input['url'])
         soup = BeautifulSoup(response.content, 'html.parser')
-        await Actor.push_data({ 'url': input['url'], 'title': soup.title.string })
+        await Actor.push_data({ 'url': run_input['url'], 'title': soup.title.string })
 ```
 
 ## What are Actors?


### PR DESCRIPTION
Hello team!
using `input` as a var name in Python is discouraged because of the built-in function by the same name. I noticed in other parts of the docs you used `actor_input` so I propose to change it here as well.

Hope this helps!