### PR TITLE
docs: Use and enforce imperative mood

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ ignore = [
     "D100",     # Missing docstring in public module
     "D104",     # Missing docstring in public package
     "D107",     # Missing docstring in `__init__`
+    "D203",     # One blank line required before class docstring
+    "D213",     # Multi-line docstring summary should start at the second line
+    "D413",     # Missing blank line after last section
     "EM",       # flake8-errmsg
     "G004",     # Logging statement uses f-string
     "ISC001",   # This rule may cause conflicts when used with the formatter
@@ -161,9 +164,6 @@ runtime-evaluated-base-classes = [
 
 [tool.ruff.lint.flake8-builtins]
 builtins-ignorelist = ["id"]
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
 
 [tool.ruff.lint.isort]
 known-local-folder = ["apify"]

--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -1138,7 +1138,7 @@ class _ActorType:
         return proxy_configuration
 
     def _get_default_exit_process(self) -> bool:
-        """Returns False for IPython, Pytest, and Scrapy environments, True otherwise."""
+        """Return False for IPython, Pytest, and Scrapy environments, True otherwise."""
         if is_running_in_ipython():
             self.log.debug('Running in IPython, setting default `exit_process` to False.')
             return False

--- a/src/apify/_utils.py
+++ b/src/apify/_utils.py
@@ -31,10 +31,16 @@ GroupName = Literal['Classes', 'Abstract classes', 'Interfaces', 'Data structure
 
 
 def docs_group(group_name: GroupName) -> Callable:  # noqa: ARG001
-    """Decorator to mark symbols for rendering and grouping in documentation.
+    """Mark a symbol for rendering and grouping in documentation.
 
-    This decorator is used purely for documentation purposes and does not alter the behavior
+    This decorator is used solely for documentation purposes and does not modify the behavior
     of the decorated callable.
+
+    Args:
+        group_name: The documentation group to which the symbol belongs.
+
+    Returns:
+        The original callable without modification.
     """
 
     def wrapper(func: Callable) -> Callable:
@@ -44,12 +50,16 @@ def docs_group(group_name: GroupName) -> Callable:  # noqa: ARG001
 
 
 def docs_name(symbol_name: str) -> Callable:  # noqa: ARG001
-    """Decorator for renaming symbols in documentation.
+    """Rename a symbol for documentation rendering.
 
-    This changes the rendered name of the symbol only in the rendered web documentation.
+    This decorator modifies only the displayed name of the symbol in the generated documentation
+    and does not affect its runtime behavior.
 
-    This decorator is used purely for documentation purposes and does not alter the behavior
-    of the decorated callable.
+    Args:
+        symbol_name: The name to be used in the documentation.
+
+    Returns:
+        The original callable without modification.
     """
 
     def wrapper(func: Callable) -> Callable:

--- a/src/apify/scrapy/_async_thread.py
+++ b/src/apify/scrapy/_async_thread.py
@@ -113,7 +113,7 @@ class AsyncThread:
         await asyncio.gather(*tasks, return_exceptions=True)
 
     def _force_exit_event_loop(self) -> None:
-        """Forcefully shut down the event loop and its thread."""
+        """Shut down the event loop and its thread forcefully."""
         try:
             logger.info('Forced shutdown of the event loop and its thread...')
             self._eventloop.call_soon_threadsafe(self._eventloop.stop)

--- a/src/apify/storages/_request_list.py
+++ b/src/apify/storages/_request_list.py
@@ -51,7 +51,7 @@ class RequestList(CrawleeRequestList):
         request_list_sources_input: list[dict[str, Any]] | None = None,
         http_client: HttpClient | None = None,
     ) -> RequestList:
-        """Creates RequestList from Actor input requestListSources.
+        """Initialize a new instance from request list source input.
 
         Args:
             name: Name of the returned RequestList.
@@ -108,9 +108,10 @@ class RequestList(CrawleeRequestList):
 
     @staticmethod
     async def _fetch_requests_from_url(
-        remote_url_requests_inputs: list[_RequestsFromUrlInput], http_client: HttpClient
+        remote_url_requests_inputs: list[_RequestsFromUrlInput],
+        http_client: HttpClient,
     ) -> list[Request]:
-        """Crete list of requests from url.
+        """Create list of requests from url.
 
         Send GET requests to urls defined in each requests_from_url of remote_url_requests_inputs. Run extracting
         callback on each response body and use URL_NO_COMMAS_REGEX regex to find all links. Create list of Requests from
@@ -119,7 +120,11 @@ class RequestList(CrawleeRequestList):
         created_requests: list[Request] = []
 
         def create_requests_from_response(request_input: _RequestsFromUrlInput, task: Task) -> None:
-            """Callback to scrape response body with regexp and create Requests from matches."""
+            """Extract links from response body and use them to create `Request` objects.
+
+            Use the regular expression to find all matching links in the response body, then create `Request`
+            objects from these links and the provided input attributes.
+            """
             matches = re.finditer(URL_NO_COMMAS_REGEX, task.result().read().decode('utf-8'))
             created_requests.extend(
                 [

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ wheels = [
 
 [[package]]
 name = "apify"
-version = "2.4.0"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "apify-client" },


### PR DESCRIPTION
- Currently, our docstrings use a mix of imperative and indicative moods basically randomly.
- PEP 257 recommends using the imperative mood for the first line of docstrings, which is also enforced by the Ruff rule [D401](https://docs.astral.sh/ruff/rules/non-imperative-mood/#non-imperative-mood-d401). So I believe the imperative form is more suitable for the docs purposes.
- In most cases, I have simply changed the verb form, but a few cases required more rewording.
- I updated the pyproject configuration to enforce it.
