### PR TITLE
fix: Set a timeout for Actor cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [1.7.1](../../releases/tag/v1.7.1) - Unreleased
 
-...
+### Fixed
+
+- Set a timeout for Actor cleanup
 
 ## [1.7.0](../../releases/tag/v1.7.0) - 2024-03-12
 


### PR DESCRIPTION
- closes #200

I could not find the actual reason why the linked run got stuck, but this should make the Actor cleanup more robust as a whole.