### PR TITLE
docs: hotfix API reference docs

### DIFF
--- a/src/apify/_crypto.py
+++ b/src/apify/_crypto.py
@@ -114,6 +114,7 @@ def private_decrypt(
     return decipher_bytes.decode('utf-8')
 
 
+@ignore_docs
 def load_private_key(private_key_file_base64: str, private_key_password: str) -> rsa.RSAPrivateKey:
     private_key = serialization.load_pem_private_key(
         base64.b64decode(private_key_file_base64.encode('utf-8')),
@@ -133,6 +134,7 @@ def _load_public_key(public_key_file_base64: str) -> rsa.RSAPublicKey:
     return public_key
 
 
+@ignore_docs
 def decrypt_input_secrets(private_key: rsa.RSAPrivateKey, input_data: Any) -> Any:
     """Decrypt input secrets."""
     if not isinstance(input_data, dict):

--- a/src/apify/_platform_event_manager.py
+++ b/src/apify/_platform_event_manager.py
@@ -126,7 +126,6 @@ event_data_adapter: TypeAdapter[EventMessage | DeprecatedEvent | UnknownEvent] =
 )
 
 
-@ignore_docs
 class PlatformEventManager(EventManager):
     """A class for managing Actor events.
 

--- a/src/apify/_platform_event_manager.py
+++ b/src/apify/_platform_event_manager.py
@@ -8,7 +8,6 @@ import websockets.client
 from pydantic import BaseModel, Discriminator, Field, TypeAdapter
 from typing_extensions import Self, Unpack, override
 
-from apify_shared.utils import ignore_docs
 from crawlee.events._event_manager import EventManager, EventManagerOptions
 from crawlee.events._local_event_manager import LocalEventManager
 from crawlee.events._types import (

--- a/src/apify/_proxy_configuration.py
+++ b/src/apify/_proxy_configuration.py
@@ -27,6 +27,7 @@ COUNTRY_CODE_REGEX = re.compile(r'^[A-Z]{2}$')
 SESSION_ID_MAX_LENGTH = 50
 
 
+@ignore_docs
 def is_url(url: str) -> bool:
     """Check if the given string is a valid URL."""
     try:

--- a/src/apify/log.py
+++ b/src/apify/log.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from apify_shared.utils import ignore_docs
 from crawlee._log_config import CrawleeLogFormatter, configure_logger, get_configured_log_level
 
 if TYPE_CHECKING:

--- a/src/apify/log.py
+++ b/src/apify/log.py
@@ -15,6 +15,7 @@ logger_name = __name__.split('.')[0]
 logger = logging.getLogger(logger_name)
 
 
+@ignore_docs
 class ActorLogFormatter(CrawleeLogFormatter):  # noqa: D101 Inherited from parent class
     pass
 

--- a/src/apify/scrapy/requests.py
+++ b/src/apify/scrapy/requests.py
@@ -28,6 +28,7 @@ def _is_request_produced_by_middleware(scrapy_request: Request) -> bool:
     return bool(scrapy_request.meta.get('redirect_times')) or bool(scrapy_request.meta.get('retry_times'))
 
 
+@ignore_docs
 def to_apify_request(scrapy_request: Request, spider: Spider) -> CrawleeRequest | None:
     """Convert a Scrapy request to an Apify request.
 
@@ -98,6 +99,7 @@ def to_apify_request(scrapy_request: Request, spider: Spider) -> CrawleeRequest 
     return apify_request
 
 
+@ignore_docs
 def to_scrapy_request(apify_request: CrawleeRequest, spider: Spider) -> Request:
     """Convert an Apify request to a Scrapy request.
 

--- a/src/apify/scrapy/requests.py
+++ b/src/apify/scrapy/requests.py
@@ -4,6 +4,8 @@ import codecs
 import pickle
 from typing import Any, cast
 
+from apify_shared.utils import ignore_docs
+
 try:
     from scrapy import Request, Spider
     from scrapy.http.headers import Headers

--- a/src/apify/scrapy/utils.py
+++ b/src/apify/scrapy/utils.py
@@ -4,6 +4,8 @@ import asyncio
 from base64 import b64encode
 from urllib.parse import unquote
 
+from apify_shared.utils import ignore_docs
+
 try:
     from scrapy.settings import Settings  # noqa: TCH002
     from scrapy.utils.project import get_project_settings

--- a/src/apify/scrapy/utils.py
+++ b/src/apify/scrapy/utils.py
@@ -18,6 +18,7 @@ except ImportError as exc:
 nested_event_loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
 
 
+@ignore_docs
 def get_basic_auth_header(username: str, password: str, auth_encoding: str = 'latin-1') -> bytes:
     """Generate a basic authentication header for the given username and password."""
     string = f'{unquote(username)}:{unquote(password)}'
@@ -25,6 +26,7 @@ def get_basic_auth_header(username: str, password: str, auth_encoding: str = 'la
     return b'Basic ' + b64encode(user_pass)
 
 
+@ignore_docs
 def get_running_event_loop_id() -> int:
     """Get the ID of the currently running event loop.
 

--- a/website/pydoc-markdown.yml
+++ b/website/pydoc-markdown.yml
@@ -4,6 +4,7 @@ loaders:
 processors:
   - type: filter
     skip_empty_modules: true
+    documented_only: false
   - type: crossref
 renderer:
   type: docusaurus


### PR DESCRIPTION
Slightly bends the `transformDocs.js` script to accommodate the new structure of the project better. 


https://github.com/user-attachments/assets/3cbd0835-165c-4fae-95b0-c1d45bed8061


At the offsite, we talked about the need for a better solution than this. With three publically documented Python projects, the current solution is becoming insufficient. 

The next Python docs steps are documented in https://github.com/apify/crawlee-python/issues/324

Closes #270 