### PR TITLE
fix: Restrict apify-shared and apify-client versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ keywords = [
     "scraping",
 ]
 dependencies = [
-    "apify-client>=1.11.0",
-    "apify-shared>=1.3.0",
+    "apify-client<2.0.0",
+    "apify-shared<2.0.0",
     "crawlee~=0.6.0",
     "cryptography>=42.0.0",
     "httpx>=0.27.0",

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ wheels = [
 
 [[package]]
 name = "apify"
-version = "2.7.0"
+version = "2.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "apify-client" },
@@ -67,8 +67,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "apify-client", specifier = ">=1.11.0" },
-    { name = "apify-shared", specifier = ">=1.3.0" },
+    { name = "apify-client", specifier = "<2.0.0" },
+    { name = "apify-shared", specifier = "<2.0.0" },
     { name = "crawlee", specifier = "~=0.6.0" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },


### PR DESCRIPTION
This will be backported to https://github.com/apify/apify-sdk-python/tree/release-v2 branch and a new patch will be released.