### PR TITLE
fix: possible infinity loop in Apify-Scrapy proxy middleware

### DIFF
--- a/src/apify/scrapy/middlewares/apify_proxy.py
+++ b/src/apify/scrapy/middlewares/apify_proxy.py
@@ -93,7 +93,7 @@ class ApifyHttpProxyMiddleware:
         request: Request,
         exception: Exception,
         spider: Spider,
-    ) -> None | Request:
+    ) -> None:
         """Process an exception that occurs during request processing.
 
         Args:
@@ -102,8 +102,9 @@ class ApifyHttpProxyMiddleware:
             spider: Scrapy Spider object.
 
         Returns:
-            If a TunnelError occurs, return the request object to halt its processing in the middleware pipeline.
-            Return None otherwise to allow the continuation of request processing.
+            Returning None, meaning Scrapy will continue processing this exception, executing any other
+            process_exception() methods of installed middleware, until no middleware is left and the default
+            exception handling kicks in.
         """
         Actor.log.debug(
             f'ApifyHttpProxyMiddleware.process_exception: request={request}, exception={exception}, spider={spider}',
@@ -114,9 +115,6 @@ class ApifyHttpProxyMiddleware:
                 f'ApifyHttpProxyMiddleware: TunnelError occurred for request="{request}", '
                 'reason="{exception}", skipping...'
             )
-            return request
-
-        return None
 
     async def _get_new_proxy_url(self: ApifyHttpProxyMiddleware) -> ParseResult:
         """Get a new proxy URL.

--- a/tests/unit/scrapy/middlewares/test_apify_proxy.py
+++ b/tests/unit/scrapy/middlewares/test_apify_proxy.py
@@ -129,24 +129,14 @@ async def test__process_request(
 
 
 @pytest.mark.parametrize(
-    ('exception', 'none_returned_values_is_expected'),
-    [
-        (TunnelError(), False),
-        (ValueError(), True),
-    ],
+    'exception',
+    [TunnelError(), ValueError()],
 )
 def test__process_exception(
     middleware: ApifyHttpProxyMiddleware,
     spider: DummySpider,
     dummy_request: Request,
     exception: Exception,
-    *,
-    none_returned_values_is_expected: bool,
 ) -> None:
-    returned_value = middleware.process_exception(dummy_request, exception, spider)
-
-    if none_returned_values_is_expected:
-        assert returned_value is None
-
-    else:
-        assert returned_value == dummy_request
+    returned_value = middleware.process_exception(dummy_request, exception, spider)  # type: ignore
+    assert returned_value is None


### PR DESCRIPTION
From the template log... it scrapes normally as it should...
```
...
2024-09-02T21:34:06.9322150Z [title_spider] [INFO] TitleSpider is parsing <200 https://apify.com/run-scrapy-in-cloud>... ({"spider": "<TitleSpider 'title_spider' at 0x7f70c7ab07f0>"})
2024-09-02T21:34:06.9455173Z [title_spider] [INFO] TitleSpider is parsing <200 https://docs.apify.com/academy/web-scraping-for-beginners>... ({"spider": "<TitleSpider 'title_spider' at 0x7f70c7ab07f0>"})
2024-09-02T21:34:06.9530763Z [title_spider] [INFO] TitleSpider is parsing <200 https://apify.com/success-stories>... ({"spider": "<TitleSpider 'title_spider' at 0x7f70c7ab07f0>"})
2024-09-02T21:34:07.0125374Z [title_spider] [INFO] TitleSpider is parsing <200 https://apify.com/templates/ts-crawlee-playwright-chrome>... ({"spider": "<TitleSpider 'title_spider' at 0x7f70c7ab07f0>"})
...
```


But when processing `https://console.apify.com/robots.txt`, it throws an exception in the proxy middleware, which is caught and logged:
```
2024-09-02T21:34:07.0410494Z [apify] [WARN] ApifyHttpProxyMiddleware: TunnelError occurred for request="<GET https://console.apify.com/robots.txt>", reason="Could not open CONNECT tunnel with proxy proxy.apify.com:8000 [{'status': 403, 'reason': b'Forbidden'}]", skipping...
```

but then it incorrectly returns the request object [here](https://github.com/apify/apify-sdk-python/blob/master/src/apify/scrapy/middlewares/apify_proxy.py#L112:L117):

```python
if isinstance(exception, TunnelError):  
    Actor.log.warning(  
        f'ApifyHttpProxyMiddleware: TunnelError occurred for request="{request}", '  
        'reason="{exception}", skipping...'  
    )  
    return request  
```

Which causes it to be rescheduled, and we're stuck in a loop.

Also check the https://github.com/apify/actor-templates/pull/288 - where the tests are executed with alpha release from this branch.