### PR TITLE
chore: Replace `respx` mocks with `pytest-httpserver` in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,13 +71,15 @@ dev = [
     "pydoc-markdown~=4.8.0",
     "pytest-asyncio~=1.1.0",
     "pytest-cov~=6.2.0",
+    "pytest-httpserver>=1.1.3",
     "pytest-timeout>=2.4.0",
     "pytest-xdist~=3.8.0",
     "pytest~=8.4.0",
-    "respx~=0.22.0",
     "ruff~=0.12.0",
     "setuptools", # setuptools are used by pytest but not explicitly required
     "uvicorn[standard]",
+    "werkzeug~=3.0.0", # Werkzeug is used by httpserver
+    "yarl~=1.20.0", # yarl is used by crawlee
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/unit/actor/test_actor_create_proxy_configuration.py
+++ b/tests/unit/actor/test_actor_create_proxy_configuration.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
-import httpx
 import pytest
 
 from apify_client import ApifyClientAsync
@@ -12,8 +11,6 @@ from apify_shared.consts import ApifyEnvVars
 from apify import Actor
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from pytest_httpserver import HTTPServer
     from werkzeug import Request, Response
 
@@ -26,20 +23,6 @@ DUMMY_PASSWORD = 'DUMMY_PASSWORD'
 def patched_apify_client(apify_client_async_patcher: ApifyClientAsyncPatcher) -> ApifyClientAsync:
     apify_client_async_patcher.patch('user', 'get', return_value={'proxy': {'password': DUMMY_PASSWORD}})
     return ApifyClientAsync()
-
-
-@pytest.fixture
-def patched_httpx_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Patch httpx client to avoid actual network calls."""
-
-    class ProxylessAsyncClient(httpx.AsyncClient):
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            kwargs.pop('proxy', None)
-            super().__init__(*args, **kwargs)
-
-    monkeypatch.setattr(httpx, 'AsyncClient', ProxylessAsyncClient)
-    yield
-    monkeypatch.undo()
 
 
 @pytest.mark.usefixtures('patched_httpx_client')

--- a/tests/unit/actor/test_request_list.py
+++ b/tests/unit/actor/test_request_list.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any, get_args
+from typing import TYPE_CHECKING, Any, get_args
+from unittest.mock import Mock
 
 import pytest
-import respx
-from httpx import Response
+from yarl import URL
 
 from crawlee._request import UserData
 from crawlee._types import HttpMethod
 
 from apify.storages._request_list import URL_NO_COMMAS_REGEX, RequestList
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+    from werkzeug import Request, Response
 
 
 @pytest.mark.parametrize(
@@ -67,20 +71,19 @@ async def test_request_list_open_request_types(
     assert request.headers.root == optional_input.get('headers', {})
 
 
-@respx.mock
-async def test_request_list_open_from_url_correctly_send_requests() -> None:
+async def test_request_list_open_from_url_correctly_send_requests(httpserver: HTTPServer) -> None:
     """Test that requests are sent to expected urls."""
     request_list_sources_input: list[dict[str, Any]] = [
         {
-            'requestsFromUrl': 'https://abc.dev/file.txt',
+            'requestsFromUrl': httpserver.url_for('/file.txt'),
             'method': 'GET',
         },
         {
-            'requestsFromUrl': 'https://www.abc.dev/file2',
+            'requestsFromUrl': httpserver.url_for('/file2'),
             'method': 'PUT',
         },
         {
-            'requestsFromUrl': 'https://www.something.som',
+            'requestsFromUrl': httpserver.url_for('/something'),
             'method': 'POST',
             'headers': {'key': 'value'},
             'payload': 'some_payload',
@@ -88,16 +91,28 @@ async def test_request_list_open_from_url_correctly_send_requests() -> None:
         },
     ]
 
-    routes = [respx.get(entry['requestsFromUrl']) for entry in request_list_sources_input]
+    routes: dict[str, Mock] = {}
+
+    def request_handler(request: Request, response: Response) -> Response:
+        routes[request.url]()
+        return response
+
+    for entry in request_list_sources_input:
+        path = str(URL(entry['requestsFromUrl']).path)
+        httpserver.expect_oneshot_request(path).with_post_hook(request_handler).respond_with_data(status=200)
+        routes[entry['requestsFromUrl']] = Mock()
 
     await RequestList.open(request_list_sources_input=request_list_sources_input)
 
-    for route in routes:
-        assert route.called
+    assert len(routes) == len(request_list_sources_input)
+
+    for entity in request_list_sources_input:
+        entity_url = entity['requestsFromUrl']
+        assert entity_url in routes
+        assert routes[entity_url].called
 
 
-@respx.mock
-async def test_request_list_open_from_url() -> None:
+async def test_request_list_open_from_url(httpserver: HTTPServer) -> None:
     """Test that create_request_list is correctly reading urls from remote url sources and also from simple input."""
     expected_simple_url = 'https://www.someurl.com'
     expected_remote_urls_1 = {'http://www.something.com', 'https://www.somethingelse.com', 'http://www.bla.net'}
@@ -111,11 +126,11 @@ async def test_request_list_open_from_url() -> None:
 
     mocked_urls = (
         MockedUrlInfo(
-            'https://abc.dev/file.txt',
+            httpserver.url_for('/file.txt'),
             'blablabla{} more blablabla{} , even more blablabla. {} '.format(*expected_remote_urls_1),
         ),
         MockedUrlInfo(
-            'https://www.abc.dev/file2',
+            httpserver.url_for('/file2'),
             'some stuff{} more stuff{} www.false_positive.com'.format(*expected_remote_urls_2),
         ),
     )
@@ -132,7 +147,8 @@ async def test_request_list_open_from_url() -> None:
         },
     ]
     for mocked_url in mocked_urls:
-        respx.get(mocked_url.url).mock(return_value=Response(200, text=mocked_url.response_text))
+        path = str(URL(mocked_url.url).path)
+        httpserver.expect_oneshot_request(path).respond_with_data(status=200, response_data=mocked_url.response_text)
 
     request_list = await RequestList.open(request_list_sources_input=request_list_sources_input)
     generated_requests = []
@@ -143,23 +159,20 @@ async def test_request_list_open_from_url() -> None:
     assert {generated_request.url for generated_request in generated_requests} == expected_urls
 
 
-@respx.mock
-async def test_request_list_open_from_url_additional_inputs() -> None:
+async def test_request_list_open_from_url_additional_inputs(httpserver: HTTPServer) -> None:
     """Test that all generated request properties are correctly populated from input values."""
     expected_url = 'https://www.someurl.com'
     example_start_url_input: dict[str, Any] = {
-        'requestsFromUrl': 'https://crawlee.dev/file.txt',
+        'requestsFromUrl': httpserver.url_for('/file.txt'),
         'method': 'POST',
         'headers': {'key': 'value'},
         'payload': 'some_payload',
         'userData': {'another_key': 'another_value'},
     }
-
-    respx.get(example_start_url_input['requestsFromUrl']).mock(return_value=Response(200, text=expected_url))
+    httpserver.expect_oneshot_request('/file.txt').respond_with_data(status=200, response_data=expected_url)
 
     request_list = await RequestList.open(request_list_sources_input=[example_start_url_input])
     request = await request_list.fetch_next_request()
-
     # Check all properties correctly created for request
     assert request
     assert request.url == expected_url

--- a/tests/unit/test_proxy_configuration.py
+++ b/tests/unit/test_proxy_configuration.py
@@ -8,7 +8,6 @@ from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
-import httpx
 import pytest
 
 from apify_client import ApifyClientAsync
@@ -17,8 +16,6 @@ from apify_shared.consts import ApifyEnvVars
 from apify._proxy_configuration import ProxyConfiguration, is_url
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from pytest_httpserver import HTTPServer
     from werkzeug import Request, Response
 
@@ -39,20 +36,6 @@ def patched_apify_client(apify_client_async_patcher: ApifyClientAsyncPatcher) ->
         },
     )
     return ApifyClientAsync()
-
-
-@pytest.fixture
-def patched_httpx_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Patch httpx client to avoid actual network calls."""
-
-    class ProxylessAsyncClient(httpx.AsyncClient):
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            kwargs.pop('proxy', None)
-            super().__init__(*args, **kwargs)
-
-    monkeypatch.setattr(httpx, 'AsyncClient', ProxylessAsyncClient)
-    yield
-    monkeypatch.undo()
 
 
 def test_basic_constructor() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -28,7 +28,7 @@ wheels = [
 
 [[package]]
 name = "apify"
-version = "2.7.3"
+version = "2.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "apify-client" },
@@ -59,12 +59,14 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-httpserver" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
-    { name = "respx" },
     { name = "ruff" },
     { name = "setuptools" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "werkzeug" },
+    { name = "yarl" },
 ]
 
 [package.metadata]
@@ -94,12 +96,14 @@ dev = [
     { name = "pytest", specifier = "~=8.4.0" },
     { name = "pytest-asyncio", specifier = "~=1.1.0" },
     { name = "pytest-cov", specifier = "~=6.2.0" },
+    { name = "pytest-httpserver", specifier = ">=1.1.3" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = "~=3.8.0" },
-    { name = "respx", specifier = "~=0.22.0" },
     { name = "ruff", specifier = "~=0.12.0" },
     { name = "setuptools" },
     { name = "uvicorn", extras = ["standard"] },
+    { name = "werkzeug", specifier = "~=3.0.0" },
+    { name = "yarl", specifier = "~=1.20.0" },
 ]
 
 [[package]]
@@ -1873,6 +1877,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-httpserver"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/d8/def15ba33bd696dd72dd4562a5287c0cba4d18a591eeb82e0b08ab385afc/pytest_httpserver-1.1.3.tar.gz", hash = "sha256:af819d6b533f84b4680b9416a5b3f67f1df3701f1da54924afd4d6e4ba5917ec", size = 68870, upload-time = "2025-04-10T08:17:15.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/d2/dfc2f25f3905921c2743c300a48d9494d29032f1389fc142e718d6978fb2/pytest_httpserver-1.1.3-py3-none-any.whl", hash = "sha256:5f84757810233e19e2bb5287f3826a71c97a3740abe3a363af9155c0f82fdbb9", size = 21000, upload-time = "2025-04-10T08:17:13.906Z" },
+]
+
+[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1984,18 +2000,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/97/bf44e6c6bd8ddbb99943baf7ba8b1a8485bcd2fe0e55e5708d7fee4ff1ae/requests_file-2.1.0.tar.gz", hash = "sha256:0f549a3f3b0699415ac04d167e9cb39bccfb730cb832b4d20be3d9867356e658", size = 6891, upload-time = "2024-05-21T16:28:00.24Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/25/dd878a121fcfdf38f52850f11c512e13ec87c2ea72385933818e5b6c15ce/requests_file-2.1.0-py2.py3-none-any.whl", hash = "sha256:cf270de5a4c5874e84599fc5778303d496c10ae5e870bfa378818f35d21bda5c", size = 4244, upload-time = "2024-05-21T16:27:57.733Z" },
-]
-
-[[package]]
-name = "respx"
-version = "0.22.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
 ]
 
 [[package]]
@@ -2498,6 +2502,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/f9/0ba83eaa0df9b9e9d1efeb2ea351d0677c37d41ee5d0f91e98423c7281c9/werkzeug-3.0.6.tar.gz", hash = "sha256:a8dd59d4de28ca70471a34cba79bed5f7ef2e036a76b3ab0835474246eb41f8d", size = 805170, upload-time = "2024-10-25T18:52:31.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/69/05837f91dfe42109203ffa3e488214ff86a6d68b2ed6c167da6cdc42349b/werkzeug-3.0.6-py3-none-any.whl", hash = "sha256:1bc0c2310d2fbb07b1dd1105eba2f7af72f322e1e455f2f93c993bee8c8a5f17", size = 227979, upload-time = "2024-10-25T18:52:30.129Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Replace `respx` mocks with `pytest-httpserver` in tests