### PR TITLE
fix: Make sure that Actor instances with non-default configurations are also accessible through the global Actor proxy after initialization

### DIFF
--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -55,9 +55,6 @@ MainReturnType = TypeVar('MainReturnType')
 class _ActorType:
     """The class of `Actor`. Only make a new instance if you're absolutely sure you need to."""
 
-    _apify_client: ApifyClientAsync
-    _configuration: Configuration
-    _is_exiting = False
     _is_rebooting = False
 
     def __init__(
@@ -76,6 +73,8 @@ class _ActorType:
                 be created.
             configure_logging: Should the default logging configuration be configured?
         """
+        self._is_exiting = False
+
         self._configuration = configuration or Configuration.get_global_configuration()
         self._configure_logging = configure_logging
         self._apify_client = self.new_client()

--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -900,11 +900,11 @@ class _ActorType:
             self.log.error('Actor.reboot() is only supported when running on the Apify platform.')
             return
 
-        if self._is_rebooting:
+        if _ActorType._is_rebooting:
             self.log.debug('Actor is already rebooting, skipping the additional reboot call.')
             return
 
-        self._is_rebooting = True
+        _ActorType._is_rebooting = True
 
         if not custom_after_sleep:
             custom_after_sleep = self._configuration.metamorph_after_sleep

--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -56,6 +56,7 @@ class _ActorType:
     """The class of `Actor`. Only make a new instance if you're absolutely sure you need to."""
 
     _is_rebooting = False
+    _is_any_instance_initialized = False
 
     def __init__(
         self,
@@ -199,6 +200,9 @@ class _ActorType:
         if self._is_initialized:
             raise RuntimeError('The Actor was already initialized!')
 
+        if _ActorType._is_any_instance_initialized:
+            self.log.warning('Repeated Actor initialization detected - this is non-standard usage, proceed with care')
+
         # Make sure that the currently initialized instance is also available through the global `Actor` proxy
         cast(Proxy, Actor).__wrapped__ = self
 
@@ -225,6 +229,7 @@ class _ActorType:
         await self._event_manager.__aenter__()
 
         self._is_initialized = True
+        _ActorType._is_any_instance_initialized = True
 
     async def exit(
         self,

--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -200,6 +200,9 @@ class _ActorType:
         if self._is_initialized:
             raise RuntimeError('The Actor was already initialized!')
 
+        # Make sure that the currently initialized instance is also available through the global `Actor` proxy
+        cast(Proxy, Actor).__wrapped__ = self
+
         self._is_exiting = False
         self._was_final_persist_state_emitted = False
 

--- a/tests/unit/actor/test_actor_lifecycle.py
+++ b/tests/unit/actor/test_actor_lifecycle.py
@@ -16,6 +16,7 @@ from crawlee.events._types import Event, EventPersistStateData
 import apify._actor
 from apify import Actor
 from apify._actor import _ActorType
+from apify._configuration import Configuration
 
 
 async def test_actor_properly_init_with_async() -> None:
@@ -33,6 +34,13 @@ async def test_actor_init() -> None:
 
     await my_actor.exit()
     assert my_actor._is_initialized is False
+
+
+async def test_actor_global_works() -> None:
+    non_default_configuration = Configuration(actor_full_name='Actor McActorson, esq.')
+
+    async with Actor(configuration=non_default_configuration):
+        assert Actor.configuration is non_default_configuration
 
 
 async def test_double_init_raises_error(prepare_test_env: Callable) -> None:

--- a/tests/unit/actor/test_actor_lifecycle.py
+++ b/tests/unit/actor/test_actor_lifecycle.py
@@ -16,7 +16,6 @@ from crawlee.events._types import Event, EventPersistStateData
 import apify._actor
 from apify import Actor
 from apify._actor import _ActorType
-from apify._configuration import Configuration
 
 
 async def test_actor_properly_init_with_async() -> None:
@@ -34,13 +33,6 @@ async def test_actor_init() -> None:
 
     await my_actor.exit()
     assert my_actor._is_initialized is False
-
-
-async def test_actor_global_works() -> None:
-    non_default_configuration = Configuration(actor_full_name='Actor McActorson, esq.')
-
-    async with Actor(configuration=non_default_configuration):
-        assert Actor.configuration is non_default_configuration
 
 
 async def test_double_init_raises_error(prepare_test_env: Callable) -> None:

--- a/tests/unit/actor/test_actor_non_default_instance.py
+++ b/tests/unit/actor/test_actor_non_default_instance.py
@@ -10,3 +10,10 @@ async def test_actor_with_non_default_config() -> None:
 
     async with Actor(config) as actor:
         assert actor.config.internal_timeout == timedelta(minutes=111)
+
+
+async def test_actor_global_works() -> None:
+    non_default_configuration = Configuration(actor_full_name='Actor McActorson, esq.')
+
+    async with Actor(configuration=non_default_configuration):
+        assert Actor.configuration is non_default_configuration

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -39,6 +39,7 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
 
     def _prepare_test_env() -> None:
         delattr(apify._actor.Actor, '__wrapped__')
+        apify._actor._ActorType._is_any_instance_initialized = False
 
         # Set the environment variable for the local storage directory to the temporary path.
         monkeypatch.setenv(ApifyEnvVars.LOCAL_STORAGE_DIR, str(tmp_path))


### PR DESCRIPTION
- closes #397
