### PR TITLE
chore: Update to Crawlee v1.0.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 dependencies = [
     "apify-client>=2.0.0,<3.0.0",
     "apify-shared>=2.0.0,<3.0.0",
-    "crawlee@git+https://github.com/apify/crawlee-python.git@master",
+    "crawlee==1.0.0rc1",
     "cachetools>=5.5.0",
     "cryptography>=42.0.0",
     # TODO: ensure compatibility with the latest version of lazy-object-proxy

--- a/tests/integration/actor_source_base/requirements.txt
+++ b/tests/integration/actor_source_base/requirements.txt
@@ -1,4 +1,4 @@
 # The test fixture will put the Apify SDK wheel path on the next line
 APIFY_SDK_WHEEL_PLACEHOLDER
 uvicorn[standard]
-crawlee[parsel] @ git+https://github.com/apify/crawlee-python.git@master
+crawlee[parsel]==1.0.0rc1

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ requires-dist = [
     { name = "apify-client", specifier = ">=2.0.0,<3.0.0" },
     { name = "apify-shared", specifier = ">=2.0.0,<3.0.0" },
     { name = "cachetools", specifier = ">=5.5.0" },
-    { name = "crawlee", git = "https://github.com/apify/crawlee-python.git?rev=master" },
+    { name = "crawlee", specifier = "==1.0.0rc1" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "impit", specifier = ">=0.5.3" },
     { name = "lazy-object-proxy", specifier = "<1.11.0" },
@@ -477,8 +477,8 @@ toml = [
 
 [[package]]
 name = "crawlee"
-version = "0.6.13"
-source = { git = "https://github.com/apify/crawlee-python.git?rev=master#0650b7e097751b0cf6b190ef4c25b05e44169389" }
+version = "1.0.0rc1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "colorama" },
@@ -492,6 +492,10 @@ dependencies = [
     { name = "tldextract" },
     { name = "typing-extensions" },
     { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/1d/31d7710b54c78d12cdc359f8f30478714768cfdab669f4464a8632bb5db6/crawlee-1.0.0rc1.tar.gz", hash = "sha256:bf644826a030fb01c1c525d7da1a73f4ce3fb89671eca9544aa0fccc5e9eaaa6", size = 24822393, upload-time = "2025-08-22T06:46:29.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/68/fcb616bd86782c1445ad8b6d3b5ec40ce970adcda755deb5cc9347ba9fb0/crawlee-1.0.0rc1-py3-none-any.whl", hash = "sha256:748e54aea1884b2cc49e4cebbfb1842159dd2b93ae17284cd947fa8a066d137f", size = 274346, upload-time = "2025-08-22T06:46:27.035Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Update to Crawlee v1.0.0rc1 to be able to release SDK v3.0.0rc1.