### PR TITLE
docs: fix `/reference` docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ check-changelog-entry:
 	poetry run python scripts/check_version_in_changelog.py
 
 build-api-reference:
-	cd website && ./build_api_reference.sh
+	cd website && poetry run ./build_api_reference.sh
 
 run-doc: build-api-reference
 	cd website && npm clean-install && npm run start

--- a/website/build_api_reference.sh
+++ b/website/build_api_reference.sh
@@ -11,7 +11,7 @@ sed_no_backup() {
 }
 
 # Create docspec dump of this package's source code through pydoc-markdown
-poetry run pydoc-markdown --quiet --dump > docspec-dump.jsonl
+pydoc-markdown --quiet --dump > docspec-dump.jsonl
 sed_no_backup "s#${PWD}/..#REPO_ROOT_PLACEHOLDER#g" docspec-dump.jsonl
 
 # Create docpec dump from the right version of the apify-shared package
@@ -24,7 +24,7 @@ sed_no_backup "s#search_path: \[../src\]#search_path: \[./src\]#g" "${apify_shar
 (
     cd "${apify_shared_tempdir}";
     git checkout --quiet "v${apify_shared_version}";
-    poetry run pydoc-markdown --quiet --dump > ./apify-shared-docspec-dump.jsonl
+    pydoc-markdown --quiet --dump > ./apify-shared-docspec-dump.jsonl
 )
 
 cp "${apify_shared_tempdir}/apify-shared-docspec-dump.jsonl" .

--- a/website/build_api_reference.sh
+++ b/website/build_api_reference.sh
@@ -11,7 +11,7 @@ sed_no_backup() {
 }
 
 # Create docspec dump of this package's source code through pydoc-markdown
-pydoc-markdown --quiet --dump > docspec-dump.jsonl
+poetry run pydoc-markdown --quiet --dump > docspec-dump.jsonl
 sed_no_backup "s#${PWD}/..#REPO_ROOT_PLACEHOLDER#g" docspec-dump.jsonl
 
 # Create docpec dump from the right version of the apify-shared package
@@ -24,7 +24,7 @@ sed_no_backup "s#search_path: \[../src\]#search_path: \[./src\]#g" "${apify_shar
 (
     cd "${apify_shared_tempdir}";
     git checkout --quiet "v${apify_shared_version}";
-    pydoc-markdown --quiet --dump > ./apify-shared-docspec-dump.jsonl
+    poetry run pydoc-markdown --quiet --dump > ./apify-shared-docspec-dump.jsonl
 )
 
 cp "${apify_shared_tempdir}/apify-shared-docspec-dump.jsonl" .


### PR DESCRIPTION
Ever since #247, the reference docs build started failing (rendering only a blank page). This is probably caused by the new `poetry` migration (and lack of `poetry run` in the right places).

![obrazek](https://github.com/user-attachments/assets/24133d6f-930a-41a3-97a2-a6548e84f57d)
