### PR TITLE
docs: synchronize package versions, fix breaking docs build

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -38,7 +38,16 @@ module.exports = {
     favicon: 'img/favicon.ico',
     githubHost: 'github.com',
     future: {
-        experimental_faster: true,
+        experimental_faster: {
+            // ssgWorkerThreads: true,
+            swcJsLoader: true,
+            swcJsMinimizer: true,
+            swcHtmlMinimizer: true,
+            lightningCssMinimizer: true,
+            rspackBundler: true,
+            mdxCrossCompilerCache: true,
+            rspackPersistentCache: true,
+        },
         v4: {
             removeLegacyPostBuildHeadAttribute: true,
             useCssCascadeLayers: false, // this breaks styles on homepage and link colors everywhere

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6,12 +6,12 @@
         "": {
             "name": "apify-sdk-python",
             "dependencies": {
-                "@apify/docs-theme": "^1.0.181",
-                "@apify/docusaurus-plugin-typedoc-api": "^4.4.3",
-                "@docusaurus/core": "^3.7.0",
-                "@docusaurus/faster": "^3.7.0",
-                "@docusaurus/plugin-client-redirects": "^3.7.0",
-                "@docusaurus/preset-classic": "^3.7.0",
+                "@apify/docs-theme": "^1.0.185",
+                "@apify/docusaurus-plugin-typedoc-api": "^4.4.6",
+                "@docusaurus/core": "^3.8.1",
+                "@docusaurus/faster": "^3.8.1",
+                "@docusaurus/plugin-client-redirects": "^3.8.1",
+                "@docusaurus/preset-classic": "^3.8.1",
                 "clsx": "^2.0.0",
                 "docusaurus-gtm-plugin": "^0.0.2",
                 "prop-types": "^15.8.1",

--- a/website/package.json
+++ b/website/package.json
@@ -21,12 +21,12 @@
         "lint:code:fix": "eslint . --fix"
     },
     "dependencies": {
-        "@apify/docs-theme": "^1.0.181",
-        "@apify/docusaurus-plugin-typedoc-api": "^4.4.3",
-        "@docusaurus/core": "^3.7.0",
-        "@docusaurus/faster": "^3.7.0",
-        "@docusaurus/plugin-client-redirects": "^3.7.0",
-        "@docusaurus/preset-classic": "^3.7.0",
+        "@apify/docs-theme": "^1.0.185",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.4.6",
+        "@docusaurus/core": "^3.8.1",
+        "@docusaurus/faster": "^3.8.1",
+        "@docusaurus/plugin-client-redirects": "^3.8.1",
+        "@docusaurus/preset-classic": "^3.8.1",
         "clsx": "^2.0.0",
         "docusaurus-gtm-plugin": "^0.0.2",
         "prop-types": "^15.8.1",


### PR DESCRIPTION
Bumps the Docusaurus-related packages and uses the [known-good configuration](https://github.com/apify/crawlee/blob/5341487a9fd8239bede48b1c1b0a8eabead81242/website/docusaurus.config.js#L59C9-L72C11) from Crawlee to fix the failing docs builds.