### PR TITLE
docs: Small docs fixes

### DIFF
--- a/docs/03-concepts/01-actor-lifecycle.mdx
+++ b/docs/03-concepts/01-actor-lifecycle.mdx
@@ -24,7 +24,7 @@ There is also the [`Actor.fail()`](../../reference/class/Actor#fail) method, whi
 
 ```python title="src/main.py"
 from apify import Actor
-from apify.consts import ActorExitCodes
+from apify_shared.consts import ActorExitCodes
 
 async def main():
     await Actor.init()

--- a/docs/03-concepts/04-actor-events.mdx
+++ b/docs/03-concepts/04-actor-events.mdx
@@ -71,12 +71,12 @@ During its runtime, the Actor receives Actor events sent by the Apify platform o
 ## Adding handlers to events
 
 To add handlers to these events, you use the [`Actor.on()`](../../reference/class/Actor#on) method,
-and to remove them, you use the [`Actor.on()`](../../reference/class/Actor#off) method.
+and to remove them, you use the [`Actor.off()`](../../reference/class/Actor#off) method.
 
 ```python title="src/main.py"
 import asyncio
 from apify import Actor
-from apify.consts import ActorEventTypes
+from apify_shared.consts import ActorEventTypes
 
 async def main():
     async with Actor:

--- a/docs/03-concepts/11-configuration.mdx
+++ b/docs/03-concepts/11-configuration.mdx
@@ -22,7 +22,7 @@ This will cause the Actor to persist its state every 10 seconds:
 
 ```python title="src/main.py"
 from apify import Actor
-from apify.consts import ActorEventTypes
+from apify_shared.consts import ActorEventTypes
 
 async def main():
     global_config = Configuration.get_global_configuration()


### PR DESCRIPTION
After we've split off `apify_shared`, we forgot to update the consts imports in the docs. This fixes it.

Also fixes one typo with `Actor.off()`.