### PR TITLE
feat: sign public url

### DIFF
--- a/src/apify/_crypto.py
+++ b/src/apify/_crypto.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import base64
+import hashlib
+import hmac
 from typing import Any
 
 from cryptography.exceptions import InvalidTag as InvalidTagException
@@ -153,3 +155,37 @@ def decrypt_input_secrets(private_key: rsa.RSAPrivateKey, input_data: Any) -> An
                 )
 
     return input_data
+
+
+CHARSET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+
+def encode_base62(num: int) -> str:
+    """Encode the given number to base62."""
+    if num == 0:
+        return CHARSET[0]
+
+    res = ''
+    while num > 0:
+        num, remainder = divmod(num, 62)
+        res = CHARSET[remainder] + res
+    return res
+
+
+# createHmacSignature
+@ignore_docs
+def create_hmac_signature(secret_key: str, message: str) -> str:
+    """Generates an HMAC signature and encodes it using Base62. Base62 encoding reduces the signature length.
+
+    Args:
+        secret_key (str): Secret key used for signing signatures
+        message (str): Message to be signed
+
+    Returns:
+        str: Base62 encoded signature
+    """
+    signature = hmac.new(secret_key.encode('utf-8'), message.encode('utf-8'), hashlib.sha256).hexdigest()[:30]
+
+    decimal_signature = int(signature, 16)
+
+    return encode_base62(decimal_signature)

--- a/src/apify/apify_storage_client/_key_value_store_client.py
+++ b/src/apify/apify_storage_client/_key_value_store_client.py
@@ -7,8 +7,8 @@ from typing_extensions import override
 
 from crawlee.storage_clients._base import KeyValueStoreClient as BaseKeyValueStoreClient
 from crawlee.storage_clients.models import KeyValueStoreListKeysPage, KeyValueStoreMetadata, KeyValueStoreRecord
-from apify._crypto import (create_hmac_signature)
 
+from apify._crypto import create_hmac_signature
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -94,7 +94,8 @@ class KeyValueStoreClient(BaseKeyValueStoreClient):
         public_api_url = self._api_public_base_url
         public_url = f'{public_api_url}/v2/key-value-stores/{self._client.resource_id}/records/{key}'
 
-        if getattr(self.storage_object, 'url_signing_secret_key', None):
-            public_url += f'?signature={create_hmac_signature(self.storage_object.url_signing_secret_key, key)}'
+        url_signing_secret_key = getattr(self.storage_object, 'url_signing_secret_key', None)  # type: ignore[attr-defined]
+        if url_signing_secret_key:
+            public_url += f'?signature={create_hmac_signature(url_signing_secret_key, key)}'
 
         return public_url

--- a/src/apify/apify_storage_client/_key_value_store_client.py
+++ b/src/apify/apify_storage_client/_key_value_store_client.py
@@ -5,8 +5,10 @@ from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
 
-from crawlee.storage_clients._base import BaseKeyValueStoreClient
+from crawlee.storage_clients._base import KeyValueStoreClient as BaseKeyValueStoreClient
 from crawlee.storage_clients.models import KeyValueStoreListKeysPage, KeyValueStoreMetadata, KeyValueStoreRecord
+from apify._crypto import (create_hmac_signature)
+
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -90,5 +92,9 @@ class KeyValueStoreClient(BaseKeyValueStoreClient):
             key: The key for which the URL should be generated.
         """
         public_api_url = self._api_public_base_url
+        public_url = f'{public_api_url}/v2/key-value-stores/{self._client.resource_id}/records/{key}'
 
-        return f'{public_api_url}/v2/key-value-stores/{self._client.resource_id}/records/{key}'
+        if getattr(self.storage_object, 'url_signing_secret_key', None):
+            public_url += f'?signature={create_hmac_signature(self.storage_object.url_signing_secret_key, key)}'
+
+        return public_url

--- a/tests/integration/test_actor_key_value_store.py
+++ b/tests/integration/test_actor_key_value_store.py
@@ -6,6 +6,7 @@ from apify_shared.consts import ApifyEnvVars
 
 from ._utils import generate_unique_resource_name
 from apify import Actor
+from apify._crypto import create_hmac_signature
 
 if TYPE_CHECKING:
     import pytest
@@ -210,10 +211,16 @@ async def test_generate_public_url_for_kvs_record(
             default_store_id = Actor.config.default_key_value_store_id
 
             store = await Actor.open_key_value_store()
-            record_url = await cast(KeyValueStoreClient, store._resource_client).get_public_url('dummy')
-            print(record_url)
+            record_key = 'dummy'
+            record_url = await cast(KeyValueStoreClient, store._resource_client).get_public_url(record_key)
+            url_signing_secret_key = cast(str, getattr(store.storage_object, 'url_signing_secret_key', None))
+            signature = create_hmac_signature(url_signing_secret_key, record_key)
 
-            assert record_url == f'{public_api_url}/v2/key-value-stores/{default_store_id}/records/dummy'
+            assert url_signing_secret_key is not None
+            assert (
+                record_url
+                == f'{public_api_url}/v2/key-value-stores/{default_store_id}/records/{record_key}?signature={signature}'
+            )
 
     actor = await make_actor(label='kvs-get-public-url', main_func=main)
     run_result = await run_actor(actor)

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -4,7 +4,14 @@ import base64
 
 import pytest
 
-from apify._crypto import _load_public_key, crypto_random_object_id, load_private_key, private_decrypt, public_encrypt
+from apify._crypto import (
+    _load_public_key,
+    create_hmac_signature,
+    crypto_random_object_id,
+    load_private_key,
+    private_decrypt,
+    public_encrypt,
+)
 
 # NOTE: Uses the same keys as in:
 # https://github.com/apify/apify-shared-js/blob/master/test/crypto.test.ts
@@ -105,3 +112,20 @@ def test_crypto_random_object_id_length_and_charset() -> None:
     long_random_object_id = crypto_random_object_id(1000)
     for char in long_random_object_id:
         assert char in 'abcdefghijklmnopqrstuvwxyzABCEDFGHIJKLMNOPQRSTUVWXYZ0123456789'
+
+
+# Check if the method is compatible with js version of the same method in:
+# https://github.com/apify/apify-shared-js/blob/master/packages/utilities/src/hmac.ts
+def test_create_valid_hmac_signature() -> None:
+    # This test uses the same secret key and message as in JS tests.
+    secret_key = 'hmac-secret-key'
+    message = 'hmac-message-to-be-authenticated'
+    assert create_hmac_signature(secret_key, message) == 'pcVagAsudj8dFqdlg7mG'
+
+
+def test_create_same_hmac() -> None:
+    # This test uses the same secret key and message as in JS tests.
+    secret_key = 'hmac-same-secret-key'
+    message = 'hmac-same-message-to-be-authenticated'
+    for _ in range(5):
+        assert create_hmac_signature(secret_key, message) == 'FYMcmTIm3idXqleF1Sw5'


### PR DESCRIPTION
This PR is part of [Issue #19363](https://github.com/apify/apify-core/issues/19363), which updates `KeyValueStore.getPublicUrl(recordKey)` to generate signed links using HMAC.


**This PR**:
- creates signature and appends it to the public URL of the record in KV store

P.S. Before merging, we need to wait for the release of Crawlee, so we can update version of Crawlee.

P.P.S It's hard to test the changes, since master branch of SDK and master branch of Crawlee are out of sync. Crawlee has some breaking changes in version 6.0, which are not yet addressed in master branch of SDK.

Previous PR that adds storageObject to Crawlee Python is [here](https://github.com/apify/crawlee-python/pull/993)

Same PR in SDK JS is [here](https://github.com/apify/apify-sdk-js/pull/358)