### PR TITLE
ci: Stop testing python 3.8

### DIFF
--- a/.github/workflows/check_version_availability.yaml
+++ b/.github/workflows/check_version_availability.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install dependencies
         run: make install-dev

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install Python dependencies
         run: make install-dev

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Run integration tests only on the oldest and newest supported Python versions,
         # as these tests are time-consuming and these versions are the most likely to encounter issues.
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
       max-parallel: 1 # no concurrency on this level, to not overshoot the test user limits
 
     steps:

--- a/.github/workflows/lint_and_type_checks.yaml
+++ b/.github/workflows/lint_and_type_checks.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       # We need to check out the head commit in case of PRs,

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
This is so that CI can pass for #210... eventually. Crawlee does not support 3.8.