### PR TITLE
feat: allow custom exit function through dependency injection

### DIFF
--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -231,7 +231,7 @@ class _ActorType:
         event_listeners_timeout: timedelta | None = EVENT_LISTENERS_TIMEOUT,
         status_message: str | None = None,
         cleanup_timeout: timedelta = timedelta(seconds=30),
-        sys_exit: Callable = sys.exit,
+        sys_exit: Callable[[int], None] = sys.exit,
     ) -> None:
         """Exit the Actor instance.
 

--- a/tests/unit/actor/test_actor_log.py
+++ b/tests/unit/actor/test_actor_log.py
@@ -91,4 +91,4 @@ async def test_actor_logs_messages_correctly(
     assert caplog.records[10].message == 'Exiting Actor'
 
     assert caplog.records[11].levelno == logging.DEBUG
-    assert caplog.records[11].message == 'Not calling sys.exit(91) because Actor is running in an unit test'
+    assert caplog.records[11].message == 'Not calling sys_exit(91) because Actor is running in an unit test'


### PR DESCRIPTION
In some contexts it is not desirable to call `sys.exit()` directly from the Actor object. This is already apparent from the surrounding code, which has to deal with such situations: IPython, pytest, or nested loop. I found yet another such situation: Twisted reactor.

I think this leads to a refactoring where the `fail()` and `exit()` functions are not responsible for ending the program, as [explicit is better than implicit](https://en.wikipedia.org/wiki/Zen_of_Python). However, such change would be a larger task I'm not up to, and it would possibly be a breaking change. I'll let the maintainers to discuss and decide the best solution.

My change is minimal and allows an escape route well within the existing API. If we use dependency injection and move `sys.exit` from being hardcoded to being a parameter of both `fail()` and `exit()`, the interface stays the same for existing code, but I'd get the ability to call these methods in contexts, where I don't want them to terminate the program:

```python
from twisted.internet import asyncioreactor, defer
from scrapy.utils.project import get_project_settings
from scrapy.crawler import CrawlerRunner
from scrapy.utils.defer import deferred_from_coro
from twisted.internet.task import react

asyncioreactor.install()

settings = get_project_settings()
runner = CrawlerRunner(settings)

@defer.inlineCallbacks
def crawl(reactor):
    yield deferred_from_coro(Actor.init())
    yield runner.crawl(MySpider)
    yield deferred_from_coro(Actor.exit())
    print("Done!")

react(crawl, [])
```

Currently, the above code won't print `Done!`, because the program ends and there is no straightforward way to prevent it. I invented a workaround like this:

```python
builtins.__IPYTHON__ = True  # deception, Actor.exit() won't call sys.exit()
yield deferred_from_coro(Actor.exit())
```

If this PR is accepted and a new version of SDK released, I could do this:

```python
yield deferred_from_coro(Actor.exit(sys_exit=lambda _: None))
```

In tests, for example, it would be possible to pass a [mock](https://docs.python.org/3/library/unittest.mock.html) and check that the `sys_exit` function got called with a correct exit code, etc.