### PR TITLE
docs: fix links and some headings

### DIFF
--- a/docs/01_overview/01_introduction.mdx
+++ b/docs/01_overview/01_introduction.mdx
@@ -1,6 +1,6 @@
 ---
+id: introduction
 title: Introduction
-sidebar_label: Introduction
 ---
 
 import CodeBlock from '@theme/CodeBlock';
@@ -21,26 +21,26 @@ Actors can be executed locally or on the [Apify platform](https://docs.apify.com
 
 If you're new to Apify, refer to the Apify platform documentation to learn [what Apify is](https://docs.apify.com/platform/about).
 
-## Quick Start
+## Quick start
 
 This section provides a quick start guide for creating and running Actors.
 
 ### Creating Actors
 
-To create and run Actors using the Apify Console, see the [Console documentation](https://docs.apify.com/academy/getting-started/creating-actors#choose-your-template).
+To create and run Actors using the Apify Console, see the [Console documentation](https://docs.apify.com/platform/console).
 
-For creating and running Python Actors locally, refer to the documentation for [creating and running Python Actors locally](./running_locally).
+For creating and running Python Actors locally, refer to the documentation for [creating and running Python Actors locally](./running-actors-locally).
 
 ### Guides
 
 Integrate the Apify SDK with popular web scraping libraries by following these guides:
-- [Requests or HTTPX](../guides/requests_and_httpx)
-- [Beautiful Soup](../guides/beautiful_soup)
+- [BeautifulSoup with HTTPX](../guides/beautifulsoup-httpx)
+- [Crawlee](../guides/crawlee)
 - [Playwright](../guides/playwright)
 - [Selenium](../guides/selenium)
 - [Scrapy](../guides/scrapy)
 
-### Usage Concepts
+### Usage concepts
 
 For a deeper understanding of the Apify SDK's features, refer to the **Usage concepts** section in the sidebar. Key topics include:
 - [Actor lifecycle](../concepts/actor-lifecycle)
@@ -48,7 +48,7 @@ For a deeper understanding of the Apify SDK's features, refer to the **Usage con
 - [Handling Actor events](../concepts/actor-events)
 - [Using proxies](../concepts/proxy-management)
 
-## Installing the Apify SDK Separately
+## Installing the Apify SDK separately
 
 When creating an Actor using the Apify CLI, the Apify SDK for Python is installed automatically. If you want to install it independently, use the following command:
 

--- a/docs/01_overview/02_running_actors_locally.mdx
+++ b/docs/01_overview/02_running_actors_locally.mdx
@@ -1,6 +1,6 @@
 ---
-title: Running Actor locally
-sidebar_label: Running Actors locally
+id: running-actors-locally
+title: Running Actors locally
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/01_overview/03_actor_structure.mdx
+++ b/docs/01_overview/03_actor_structure.mdx
@@ -1,6 +1,6 @@
 ---
+id: actor-structure
 title: Actor structure
-sidebar_label: Actor structure
 ---
 
 import CodeBlock from '@theme/CodeBlock';
@@ -17,7 +17,7 @@ The `.actor/` directory contains the [Actor configuration](https://docs.apify.co
 The Actor's runtime dependencies are specified in the `requirements.txt` file,
 which follows the [standard requirements file format](https://pip.pypa.io/en/stable/reference/requirements-file-format/).
 
-The Actor's source code is in the `src/` folder. This folder contains two important files: `main.py`, which contains the main function of the Actor, and `__main__.py`, which is the entrypoint of the Actor package, setting up the Actor [logger](../concepts/logging) and executing the Actor's main function via [`asyncio.run()`](https://docs.python.org/3/library/asyncio-runner.html#asyncio.run).
+The Actor's source code is in the `src/` folder. This folder contains two important files: `main.py`, which contains the main function of the Actor, and `__main__.py`, which is the entrypoint of the Actor package, setting up the Actor [logger](../concepts/logging) and executing the Actor's main function via [`asyncio.run`](https://docs.python.org/3/library/asyncio-runner.html#asyncio.run).
 
 <Tabs>
     <TabItem value="main.py" label="main.py" default>

--- a/docs/02_guides/01_beautifulsoup_httpx.mdx
+++ b/docs/02_guides/01_beautifulsoup_httpx.mdx
@@ -1,6 +1,6 @@
 ---
+id: beautifulsoup-httpx
 title: Using BeautifulSoup with HTTPX
-sidebar_label: Using BeautifulSoup with HTTPX
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/02_guides/02_crawlee.mdx
+++ b/docs/02_guides/02_crawlee.mdx
@@ -1,6 +1,6 @@
 ---
+id: crawlee
 title: Using Crawlee
-sidebar_label: Using Crawlee
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/02_guides/03_playwright.mdx
+++ b/docs/02_guides/03_playwright.mdx
@@ -1,6 +1,6 @@
 ---
+id: playwright
 title: Using Playwright
-sidebar_label: Using Playwright
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/02_guides/04_selenium.mdx
+++ b/docs/02_guides/04_selenium.mdx
@@ -1,6 +1,6 @@
 ---
+id: selenium
 title: Using Selenium
-sidebar_label: Using Selenium
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/02_guides/05_scrapy.mdx
+++ b/docs/02_guides/05_scrapy.mdx
@@ -1,6 +1,6 @@
 ---
+id: scrapy
 title: Using Scrapy
-sidebar_label: Using Scrapy
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/03_concepts/01_actor_lifecycle.mdx
+++ b/docs/03_concepts/01_actor_lifecycle.mdx
@@ -1,6 +1,6 @@
 ---
+id: actor-lifecycle
 title: Actor lifecycle
-sidebar_label: Actor lifecycle
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/03_concepts/02_actor_input.mdx
+++ b/docs/03_concepts/02_actor_input.mdx
@@ -1,6 +1,6 @@
 ---
+id: actor-input
 title: Actor input
-sidebar_label: Actor input
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/03_concepts/03_storages.mdx
+++ b/docs/03_concepts/03_storages.mdx
@@ -1,6 +1,6 @@
 ---
+id: storages
 title: Working with storages
-sidebar_label: Working with storages
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/03_concepts/04_actor_events.mdx
+++ b/docs/03_concepts/04_actor_events.mdx
@@ -1,6 +1,6 @@
 ---
-title: Handling Actor events & persisting state
-sidebar_label: Actor events & state persistence
+id: actor-events
+title: Actor events & state persistence
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/03_concepts/06_interacting_with_other_actors.mdx
+++ b/docs/03_concepts/06_interacting_with_other_actors.mdx
@@ -1,6 +1,6 @@
 ---
+id: interacting-with-other-actors
 title: Interacting with other Actors
-sidebar_label: Interacting with other Actors
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/03_concepts/07_webhooks.mdx
+++ b/docs/03_concepts/07_webhooks.mdx
@@ -1,6 +1,6 @@
 ---
+id: webhooks
 title: Creating webhooks
-sidebar_label: Creating webhooks
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/03_concepts/08_access_apify_api.mdx
+++ b/docs/03_concepts/08_access_apify_api.mdx
@@ -1,6 +1,6 @@
 ---
-title: Accessing the Apify API
-sidebar_label: Accessing Apify API
+id: access-apify-api
+title: Accessing Apify API
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/03_concepts/09_running_webserver.mdx
+++ b/docs/03_concepts/09_running_webserver.mdx
@@ -1,6 +1,6 @@
 ---
-title: Running a webserver in your Actor
-sidebar_label: Running a webserver
+id: running-webserver
+title: Running webserver in your Actor
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/03_concepts/10_logging.mdx
+++ b/docs/03_concepts/10_logging.mdx
@@ -1,6 +1,6 @@
 ---
+id: logging
 title: Logging
-sidebar_label: Logging
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/03_concepts/11_configuration.mdx
+++ b/docs/03_concepts/11_configuration.mdx
@@ -1,6 +1,6 @@
 ---
-title: Actor configuration and environment variables
-sidebar_label: Configuration & env vars
+id: actor-configuration
+title: Actor configuration
 ---
 
 import CodeBlock from '@theme/CodeBlock';
@@ -24,6 +24,8 @@ This will cause the Actor to persist its state every 10 seconds:
 </CodeBlock>
 
 ## Configuring via environment variables
+
+All the configuration options can be set via environment variables. The environment variables are prefixed with `APIFY_`, and the configuration options are in uppercase, with underscores as separators. See the [`Configuration`](../../reference/class/Configuration) API reference for the full list of configuration options.
 
 This Actor run will not persist its local storages to the filesystem:
 


### PR DESCRIPTION
I broke some links in #378, so this update fixes them. Additionally, there are some cosmetic changes, such as updating the titles to the correct case format.