### PR TITLE
fix: Set version constraint of the `websockets` dependency to <14.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ httpx = ">=0.27.0"
 lazy-object-proxy = ">=1.10.0"
 scrapy = { version = ">=2.11.0", optional = true }
 typing-extensions = ">=4.1.0"
-websockets = ">=10.0"
+websockets = ">=10.0 <14.0.0"
 
 [tool.poetry.group.dev.dependencies]
 build = "~1.2.0"


### PR DESCRIPTION
New version 14 introduces some backward incompatible changes that are breaking existing code.