### PR TITLE
docs: bump `typedoc-api` plugin

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7,7 +7,7 @@
             "name": "apify-sdk-python",
             "dependencies": {
                 "@apify/docs-theme": "^1.0.167",
-                "@apify/docusaurus-plugin-typedoc-api": "^4.3.12",
+                "@apify/docusaurus-plugin-typedoc-api": "^4.4.3",
                 "@docusaurus/core": "^3.7.0",
                 "@docusaurus/faster": "^3.7.0",
                 "@docusaurus/plugin-client-redirects": "^3.7.0",
@@ -542,9 +542,9 @@
             }
         },
         "node_modules/@apify/docusaurus-plugin-typedoc-api": {
-            "version": "4.3.12",
-            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.3.12.tgz",
-            "integrity": "sha512-76KquQjw6F5i/Zybk32HcK5xwSaek6JlCqAV313eNUqqIhQ9q/4BGX+xpJjNSz1yGjy+FdSy3dmHJdqUJQAQYg==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.4.3.tgz",
+            "integrity": "sha512-zIYqkALQOrOy5brZEHX2WAgUnVykOK36tGlKhbLK+8NGtfoStCWE9nfkDZqrglcWChxmzqERTs92TbzmFtal+A==",
             "license": "MIT",
             "dependencies": {
                 "@docusaurus/plugin-content-docs": "^3.5.2",

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@apify/docs-theme": "^1.0.167",
-        "@apify/docusaurus-plugin-typedoc-api": "^4.3.12",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.4.3",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/faster": "^3.7.0",
         "@docusaurus/plugin-client-redirects": "^3.7.0",


### PR DESCRIPTION
Introduces recent features and fixes from the plugin.

Enables docs versioning for Python projects.

Handles `TypeAlias`ed types (expands known aliases to their values).

![obrazek](https://github.com/user-attachments/assets/187f19e4-f022-4c2f-ae17-bb79f40c1afc)

Fixes an issue with `Unpack` type in reexported types - below screenshot of Crawlee's Dataset in Apify SDK Python docs (see that the `Unpack`-type kwargs are not expanded) :

![obrazek](https://github.com/user-attachments/assets/77f3d43e-4fbb-4bc8-b24b-48ba6fbebab8)
