### PR TITLE
docs: Add force_cloud argument documentation

### DIFF
--- a/docs/03_concepts/03_storages.mdx
+++ b/docs/03_concepts/03_storages.mdx
@@ -40,7 +40,7 @@ Each dataset item, key-value store record, or request in a request queue is then
 
 ## Local Actor run with non-local storage
 
-When developing locally, opening any storage will by default use local storage. To change this behavior and to use non-local storage you have to use `force_cloud=True` argument in [`Actor.open_dataset`](../../reference/class/Actor#open_dataset), [`Actor.open_request_queue`](../../reference/class/Actor#open_request_queue) or [`Actor.open_key_value_store`](../../reference/class/Actor#open_key_value_store). Proper use of this argument allows you to work with both local and non-local storages.
+When developing locally, opening any storage will by default use local storage. To change this behavior and to use non-local storage you have to use `force_cloud=True` argument in [`Actor.open_dataset`](../../reference/class/Actor#open_dataset), [`Actor.open_request_queue`](../../reference/class/Actor#open_request_queue) or [`Actor.open_key_value_store`](../../reference/class/Actor#open_key_value_store). Proper use of this argument allows you to work with both local and remote storages.
 
 ### Local storage persistence
 

--- a/docs/03_concepts/03_storages.mdx
+++ b/docs/03_concepts/03_storages.mdx
@@ -38,6 +38,10 @@ Each storage is then stored in its own folder, named after the storage, or calle
 
 Each dataset item, key-value store record, or request in a request queue is then stored in its own file in the storage folder. Dataset items and request queue requests are always JSON files, and key-value store records can be any file type, based on its content type. For example, the Actor input is typically stored in `storage/key_value_stores/default/INPUT.json`.
 
+## Local Actor run with non-local storage
+
+When developing locally, opening any storage will by default use local storage. To change this behavior and to use non-local storage you have to use `force_cloud=True` argument in [`Actor.open_dataset`](../../reference/class/Actor#open_dataset), [`Actor.open_request_queue`](../../reference/class/Actor#open_request_queue) or [`Actor.open_key_value_store`](../../reference/class/Actor#open_key_value_store). Proper use of this argument allows you to work with both local and non-local storages.
+
 ### Local storage persistence
 
 By default, the storage contents are persisted across multiple Actor runs. To clean up the Actor storages before the running the Actor, use the `--purge` flag of the [`apify run`](https://docs.apify.com/cli/docs/reference#apify-run) command of the Apify CLI.

--- a/docs/03_concepts/03_storages.mdx
+++ b/docs/03_concepts/03_storages.mdx
@@ -38,9 +38,11 @@ Each storage is then stored in its own folder, named after the storage, or calle
 
 Each dataset item, key-value store record, or request in a request queue is then stored in its own file in the storage folder. Dataset items and request queue requests are always JSON files, and key-value store records can be any file type, based on its content type. For example, the Actor input is typically stored in `storage/key_value_stores/default/INPUT.json`.
 
-## Local Actor run with non-local storage
+## Local Actor run with remote storage
 
-When developing locally, opening any storage will by default use local storage. To change this behavior and to use non-local storage you have to use `force_cloud=True` argument in [`Actor.open_dataset`](../../reference/class/Actor#open_dataset), [`Actor.open_request_queue`](../../reference/class/Actor#open_request_queue) or [`Actor.open_key_value_store`](../../reference/class/Actor#open_key_value_store). Proper use of this argument allows you to work with both local and remote storages.
+When developing locally, opening any storage will by default use local storage. To change this behavior and to use remote storage you have to use `force_cloud=True` argument in [`Actor.open_dataset`](../../reference/class/Actor#open_dataset), [`Actor.open_request_queue`](../../reference/class/Actor#open_request_queue) or [`Actor.open_key_value_store`](../../reference/class/Actor#open_key_value_store). Proper use of this argument allows you to work with both local and remote storages.
+
+Calling another remote Actor and accessing its default storage is typical use-case for using `force-cloud=True` argument to open remote Actor's storages.
 
 ### Local storage persistence
 


### PR DESCRIPTION
Add small docs section about how to use `force_cloud` argument in local development.

Documents #412 