### PR TITLE
chore: bump `@apify/docusaurus-plugin-typedoc-api`

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -86,6 +86,7 @@ module.exports = {
                 pathToCurrentVersionTypedocJSON: `${__dirname}/api-typedoc-generated.json`,
                 sortSidebar: groupSort,
                 routeBasePath: 'reference',
+                python: true,
             },
         ],
         ...config.plugins,

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7,7 +7,7 @@
             "name": "apify-sdk-python",
             "dependencies": {
                 "@apify/docs-theme": "^1.0.132",
-                "@apify/docusaurus-plugin-typedoc-api": "^4.2.5",
+                "@apify/docusaurus-plugin-typedoc-api": "^4.2.6",
                 "@docusaurus/core": "^3.5.2",
                 "@docusaurus/plugin-client-redirects": "^3.5.2",
                 "@docusaurus/preset-classic": "^3.5.2",
@@ -323,14 +323,15 @@
             }
         },
         "node_modules/@apify/docusaurus-plugin-typedoc-api": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.2.5.tgz",
-            "integrity": "sha512-JfyTI+GQjsBeeB/iw5lj9JcZ76bsczcdlXlodjtRyIkjCRjm7d3a3UM+YgCZn5G7B0UMPcPuB4x07MXSlRGZ4w==",
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.2.6.tgz",
+            "integrity": "sha512-M/rpRqbHZjL49xXtvdxdh/M7jSSR5lb3mjKERzKKnX6i92B5BRetL7Eb4qHre9QPQVijgzILhlhTi8otvr0LAw==",
             "license": "MIT",
             "dependencies": {
                 "@docusaurus/plugin-content-docs": "^3.5.2",
                 "@docusaurus/types": "^3.5.2",
                 "@docusaurus/utils": "^3.5.2",
+                "@types/react": "^18.3.11",
                 "@vscode/codicons": "^0.0.35",
                 "marked": "^9.1.6",
                 "marked-smartypants": "^1.1.5",
@@ -5149,9 +5150,10 @@
             "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
         },
         "node_modules/@types/react": {
-            "version": "18.3.8",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.8.tgz",
-            "integrity": "sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q==",
+            "version": "18.3.11",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+            "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -21807,13 +21809,14 @@
             }
         },
         "@apify/docusaurus-plugin-typedoc-api": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.2.5.tgz",
-            "integrity": "sha512-JfyTI+GQjsBeeB/iw5lj9JcZ76bsczcdlXlodjtRyIkjCRjm7d3a3UM+YgCZn5G7B0UMPcPuB4x07MXSlRGZ4w==",
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.2.6.tgz",
+            "integrity": "sha512-M/rpRqbHZjL49xXtvdxdh/M7jSSR5lb3mjKERzKKnX6i92B5BRetL7Eb4qHre9QPQVijgzILhlhTi8otvr0LAw==",
             "requires": {
                 "@docusaurus/plugin-content-docs": "^3.5.2",
                 "@docusaurus/types": "^3.5.2",
                 "@docusaurus/utils": "^3.5.2",
+                "@types/react": "^18.3.11",
                 "@vscode/codicons": "^0.0.35",
                 "marked": "^9.1.6",
                 "marked-smartypants": "^1.1.5",
@@ -24823,9 +24826,9 @@
             "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
         },
         "@types/react": {
-            "version": "18.3.8",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.8.tgz",
-            "integrity": "sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q==",
+            "version": "18.3.11",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+            "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
             "requires": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@apify/docs-theme": "^1.0.132",
-        "@apify/docusaurus-plugin-typedoc-api": "^4.2.5",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.2.6",
         "@docusaurus/core": "^3.5.2",
         "@docusaurus/plugin-client-redirects": "^3.5.2",
         "@docusaurus/preset-classic": "^3.5.2",


### PR DESCRIPTION
Fixes type-wise links between documentation pages (see https://github.com/apify/apify-client-js/issues/591 for more context ). 