### PR TITLE
docs: fix changelog generation by bumping `@apify/docs-theme` plugin

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "apify-sdk-python",
             "dependencies": {
-                "@apify/docs-theme": "^1.0.167",
+                "@apify/docs-theme": "^1.0.169",
                 "@apify/docusaurus-plugin-typedoc-api": "^4.4.3",
                 "@docusaurus/core": "^3.7.0",
                 "@docusaurus/faster": "^3.7.0",

--- a/website/package.json
+++ b/website/package.json
@@ -21,7 +21,7 @@
         "lint:code:fix": "eslint . --fix"
     },
     "dependencies": {
-        "@apify/docs-theme": "^1.0.167",
+        "@apify/docs-theme": "^1.0.169",
         "@apify/docusaurus-plugin-typedoc-api": "^4.4.3",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/faster": "^3.7.0",


### PR DESCRIPTION
Introduces fixes from https://github.com/apify/apify-docs/pull/1427 into the documentation of this project. 