### PR TITLE
Improve error handling for `to_apify_request` serialization failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [1.6.1](../../releases/tag/v1.6.1) - Unreleased
 
-...
+### Fixed
+
+- Improve error handling for `to_apify_request` serialization failures
 
 ## [1.6.0](../../releases/tag/v1.6.0) - 2024-02-23
 

--- a/src/apify/scrapy/requests.py
+++ b/src/apify/scrapy/requests.py
@@ -35,7 +35,7 @@ def to_apify_request(scrapy_request: Request, spider: Spider) -> dict | None:
         The converted Apify request if the conversion was successful, otherwise None.
     """
     if not isinstance(scrapy_request, Request):
-        Actor.log.warn('Failed to convert to Apify request: Scrapy request must be a Request instance.')
+        Actor.log.warning('Failed to convert to Apify request: Scrapy request must be a Request instance.')
         return None
 
     call_id = crypto_random_object_id(8)
@@ -73,7 +73,7 @@ def to_apify_request(scrapy_request: Request, spider: Spider) -> dict | None:
         apify_request['userData']['scrapy_request'] = scrapy_request_dict_encoded
 
     except Exception as exc:
-        Actor.log.warn(f'Conversion of Scrapy request {scrapy_request} to Apify request failed; {exc}')
+        Actor.log.warning(f'Conversion of Scrapy request {scrapy_request} to Apify request failed; {exc}')
         return None
 
     Actor.log.debug(f'[{call_id}]: scrapy_request was converted to the apify_request={apify_request}')

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -85,6 +85,10 @@ class ApifyScheduler(BaseScheduler):
             raise TypeError('self.spider must be an instance of the Spider class')
 
         apify_request = to_apify_request(request, spider=self.spider)
+        if apify_request is None:
+            Actor.log.warn(f'Request {request} was not enqueued because it could not be converted to Apify request.')
+            return False
+
         Actor.log.debug(f'[{call_id}]: scrapy_request was transformed to apify_request (apify_request={apify_request})')
 
         if not isinstance(self._rq, RequestQueue):

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -86,7 +86,7 @@ class ApifyScheduler(BaseScheduler):
 
         apify_request = to_apify_request(request, spider=self.spider)
         if apify_request is None:
-            Actor.log.warn(f'Request {request} was not enqueued because it could not be converted to Apify request.')
+            Actor.log.error(f'Request {request} was not enqueued because it could not be converted to Apify request.')
             return False
 
         Actor.log.debug(f'[{call_id}]: scrapy_request was transformed to apify_request (apify_request={apify_request})')

--- a/tests/unit/scrapy/requests/test_to_apify_request.py
+++ b/tests/unit/scrapy/requests/test_to_apify_request.py
@@ -21,6 +21,7 @@ def test__to_apify_request__simple(spider: Spider) -> None:
     scrapy_request = Request(url='https://example.com')
 
     apify_request = to_apify_request(scrapy_request, spider)
+    assert apify_request is not None
     assert apify_request.get('url') == 'https://example.com'
 
     user_data = apify_request.get('userData', {})
@@ -35,6 +36,7 @@ def test__to_apify_request__headers(spider: Spider) -> None:
 
     apify_request = to_apify_request(scrapy_request, spider)
 
+    assert apify_request is not None
     assert apify_request['headers'] == dict(scrapy_request_headers.to_unicode_dict())
 
 
@@ -47,6 +49,7 @@ def test__to_apify_request__without_id_and_unique_key(spider: Spider) -> None:
 
     apify_request = to_apify_request(scrapy_request, spider)
 
+    assert apify_request is not None
     assert apify_request.get('url') == 'https://example.com'
     assert apify_request.get('method') == 'GET'
 
@@ -70,6 +73,7 @@ def test__to_apify_request__with_id_and_unique_key(spider: Spider) -> None:
     )
 
     apify_request = to_apify_request(scrapy_request, spider)
+    assert apify_request is not None
 
     assert apify_request.get('url') == 'https://example.com'
     assert apify_request.get('method') == 'GET'
@@ -87,5 +91,5 @@ def test__to_apify_request__with_id_and_unique_key(spider: Spider) -> None:
 def test__to_apify_request__invalid_scrapy_request(spider: Spider) -> None:
     scrapy_request = 'invalid_request'
 
-    with pytest.raises(TypeError):
-        to_apify_request(scrapy_request, spider)
+    apify_request = to_apify_request(scrapy_request, spider)
+    assert apify_request is None


### PR DESCRIPTION
The PR addresses the problem identified in [Issue #189](https://github.com/apify/apify-sdk-python/issues/189), where `to_apify_request` could fail silently during serialization of the Scrapy request. This PR has introduced enhanced error handling to ensure users are informed if serialization of a request fails, preventing the request from being not enqueued without notification.