### PR TITLE
Improve unique key generation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## [1.6.1](../../releases/tag/v1.6.1) - Unreleased
+## [1.7.0](../../releases/tag/v1.7.0) - Unreleased
+
+### Added
+
+- Add a new way of generating the `uniqueKey` field of the request, aligning it with the Crawlee.
 
 ### Fixed
 
 - Improve error handling for `to_apify_request` serialization failures
+- Scrapy's `Request.dont_filter` works.
 
 ## [1.6.0](../../releases/tag/v1.6.0) - 2024-02-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apify"
-version = "1.6.1"
+version = "1.7.0"
 description = "Apify SDK for Python"
 readme = "README.md"
 license = { text = "Apache Software License" }

--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -415,14 +415,14 @@ ListOrDictOrAny = TypeVar('ListOrDictOrAny', list, dict, Any)
 
 
 def compute_short_hash(data: bytes, *, length: int = 8) -> str:
-    """Computes a hexadecimal SHA-256 hash of the provided data and returns a substring of it.
+    """Computes a hexadecimal SHA-256 hash of the provided data and returns a substring (prefix) of it.
 
     Args:
         data: The binary data to be hashed.
         length: The length of the hash to be returned.
 
     Returns:
-        An 8-character hexadecimal hash.
+        A substring (prefix) of the hexadecimal hash of the data.
     """
     hash_object = sha256(data)
     return hash_object.hexdigest()[:length]

--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -295,8 +295,8 @@ def maybe_parse_body(body: bytes, content_type: str) -> Any:
 
 def unique_key_to_request_id(unique_key: str) -> str:
     """Generate request ID based on unique key in a deterministic way."""
-    id_ = re.sub(r'(\+|\/|=)', '', b64encode(sha256(unique_key.encode('utf-8')).digest()).decode('utf-8'))
-    return id_[:REQUEST_ID_LENGTH] if len(id_) > REQUEST_ID_LENGTH else id_
+    request_id = re.sub(r'(\+|\/|=)', '', b64encode(sha256(unique_key.encode('utf-8')).digest()).decode('utf-8'))
+    return request_id[:REQUEST_ID_LENGTH] if len(request_id) > REQUEST_ID_LENGTH else request_id
 
 
 async def force_rename(src_dir: str, dst_dir: str) -> None:

--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -295,8 +295,8 @@ def maybe_parse_body(body: bytes, content_type: str) -> Any:
 
 def unique_key_to_request_id(unique_key: str) -> str:
     """Generate request ID based on unique key in a deterministic way."""
-    id = re.sub(r'(\+|\/|=)', '', b64encode(sha256(unique_key.encode('utf-8')).digest()).decode('utf-8'))  # noqa: A001
-    return id[:REQUEST_ID_LENGTH] if len(id) > REQUEST_ID_LENGTH else id
+    id_ = re.sub(r'(\+|\/|=)', '', b64encode(sha256(unique_key.encode('utf-8')).digest()).decode('utf-8'))
+    return id_[:REQUEST_ID_LENGTH] if len(id_) > REQUEST_ID_LENGTH else id_
 
 
 async def force_rename(src_dir: str, dst_dir: str) -> None:

--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -414,21 +414,18 @@ PARSE_DATE_FIELDS_KEY_SUFFIX = 'At'
 ListOrDictOrAny = TypeVar('ListOrDictOrAny', list, dict, Any)
 
 
-def get_short_base64_hash(data: bytes) -> str:
-    """Generates an 8-character, base64-encoded SHA-256 hash of the provided data.
+def compute_short_hash(data: bytes, *, length: int = 8) -> str:
+    """Computes a hexadecimal SHA-256 hash of the provided data and returns a substring of it.
 
     Args:
         data: The binary data to be hashed.
+        length: The length of the hash to be returned.
 
     Returns:
-        An 8-character, base64-encoded hash.
+        An 8-character hexadecimal hash.
     """
-    # Create a SHA-256 hash of the payload.
     hash_object = sha256(data)
-    # Convert the hash to a base64-encoded string.
-    base64_encoded_hash = b64encode(hash_object.digest()).decode()
-    # Remove any '+' or '/' or '=' characters and return the first 8 characters.
-    return base64_encoded_hash.replace('+', '').replace('/', '').replace('=', '')[:8]
+    return hash_object.hexdigest()[:length]
 
 
 def normalize_url(url: str, *, keep_url_fragment: bool = False) -> str:
@@ -512,7 +509,7 @@ def compute_unique_key(
 
     # Compute and return the extended unique key if required.
     if use_extended_unique_key:
-        payload_hash = get_short_base64_hash(payload) if payload else ''
+        payload_hash = compute_short_hash(payload) if payload else ''
         return f'{normalized_method}({payload_hash}):{normalized_url}'
 
     # Log information if there is a non-GET request with a payload.

--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import builtins
 import contextlib
 import functools
-import hashlib
 import inspect
 import json
 import mimetypes
@@ -13,10 +11,13 @@ import os
 import re
 import sys
 import time
+from base64 import b64encode
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from datetime import datetime, timezone
+from hashlib import sha256
 from importlib import metadata
+from logging import getLogger
 from typing import (
     Any,
     Callable,
@@ -30,6 +31,7 @@ from typing import (
     overload,
 )
 from typing import OrderedDict as OrderedDictType
+from urllib.parse import parse_qsl, urlencode, urlparse
 
 import aioshutil
 import psutil
@@ -59,6 +61,7 @@ from apify_shared.utils import (
 from apify.consts import REQUEST_ID_LENGTH, StorageTypes
 
 T = TypeVar('T')
+logger = getLogger(__name__)
 
 
 def get_system_info() -> dict:
@@ -292,8 +295,7 @@ def maybe_parse_body(body: bytes, content_type: str) -> Any:
 
 def unique_key_to_request_id(unique_key: str) -> str:
     """Generate request ID based on unique key in a deterministic way."""
-    id = re.sub(r'(\+|\/|=)', '', base64.b64encode(hashlib.sha256(unique_key.encode('utf-8')).digest()).decode('utf-8'))  # noqa: A001
-
+    id = re.sub(r'(\+|\/|=)', '', b64encode(sha256(unique_key.encode('utf-8')).digest()).decode('utf-8'))  # noqa: A001
     return id[:REQUEST_ID_LENGTH] if len(id) > REQUEST_ID_LENGTH else id
 
 
@@ -410,3 +412,118 @@ def budget_ow(
 PARSE_DATE_FIELDS_MAX_DEPTH = 3
 PARSE_DATE_FIELDS_KEY_SUFFIX = 'At'
 ListOrDictOrAny = TypeVar('ListOrDictOrAny', list, dict, Any)
+
+
+def get_short_base64_hash(data: bytes) -> str:
+    """Generates an 8-character, base64-encoded SHA-256 hash of the provided data.
+
+    Args:
+        data: The binary data to be hashed.
+
+    Returns:
+        An 8-character, base64-encoded hash.
+    """
+    # Create a SHA-256 hash of the payload.
+    hash_object = sha256(data)
+    # Convert the hash to a base64-encoded string.
+    base64_encoded_hash = b64encode(hash_object.digest()).decode()
+    # Remove any '+' or '/' or '=' characters and return the first 8 characters.
+    return base64_encoded_hash.replace('+', '').replace('/', '').replace('=', '')[:8]
+
+
+def normalize_url(url: str, *, keep_url_fragment: bool = False) -> str:
+    """Normalizes a URL.
+
+    This function cleans and standardizes a URL by removing leading and trailing whitespaces,
+    converting the scheme and netloc to lower case, stripping unwanted tracking parameters
+    (specifically those beginning with 'utm_'), sorting the remaining query parameters alphabetically,
+    and optionally retaining the URL fragment. The goal is to ensure that URLs that are functionally
+    identical but differ in trivial ways (such as parameter order or casing) are treated as the same.
+
+    Args:
+        url: The URL to be normalized.
+        keep_url_fragment: Flag to determine whether the fragment part of the URL should be retained.
+
+    Returns:
+        A string containing the normalized URL. If normalization fails, the original URL is returned. It logs
+            a warning message in this case.
+    """
+    try:
+        # Parse the URL
+        parsed_url = urlparse(url.strip())
+        search_params = dict(parse_qsl(parsed_url.query))  # Convert query to a dict
+
+        # Remove any 'utm_' parameters
+        search_params = {k: v for k, v in search_params.items() if not k.startswith('utm_')}
+
+        # Construct the new query string
+        sorted_keys = sorted(search_params.keys())
+        sorted_query = urlencode([(k, search_params[k]) for k in sorted_keys])
+
+        # Construct the final URL
+        new_url = (
+            parsed_url._replace(
+                query=sorted_query,
+                scheme=parsed_url.scheme,
+                netloc=parsed_url.netloc,
+                path=parsed_url.path.rstrip('/'),
+            )
+            .geturl()
+            .lower()
+        )
+
+        # Retain the URL fragment if required
+        if not keep_url_fragment:
+            new_url = new_url.split('#')[0]
+
+    except Exception as exc:
+        logger.warning(f'Failed to normalize URL: {exc}')
+        return url
+
+    else:
+        return new_url
+
+
+def compute_unique_key(
+    url: str,
+    method: str = 'GET',
+    payload: bytes | None = None,
+    *,
+    keep_url_fragment: bool = False,
+    use_extended_unique_key: bool = False,
+) -> str:
+    """Computes a unique key for caching & deduplication of requests.
+
+    This function computes a unique key by normalizing the provided URL and method.
+    If 'use_extended_unique_key' is True and a payload is provided, the payload is hashed and
+    included in the key. Otherwise, the unique key is just the normalized URL.
+
+    Args:
+        url: The request URL.
+        method: The HTTP method, defaults to 'GET'.
+        payload: The request payload, defaults to None.
+        keep_url_fragment: A flag indicating whether to keep the URL fragment, defaults to False.
+        use_extended_unique_key: A flag indicating whether to include a hashed payload in the key, defaults to False.
+
+    Returns:
+        A string representing the unique key for the request.
+    """
+    # Normalize the URL and method.
+    normalized_url = normalize_url(url, keep_url_fragment=keep_url_fragment)
+    normalized_method = method.upper()
+
+    # Compute and return the extended unique key if required.
+    if use_extended_unique_key:
+        payload_hash = get_short_base64_hash(payload) if payload else ''
+        return f'{normalized_method}({payload_hash}):{normalized_url}'
+
+    # Log information if there is a non-GET request with a payload.
+    if normalized_method != 'GET' and payload:
+        logger.info(
+            f'We have encountered a {normalized_method} Request with a payload. This is fine. Just letting you know '
+            'that if your requests point to the same URL and differ only in method and payload, you should consider '
+            'using the "use_extended_unique_key" option.'
+        )
+
+    # Return the normalized URL as the unique key.
+    return normalized_url

--- a/src/apify/scrapy/requests.py
+++ b/src/apify/scrapy/requests.py
@@ -46,6 +46,7 @@ def to_apify_request(scrapy_request: Request, spider: Spider) -> dict | None:
         apify_request = {
             'url': scrapy_request.url,
             'method': scrapy_request.method,
+            'payload': scrapy_request.body,
             'userData': scrapy_request.meta.get('userData', {}),
         }
 
@@ -55,9 +56,14 @@ def to_apify_request(scrapy_request: Request, spider: Spider) -> dict | None:
         else:
             Actor.log.warning(f'Invalid scrapy_request.headers type, not scrapy.http.headers.Headers: {scrapy_request.headers}')
 
-        # If the request was produced by the middleware (e.g. retry or redirect), we need to compute the unique key here
+        # If the request was produced by the middleware (e.g. retry or redirect), we must compute the unique key here
         if _is_request_produced_by_middleware(scrapy_request):
-            apify_request['uniqueKey'] = compute_unique_key(scrapy_request.url, scrapy_request.method)
+            apify_request['uniqueKey'] = compute_unique_key(
+                url=scrapy_request.url,
+                method=scrapy_request.method,
+                payload=scrapy_request.body,
+                use_extended_unique_key=True,
+            )
         # Othwerwise, we can use the unique key (also the id) from the meta
         else:
             if scrapy_request.meta.get('apify_request_id'):

--- a/src/apify/scrapy/requests.py
+++ b/src/apify/scrapy/requests.py
@@ -13,6 +13,7 @@ except ImportError as exc:
     ) from exc
 
 from apify._crypto import crypto_random_object_id
+from apify._utils import compute_unique_key
 from apify.actor import Actor
 
 
@@ -48,21 +49,27 @@ def to_apify_request(scrapy_request: Request, spider: Spider) -> dict | None:
             'userData': scrapy_request.meta.get('userData', {}),
         }
 
+        # Convert Scrapy's headers to a dictionary and store them in the apify_request
         if isinstance(scrapy_request.headers, Headers):
             apify_request['headers'] = dict(scrapy_request.headers.to_unicode_dict())
         else:
             Actor.log.warning(f'Invalid scrapy_request.headers type, not scrapy.http.headers.Headers: {scrapy_request.headers}')
 
+        # If the request was produced by the middleware (e.g. retry or redirect), we need to compute the unique key here
         if _is_request_produced_by_middleware(scrapy_request):
-            apify_request['uniqueKey'] = scrapy_request.url
+            apify_request['uniqueKey'] = compute_unique_key(scrapy_request.url, scrapy_request.method)
+        # Othwerwise, we can use the unique key (also the id) from the meta
         else:
-            # Add 'id' to the apify_request
             if scrapy_request.meta.get('apify_request_id'):
                 apify_request['id'] = scrapy_request.meta['apify_request_id']
 
-            # Add 'uniqueKey' to the apify_request
             if scrapy_request.meta.get('apify_request_unique_key'):
                 apify_request['uniqueKey'] = scrapy_request.meta['apify_request_unique_key']
+
+        # If the request's dont_filter field is set, we must generate a random `uniqueKey` to avoid deduplication
+        # of the request in the Request Queue.
+        if scrapy_request.dont_filter:
+            apify_request['uniqueKey'] = crypto_random_object_id(8)
 
         # Serialize the Scrapy Request and store it in the apify_request.
         #   - This process involves converting the Scrapy Request object into a dictionary, encoding it to base64,

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -95,7 +95,12 @@ class ApifyScheduler(BaseScheduler):
             raise TypeError('self._rq must be an instance of the RequestQueue class')
 
         try:
-            result = nested_event_loop.run_until_complete(self._rq.add_request(apify_request))
+            result = nested_event_loop.run_until_complete(
+                self._rq.add_request(
+                    apify_request,
+                    use_extended_unique_key=True,
+                )
+            )
         except BaseException:
             traceback.print_exc()
             raise

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,13 +14,13 @@ from apify_shared.consts import ActorEnvVars, ApifyEnvVars
 
 from apify._utils import (
     budget_ow,
+    compute_short_hash,
     compute_unique_key,
     fetch_and_parse_env_var,
     force_remove,
     force_rename,
     get_cpu_usage_percent,
     get_memory_usage_bytes,
-    get_short_base64_hash,
     guess_file_extension,
     maybe_parse_bool,
     maybe_parse_datetime,
@@ -273,25 +273,25 @@ def test__budget_ow() -> None:
 
 def test_get_short_base64_hash_with_known_input() -> None:
     data = b'Hello world!'
-    expected_hash = 'wFNeSK3n'
-    assert get_short_base64_hash(data) == expected_hash, 'The hash does not match the expected output'
+    expected_hash = 'c0535e4b'
+    assert compute_short_hash(data) == expected_hash, 'The hash does not match the expected output'
 
 
 def test_get_short_base64_hash_with_empty_input() -> None:
     data = b''
-    expected_hash = '47DEQpj8'
-    assert get_short_base64_hash(data) == expected_hash, 'The hash for an empty input should follow the expected pattern'
+    expected_hash = 'e3b0c442'
+    assert compute_short_hash(data) == expected_hash, 'The hash for an empty input should follow the expected pattern'
 
 
 def test_get_short_base64_hash_output_length() -> None:
     data = b'some random data'
-    assert len(get_short_base64_hash(data)) == 8, 'The output hash should be 8 characters long'
+    assert len(compute_short_hash(data)) == 8, 'The output hash should be 8 characters long'
 
 
 def test_get_short_base64_hash_differentiates_input() -> None:
     data1 = b'input 1'
     data2 = b'input 2'
-    assert get_short_base64_hash(data1) != get_short_base64_hash(data2), 'Different inputs should produce different hashes'
+    assert compute_short_hash(data1) != compute_short_hash(data2), 'Different inputs should produce different hashes'
 
 
 @pytest.mark.parametrize(
@@ -328,11 +328,11 @@ def test_normalize_url(url: str, expected_output: str, *, keep_url_fragment: boo
         ('http://example.com', 'GET', None, False, False, 'http://example.com'),
         ('http://example.com', 'POST', None, False, False, 'http://example.com'),
         ('http://example.com', 'GET', b'data', False, False, 'http://example.com'),
-        ('http://example.com', 'GET', b'data', False, True, 'GET(Om6weQ85):http://example.com'),
-        ('http://example.com', 'POST', b'data', False, True, 'POST(Om6weQ85):http://example.com'),
+        ('http://example.com', 'GET', b'data', False, True, 'GET(3a6eb079):http://example.com'),
+        ('http://example.com', 'POST', b'data', False, True, 'POST(3a6eb079):http://example.com'),
         ('http://example.com#fragment', 'GET', None, True, False, 'http://example.com#fragment'),
         ('http://example.com#fragment', 'GET', None, False, False, 'http://example.com'),
-        ('http://example.com', 'DELETE', b'test', False, True, 'DELETE(n4bQgYhM):http://example.com'),
+        ('http://example.com', 'DELETE', b'test', False, True, 'DELETE(9f86d081):http://example.com'),
         ('https://example.com?utm_content=test', 'GET', None, False, False, 'https://example.com'),
         ('https://example.com?utm_content=test', 'GET', None, True, False, 'https://example.com'),
     ],

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,15 +14,18 @@ from apify_shared.consts import ActorEnvVars, ApifyEnvVars
 
 from apify._utils import (
     budget_ow,
+    compute_unique_key,
     fetch_and_parse_env_var,
     force_remove,
     force_rename,
     get_cpu_usage_percent,
     get_memory_usage_bytes,
+    get_short_base64_hash,
     guess_file_extension,
     maybe_parse_bool,
     maybe_parse_datetime,
     maybe_parse_int,
+    normalize_url,
     raise_on_duplicate_storage,
     raise_on_non_existing_storage,
     run_func_at_interval_async,
@@ -266,3 +269,100 @@ def test__budget_ow() -> None:
             'ordered_dict': (dict, False),
         },
     )
+
+
+def test_get_short_base64_hash_with_known_input() -> None:
+    data = b'Hello world!'
+    expected_hash = 'wFNeSK3n'
+    assert get_short_base64_hash(data) == expected_hash, 'The hash does not match the expected output'
+
+
+def test_get_short_base64_hash_with_empty_input() -> None:
+    data = b''
+    expected_hash = '47DEQpj8'
+    assert get_short_base64_hash(data) == expected_hash, 'The hash for an empty input should follow the expected pattern'
+
+
+def test_get_short_base64_hash_output_length() -> None:
+    data = b'some random data'
+    assert len(get_short_base64_hash(data)) == 8, 'The output hash should be 8 characters long'
+
+
+def test_get_short_base64_hash_differentiates_input() -> None:
+    data1 = b'input 1'
+    data2 = b'input 2'
+    assert get_short_base64_hash(data1) != get_short_base64_hash(data2), 'Different inputs should produce different hashes'
+
+
+@pytest.mark.parametrize(
+    ('url', 'expected_output', 'keep_url_fragment'),
+    [
+        ('https://example.com/?utm_source=test&utm_medium=test&key=value', 'https://example.com?key=value', False),
+        ('http://example.com/?key=value&another_key=another_value', 'http://example.com?another_key=another_value&key=value', False),
+        ('HTTPS://EXAMPLE.COM/?KEY=VALUE', 'https://example.com?key=value', False),
+        ('', '', False),
+        ('http://example.com/#fragment', 'http://example.com#fragment', True),
+        ('http://example.com/#fragment', 'http://example.com', False),
+        ('  https://example.com/  ', 'https://example.com', False),
+        ('http://example.com/?b=2&a=1', 'http://example.com?a=1&b=2', False),
+    ],
+    ids=[
+        'remove_utm_params',
+        'retain_sort_non_utm_params',
+        'convert_scheme_netloc_to_lowercase',
+        'handle_empty_url',
+        'retain_fragment',
+        'remove_fragment',
+        'trim_whitespace',
+        'sort_query_params',
+    ],
+)
+def test_normalize_url(url: str, expected_output: str, *, keep_url_fragment: bool) -> None:
+    output = normalize_url(url, keep_url_fragment=keep_url_fragment)
+    assert output == expected_output
+
+
+@pytest.mark.parametrize(
+    ('url', 'method', 'payload', 'keep_url_fragment', 'use_extended_unique_key', 'expected_output'),
+    [
+        ('http://example.com', 'GET', None, False, False, 'http://example.com'),
+        ('http://example.com', 'POST', None, False, False, 'http://example.com'),
+        ('http://example.com', 'GET', b'data', False, False, 'http://example.com'),
+        ('http://example.com', 'GET', b'data', False, True, 'GET(Om6weQ85):http://example.com'),
+        ('http://example.com', 'POST', b'data', False, True, 'POST(Om6weQ85):http://example.com'),
+        ('http://example.com#fragment', 'GET', None, True, False, 'http://example.com#fragment'),
+        ('http://example.com#fragment', 'GET', None, False, False, 'http://example.com'),
+        ('http://example.com', 'DELETE', b'test', False, True, 'DELETE(n4bQgYhM):http://example.com'),
+        ('https://example.com?utm_content=test', 'GET', None, False, False, 'https://example.com'),
+        ('https://example.com?utm_content=test', 'GET', None, True, False, 'https://example.com'),
+    ],
+    ids=[
+        'simple_get',
+        'simple_post',
+        'get_with_payload',
+        'get_with_payload_extended',
+        'post_with_payload_extended',
+        'get_with_fragment',
+        'get_remove_fragment',
+        'delete_with_payload_extended',
+        'get_remove_utm',
+        'get_keep_utm_fragment',
+    ],
+)
+def test_compute_unique_key(
+    url: str,
+    method: str,
+    payload: bytes | None,
+    *,
+    keep_url_fragment: bool,
+    use_extended_unique_key: bool,
+    expected_output: str,
+) -> None:
+    output = compute_unique_key(
+        url,
+        method,
+        payload,
+        keep_url_fragment=keep_url_fragment,
+        use_extended_unique_key=use_extended_unique_key,
+    )
+    assert output == expected_output


### PR DESCRIPTION
## Description

### Request Queue

- Updates `RequestQueue.add_request` method by improving its unique key generation logic.
  - The logic is exposed via new optional parameters of `add_request`.
- I also extended the docstring to make clear what it does (mainly regarding the deduplication).
- The PR introduces 3 new "helper" functions in the `apify/_utils.py`:
    - `get_short_base64_hash` based on the [_hashPayload](https://github.com/apify/crawlee/blob/v3.8.1/packages/core/src/request.ts#L397:L405).
    - `normalize_url` based on the [normalizeUrl](https://github.com/apify/apify-shared-js/blob/%40apify/input_schema%403.5.15/packages/utilities/src/utilities.client.ts#L128:L158).
    - `compute_unique_key` based on the [_computeUniqueKey](https://github.com/apify/crawlee/blob/v3.8.1/packages/core/src/request.ts#L381-L395).

### Scrapy integration

- Use this new Request Queue functionality in the Scrapy integration.
- Also add support for `scrapy.Request.dont_filter` field in the `to_apify_request`.

## Issues

- Closing both of these issues:
  - https://github.com/apify/apify-sdk-python/issues/141
    - Technical debt in Request Queue. 
  - https://github.com/apify/apify-sdk-python/issues/190
    - Bug in the Scrapy integration.

## Testing

### Unit tests

- The new code is covered by unit tests.

### Manual testing / execution

The `YieldPostSpider` tests the case of the POST requests to the same URL. 
  - It's copied from [#issuecomment-1978609687](https://github.com/apify/apify-sdk-python/issues/190#issuecomment-1978609687) - thank you @honzajavorek!

```python
# spiders/yield_post.py
import json
import json
from typing import Generator, cast

from scrapy import Request, Spider as BaseSpider
from scrapy.http import TextResponse


class YieldPostSpider(BaseSpider):
    name = 'yield-post'

    def start_requests(self) -> Generator[Request, None, None]:
        for number in range(3):
            yield Request(
                'https://httpbin.org/post',
                method='POST',
                body=json.dumps(dict(code=f'CODE{number:0>4}', rate=number)),
                headers={'Content-Type': 'application/json'},
            )

    def parse(self, response: TextResponse) -> Generator[dict, None, None]:
        data = json.loads(cast(dict, response.json())['data'])
        yield data
```

The `DontFilterSpider` tests the case of the Scrapy request with `dont_filter` option. 
  - It's copied from [issuecomment-1978953372](https://github.com/apify/apify-sdk-python/issues/190#issuecomment-1978953372) - thank you @honzajavorek!

```python
from typing import Generator

from scrapy import Request, Spider as BaseSpider
from scrapy.http import TextResponse


class DontFilterSpider(BaseSpider):
    name = 'dont-filter'

    def start_requests(self) -> Generator[Request, None, None]:
        for _ in range(3):
            yield Request('https://httpbin.org/get', method='GET', dont_filter=True)

    def parse(self, response: TextResponse) -> Generator[dict, None, None]:
        yield {'something': True}
```

And `src/main.py` to execute these spiders with Apify:
```python
from __future__ import annotations

from scrapy.crawler import CrawlerProcess

from apify import Actor
from apify.scrapy.utils import apply_apify_settings

from .spiders.yield_post import YieldPostSpider as Spider
# from .spiders.dont_filter import DontFilterSpider as Spider


async def main() -> None:
    """Apify Actor main coroutine for executing the Scrapy spider."""
    async with Actor:
        Actor.log.info('Actor is being executed...')

        # Apply Apify settings, it will override the Scrapy project settings
        settings = apply_apify_settings()

        # Execute the spider using Scrapy CrawlerProcess
        process = CrawlerProcess(settings, install_root_handler=False)
        process.crawl(Spider)
        process.start()
```

Execute it using Scrapy:
```
scrapy crawl 'dont-filter' -o dont_filter_output.json
```

```
scrapy crawl 'yield-post' -o yield_post_output.json
```

And using Apify (need to change the Spider in the `main.py` manually):

```
apify run --purge
```

And it produces the same output :tada:.