### PR TITLE
ci: Add workflow dispatch for pre-release workflow

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -8,6 +8,9 @@ on:
     tags-ignore:
       - "**" # Ignore all tags to prevent duplicate builds when tags are pushed.
 
+  # Or it can be triggered manually.
+  workflow_dispatch:
+
 jobs:
   release_metadata:
     if: "!startsWith(github.event.head_commit.message, 'docs') && !startsWith(github.event.head_commit.message, 'ci') && startsWith(github.repository, 'apify/')"
@@ -65,7 +68,7 @@ jobs:
     steps:
       - name: Prepare distribution
         uses: apify/workflows/prepare-pypi-distribution@main
-        with: 
+        with:
           package_name: apify
           is_prerelease: "yes"
           version_number: ${{ needs.release_metadata.outputs.version_number }}


### PR DESCRIPTION
To be able to solve issues like this - https://github.com/apify/apify-sdk-python/actions/runs/12671344582/job/35314370843, by manual re-run.