### PR TITLE
chore: add `APIFY_USER_IS_PAYING` env var annotation to the configuration

### DIFF
--- a/src/apify/_configuration.py
+++ b/src/apify/_configuration.py
@@ -334,6 +334,14 @@ class Configuration(CrawleeConfiguration):
         ),
     ] = None
 
+    user_is_paying: Annotated[
+        str | None,
+        Field(
+            alias='apify_user_is_paying',
+            description='If set to "1", the user calling the Actor is paying user',
+        ),
+    ] = None
+
     web_server_port: Annotated[
         int,
         Field(


### PR DESCRIPTION
Adds `APIFY_USER_IS_PAYING` environmental variable annotation to the configuration.

- PR with updated documentation is here: https://github.com/apify/apify-docs/pull/1706
- PR with changes to the `apify-shared-python` (adding the env variable to the shared constants): https://github.com/apify/apify-shared-python/pull/40 