### PR TITLE
Fix conversion of `headers` fields in Apify <--> Scrapy request translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [1.5.5](../../releases/tag/v1.5.5) - Unreleased
 
-...
+### Fixed
+
+- Fix conversion of `headers` fields in Apify <--> Scrapy request translation
 
 ## [1.5.4](../../releases/tag/v1.5.4) - 2024-01-24
 

--- a/tests/unit/scrapy/requests/test_to_apify_request.py
+++ b/tests/unit/scrapy/requests/test_to_apify_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 from scrapy import Request, Spider
+from scrapy.http.headers import Headers
 
 from apify.scrapy.requests import to_apify_request
 
@@ -26,6 +27,15 @@ def test__to_apify_request__simple(spider: Spider) -> None:
     assert isinstance(user_data, dict)
     assert 'scrapy_request' in user_data
     assert isinstance(user_data.get('scrapy_request'), str)
+
+
+def test__to_apify_request__headers(spider: Spider) -> None:
+    scrapy_request_headers = Headers({'Authorization': 'Bearer access_token'})
+    scrapy_request = Request(url='https://example.com', headers=scrapy_request_headers)
+
+    apify_request = to_apify_request(scrapy_request, spider)
+
+    assert apify_request['headers'] == dict(scrapy_request_headers.to_unicode_dict())
 
 
 def test__to_apify_request__without_id_and_unique_key(spider: Spider) -> None:

--- a/tests/unit/scrapy/requests/test_to_scrapy_request.py
+++ b/tests/unit/scrapy/requests/test_to_scrapy_request.py
@@ -4,6 +4,7 @@ import binascii
 
 import pytest
 from scrapy import Request, Spider
+from scrapy.http.headers import Headers
 
 from apify.scrapy.requests import to_scrapy_request
 
@@ -54,7 +55,7 @@ def test__to_scrapy_request__without_reconstruction_with_optional_fields(spider:
     assert apify_request['method'] == scrapy_request.method
     assert apify_request['id'] == scrapy_request.meta.get('apify_request_id')
     assert apify_request['uniqueKey'] == scrapy_request.meta.get('apify_request_unique_key')
-    assert apify_request['headers'] == scrapy_request.headers
+    assert Headers(apify_request['headers']) == scrapy_request.headers
     assert apify_request['userData'] == scrapy_request.meta.get('userData')
 
 
@@ -101,7 +102,7 @@ def test__to_scrapy_request__with_reconstruction_with_optional_fields(spider: Sp
     assert apify_request['method'] == scrapy_request.method
     assert apify_request['id'] == scrapy_request.meta.get('apify_request_id')
     assert apify_request['uniqueKey'] == scrapy_request.meta.get('apify_request_unique_key')
-    assert apify_request['headers'] == scrapy_request.headers
+    assert Headers(apify_request['headers']) == scrapy_request.headers
     assert apify_request['userData'] == scrapy_request.meta.get('userData')
 
 


### PR DESCRIPTION
### Problem description

Scrapy uses its own data structure for headers (`scrapy.http.Headers`). We need to convert it to the dictionary in `to_apify_request` to be able to serialize it. Then in the `to_scrapy_request` we need to convert it back to the `scrapy.http.Headers`.

### Issue

- Closes: https://github.com/apify/actor-templates/issues/270
