### PR TITLE
refactor!: Test with crawlee branch storage-clients-and-configurations-2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 dependencies = [
     "apify-client>=2.0.0,<3.0.0",
     "apify-shared>=2.0.0,<3.0.0",
-    "crawlee==1.0.0rc1",
+    "crawlee @ git+https://github.com/apify/crawlee-python.git@storage-clients-and-configurations",
     "cachetools>=5.5.0",
     "cryptography>=42.0.0",
     # TODO: ensure compatibility with the latest version of lazy-object-proxy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 dependencies = [
     "apify-client>=2.0.0,<3.0.0",
     "apify-shared>=2.0.0,<3.0.0",
-    "crawlee @ git+https://github.com/apify/crawlee-python.git@storage-clients-and-configurations",
+    "crawlee @ git+https://github.com/apify/crawlee-python.git@storage-clients-and-configurations-2",
     "cachetools>=5.5.0",
     "cryptography>=42.0.0",
     # TODO: ensure compatibility with the latest version of lazy-object-proxy

--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -128,10 +128,6 @@ class _ActorType:
         self._configure_logging = configure_logging
         self._apify_client = self.new_client()
 
-        # Create an instance of the cloud storage client, the local storage client is obtained
-        # from the service locator.
-        self._cloud_storage_client = ApifyStorageClient()
-
         # Set the event manager based on whether the Actor is running on the platform or locally.
         self._event_manager = (
             ApifyEventManager(
@@ -281,6 +277,10 @@ class _ActorType:
 
         if _ActorType._is_any_instance_initialized:
             self.log.warning('Repeated Actor initialization detected - this is non-standard usage, proceed with care')
+
+        # Create an instance of the cloud storage client, the local storage client is obtained
+        # from the service locator
+        self._cloud_storage_client = ApifyStorageClient(configuration=self.configuration)
 
         # Make sure that the currently initialized instance is also available through the global `Actor` proxy
         cast('Proxy', Actor).__wrapped__ = self

--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -429,7 +429,6 @@ class _ActorType:
         return await Dataset.open(
             id=id,
             name=name,
-            configuration=self._configuration,
             storage_client=storage_client,
         )
 
@@ -463,7 +462,6 @@ class _ActorType:
         return await KeyValueStore.open(
             id=id,
             name=name,
-            configuration=self._configuration,
             storage_client=storage_client,
         )
 
@@ -500,7 +498,6 @@ class _ActorType:
         return await RequestQueue.open(
             id=id,
             name=name,
-            configuration=self._configuration,
             storage_client=storage_client,
         )
 

--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -13,7 +13,6 @@ from pydantic import AliasChoices
 
 from apify_client import ApifyClientAsync
 from apify_shared.consts import ActorEnvVars, ActorExitCodes, ApifyEnvVars
-from crawlee import service_locator
 from crawlee.events import (
     Event,
     EventAbortingData,
@@ -25,7 +24,7 @@ from crawlee.events import (
 )
 
 from apify._charging import ChargeResult, ChargingManager, ChargingManagerImplementation
-from apify._configuration import Configuration
+from apify._configuration import Configuration, service_locator
 from apify._consts import EVENT_LISTENERS_TIMEOUT
 from apify._crypto import decrypt_input_secrets, load_private_key
 from apify._models import ActorRun
@@ -119,7 +118,9 @@ class _ActorType:
         self._exit_process = self._get_default_exit_process() if exit_process is None else exit_process
         self._is_exiting = False
 
-        self._configuration = configuration or Configuration.get_global_configuration()
+        if configuration:
+            service_locator.set_configuration(configuration)
+        self._configuration = service_locator.get_configuration()
         self._configure_logging = configure_logging
         self._apify_client = self.new_client()
 

--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -13,6 +13,7 @@ from pydantic import AliasChoices
 
 from apify_client import ApifyClientAsync
 from apify_shared.consts import ActorEnvVars, ActorExitCodes, ApifyEnvVars
+from crawlee import service_locator
 from crawlee.errors import ServiceConflictError
 from crawlee.events import (
     Event,
@@ -25,7 +26,7 @@ from crawlee.events import (
 )
 
 from apify._charging import ChargeResult, ChargingManager, ChargingManagerImplementation
-from apify._configuration import Configuration, service_locator
+from apify._configuration import Configuration
 from apify._consts import EVENT_LISTENERS_TIMEOUT
 from apify._crypto import decrypt_input_secrets, load_private_key
 from apify._models import ActorRun

--- a/src/apify/_configuration.py
+++ b/src/apify/_configuration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import traceback
 from datetime import datetime, timedelta
 from decimal import Decimal
 from logging import getLogger
@@ -417,6 +418,7 @@ class Configuration(CrawleeConfiguration):
         """
         if self.is_at_home and not self.disable_browser_sandbox:
             self.disable_browser_sandbox = True
+            logger.info('Stack trace:\n%s', ''.join(traceback.format_stack()))
             logger.warning('Actor is running on the Apify platform, `disable_browser_sandbox` was changed to True.')
         return self
 

--- a/src/apify/_configuration.py
+++ b/src/apify/_configuration.py
@@ -440,13 +440,21 @@ class ApifyServiceLocator(ServiceLocator):
     def get_configuration(self) -> Configuration:
         # ApifyServiceLocator can store any children of Crawlee Configuration, but in Apify context it is desired to
         # return Apify Configuration.
+        if isinstance(self._configuration, Configuration):
+            # If Apify configuration was already stored in service locator, return it.
+            return self._configuration
+
         stored_configuration = super().get_configuration()
+
         # Ensure the returned configuration is of type Apify Configuration.
+        # Most likely crawlee configuration was already set. Create Apify configuration from it.
+        # Env vars will have lower priority than the stored configuration.
         model_dump = stored_configuration.model_dump()
         # The configuration will read env variables first and overridden with stored_configuration
         _config = Configuration()
         for key in model_dump:
-            setattr(_config, key, model_dump[key])
+            if model_dump[key]:
+                setattr(_config, key, model_dump[key])
         return _config
 
 

--- a/src/apify/scrapy/extensions/_httpcache.py
+++ b/src/apify/scrapy/extensions/_httpcache.py
@@ -56,7 +56,6 @@ class ApifyCacheStorage:
                 storage_client = ApifyStorageClient()
                 return await KeyValueStore.open(
                     name=kvs_name,
-                    configuration=configuration,
                     storage_client=storage_client,
                 )
             return await KeyValueStore.open(name=kvs_name)

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -53,7 +53,6 @@ class ApifyScheduler(BaseScheduler):
             if configuration.is_at_home:
                 storage_client = ApifyStorageClient()
                 return await RequestQueue.open(
-                    configuration=configuration,
                     storage_client=storage_client,
                 )
             return await RequestQueue.open()

--- a/src/apify/storage_clients/_apify/_storage_client.py
+++ b/src/apify/storage_clients/_apify/_storage_client.py
@@ -4,12 +4,12 @@ from typing import TYPE_CHECKING
 
 from typing_extensions import override
 
+from crawlee import service_locator
 from crawlee.storage_clients._base import StorageClient
 
 from ._dataset_client import ApifyDatasetClient
 from ._key_value_store_client import ApifyKeyValueStoreClient
 from ._request_queue_client import ApifyRequestQueueClient
-from apify._configuration import service_locator
 from apify._utils import docs_group
 
 if TYPE_CHECKING:
@@ -40,12 +40,13 @@ class ApifyStorageClient(StorageClient):
         # Import here to avoid circular imports.
         from apify import Configuration as ApifyConfiguration  # noqa: PLC0415
 
-        if isinstance(self._configuration, ApifyConfiguration):
-            return await ApifyDatasetClient.open(id=id, name=name, configuration=self._configuration)
+        configuration = configuration or ApifyConfiguration.get_global_configuration()
+        if isinstance(configuration, ApifyConfiguration):
+            return await ApifyDatasetClient.open(id=id, name=name, configuration=configuration)
 
         raise TypeError(
             f'Expected "configuration" to be an instance of "apify.Configuration", '
-            f'but got {type(self._configuration).__name__} instead.'
+            f'but got {type(configuration).__name__} instead.'
         )
 
     @override
@@ -59,12 +60,13 @@ class ApifyStorageClient(StorageClient):
         # Import here to avoid circular imports.
         from apify import Configuration as ApifyConfiguration  # noqa: PLC0415
 
-        if isinstance(self._configuration, ApifyConfiguration):
-            return await ApifyKeyValueStoreClient.open(id=id, name=name, configuration=self._configuration)
+        configuration = configuration or ApifyConfiguration.get_global_configuration()
+        if isinstance(configuration, ApifyConfiguration):
+            return await ApifyKeyValueStoreClient.open(id=id, name=name, configuration=configuration)
 
         raise TypeError(
             f'Expected "configuration" to be an instance of "apify.Configuration", '
-            f'but got {type(self._configuration).__name__} instead.'
+            f'but got {type(configuration).__name__} instead.'
         )
 
     @override
@@ -78,15 +80,11 @@ class ApifyStorageClient(StorageClient):
         # Import here to avoid circular imports.
         from apify import Configuration as ApifyConfiguration  # noqa: PLC0415
 
-        if isinstance(self._configuration, ApifyConfiguration):
-            return await ApifyRequestQueueClient.open(id=id, name=name, configuration=self._configuration)
+        configuration = configuration or ApifyConfiguration.get_global_configuration()
+        if isinstance(configuration, ApifyConfiguration):
+            return await ApifyRequestQueueClient.open(id=id, name=name, configuration=configuration)
 
         raise TypeError(
             f'Expected "configuration" to be an instance of "apify.Configuration", '
-            f'but got {type(self._configuration).__name__} instead.'
+            f'but got {type(configuration).__name__} instead.'
         )
-
-    @override
-    def create_client(self, configuration: Configuration) -> ApifyStorageClient:
-        """Create a storage client from an existing storage client potentially just replacing the configuration."""
-        return ApifyStorageClient(configuration)

--- a/tests/integration/actor_source_base/requirements.txt
+++ b/tests/integration/actor_source_base/requirements.txt
@@ -1,4 +1,4 @@
 # The test fixture will put the Apify SDK wheel path on the next line
 APIFY_SDK_WHEEL_PLACEHOLDER
 uvicorn[standard]
-crawlee[parsel]==1.0.0rc1
+crawlee[parsel] @ git+https://github.com/apify/crawlee-python.git@storage-clients-and-configurations

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -60,16 +60,8 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
         service_locator._storage_client = None
         service_locator._storage_instance_manager = None
 
-        # Reset the retrieval flags.
-        service_locator._configuration_was_retrieved = False
-        service_locator._event_manager_was_retrieved = False
-        service_locator._storage_client_was_retrieved = False
-
         # Verify that the test environment was set up correctly.
         assert os.environ.get(ApifyEnvVars.LOCAL_STORAGE_DIR) == str(tmp_path)
-        assert service_locator._configuration_was_retrieved is False
-        assert service_locator._storage_client_was_retrieved is False
-        assert service_locator._event_manager_was_retrieved is False
 
     return _prepare_test_env
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -58,7 +58,7 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
         service_locator._configuration = None
         service_locator._event_manager = None
         service_locator._storage_client = None
-        service_locator._storage_instance_manager = None
+        service_locator.storage_instance_manager.clear_cache()
 
         # Verify that the test environment was set up correctly.
         assert os.environ.get(ApifyEnvVars.LOCAL_STORAGE_DIR) == str(tmp_path)

--- a/tests/unit/actor/test_configuration.py
+++ b/tests/unit/actor/test_configuration.py
@@ -1,7 +1,10 @@
 import pytest
 
 from crawlee.configuration import Configuration as CrawleeConfiguration
+from crawlee.crawlers import BasicCrawler
+from crawlee.errors import ServiceConflictError
 
+from apify import Actor
 from apify import Configuration as ApifyConfiguration
 from apify._configuration import service_locator
 
@@ -28,10 +31,108 @@ def test_disable_browser_sandbox(
 
 def test_apify_configuration_is_always_used() -> None:
     """Set Crawlee Configuration in service_locator and verify that Apify Configuration is returned."""
-    # Some value to verify
-    max_used_cpu_ratio = 0.123456
+    max_used_cpu_ratio = 0.123456  # Some unique value to verify configuration
     service_locator.set_configuration(CrawleeConfiguration(max_used_cpu_ratio=max_used_cpu_ratio))
 
     returned_config = service_locator.get_configuration()
     assert returned_config.max_used_cpu_ratio == max_used_cpu_ratio
     assert isinstance(returned_config, ApifyConfiguration)
+
+
+async def test_existing_apify_config_respected_by_actor() -> None:
+    """Set Apify Configuration in service_locator and verify that Actor respects it."""
+    max_used_cpu_ratio = 0.123456  # Some unique value to verify configuration
+    apify_config = ApifyConfiguration(max_used_cpu_ratio=max_used_cpu_ratio)
+    service_locator.set_configuration(apify_config)
+    async with Actor:
+        pass
+
+    returned_config = service_locator.get_configuration()
+    assert returned_config is apify_config
+
+
+async def test_existing_crawlee_config_respected_by_actor() -> None:
+    """Set Crawlee Configuration in service_locator and verify that Actor respects it."""
+    max_used_cpu_ratio = 0.123456  # Some unique value to verify configuration
+    crawlee_config = CrawleeConfiguration(max_used_cpu_ratio=max_used_cpu_ratio)
+    service_locator.set_configuration(crawlee_config)
+    async with Actor:
+        pass
+
+    returned_config = service_locator.get_configuration()
+    assert returned_config is not crawlee_config
+    assert isinstance(returned_config, ApifyConfiguration)
+    # Make sure the Crawlee Configuration was used to create returned Apify Configuration
+    assert returned_config.max_used_cpu_ratio == max_used_cpu_ratio
+
+
+async def test_existing_apify_config_throws_error_when_set_in_actor() -> None:
+    """Test that passing explicit configuration to actor after service locator configuration was already set,
+    raises exception."""
+    service_locator.set_configuration(ApifyConfiguration())
+    with pytest.raises(ServiceConflictError):
+        async with Actor(configuration=ApifyConfiguration()):
+            pass
+
+
+async def test_setting_config_after_actor_raises_exception() -> None:
+    """Test that passing setting configuration in service locator after actor wa created raises an exception."""
+    async with Actor():
+        with pytest.raises(ServiceConflictError):
+            service_locator.set_configuration(ApifyConfiguration())
+
+
+async def test_actor_using_input_configuration() -> None:
+    """Test that passing setting configuration in service locator after actor wa created raises an exception."""
+    apify_config = ApifyConfiguration()
+    async with Actor(configuration=apify_config):
+        pass
+
+    assert service_locator.get_configuration() is apify_config
+
+
+async def test_crawler_implicit_configuration_through_actor() -> None:
+    """Test that crawler uses Actor configuration unless explicit configuration was passed to it."""
+    apify_config = ApifyConfiguration()
+    async with Actor(configuration=apify_config):
+        crawler = BasicCrawler()
+
+    assert crawler._service_locator.get_configuration() is apify_config
+    assert service_locator.get_configuration() is apify_config
+
+
+async def test_crawler_implicit_configuration() -> None:
+    """Test that crawler and Actor use implicit service_locator based configuration unless explicit configuration
+    was passed to them."""
+    async with Actor():
+        crawler_1 = BasicCrawler()
+
+    assert service_locator.get_configuration() is crawler_1._service_locator.get_configuration()
+
+
+async def test_crawlers_own_configuration() -> None:
+    """Test that crawlers can use own configurations without crashing."""
+    config_actor = ApifyConfiguration()
+    apify_crawler_1 = ApifyConfiguration()
+    apify_crawler_2 = ApifyConfiguration()
+
+    async with Actor(configuration=config_actor):
+        crawler_1 = BasicCrawler(configuration=apify_crawler_1)
+        crawler_2 = BasicCrawler(configuration=apify_crawler_2)
+
+    assert service_locator.get_configuration() is config_actor
+    assert crawler_1._service_locator.get_configuration() is apify_crawler_1
+    assert crawler_2._service_locator.get_configuration() is apify_crawler_2
+
+
+async def test_crawler_global_configuration() -> None:
+    """Test that crawler and Actor use explicit service_locator based configuration unless explicit configuration
+    was passed to them."""
+    config_global = ApifyConfiguration()
+    service_locator.set_configuration(config_global)
+
+    async with Actor():
+        crawler_1 = BasicCrawler()
+
+    assert service_locator.get_configuration() is config_global
+    assert crawler_1._service_locator.get_configuration() is config_global

--- a/tests/unit/actor/test_configuration.py
+++ b/tests/unit/actor/test_configuration.py
@@ -1,6 +1,9 @@
 import pytest
 
-from apify import Configuration
+from crawlee.configuration import Configuration as CrawleeConfiguration
+
+from apify import Configuration as ApifyConfiguration
+from apify._configuration import service_locator
 
 
 @pytest.mark.parametrize(
@@ -16,6 +19,19 @@ def test_disable_browser_sandbox(
     *, is_at_home: bool, disable_browser_sandbox_in: bool, disable_browser_sandbox_out: bool
 ) -> None:
     assert (
-        Configuration(is_at_home=is_at_home, disable_browser_sandbox=disable_browser_sandbox_in).disable_browser_sandbox
+        ApifyConfiguration(
+            is_at_home=is_at_home, disable_browser_sandbox=disable_browser_sandbox_in
+        ).disable_browser_sandbox
         == disable_browser_sandbox_out
     )
+
+
+def test_apify_configuration_is_always_used() -> None:
+    """Set Crawlee Configuration in service_locator and verify that Apify Configuration is returned."""
+    # Some value to verify
+    max_used_cpu_ratio = 0.123456
+    service_locator.set_configuration(CrawleeConfiguration(max_used_cpu_ratio=max_used_cpu_ratio))
+
+    returned_config = service_locator.get_configuration()
+    assert returned_config.max_used_cpu_ratio == max_used_cpu_ratio
+    assert isinstance(returned_config, ApifyConfiguration)

--- a/tests/unit/actor/test_configuration.py
+++ b/tests/unit/actor/test_configuration.py
@@ -136,3 +136,26 @@ async def test_crawler_global_configuration() -> None:
 
     assert service_locator.get_configuration() is config_global
     assert crawler_1._service_locator.get_configuration() is config_global
+
+
+async def test_storage_retrieved_is_different_with_different_config() -> None:
+    """Test that retrieving storage depends on used configuration."""
+    config_actor = ApifyConfiguration()
+    apify_crawler_1 = ApifyConfiguration()
+
+    async with Actor(configuration=config_actor):
+        actor_kvs = await Actor.open_key_value_store()
+        crawler_1 = BasicCrawler(configuration=apify_crawler_1)
+        crawler_kvs = await crawler_1.get_key_value_store()
+
+    assert actor_kvs is not crawler_kvs
+
+
+async def test_storage_retrieved_is_same_with_same_config() -> None:
+    """Test that retrieving storage is same if same configuration is used."""
+    async with Actor():
+        actor_kvs = await Actor.open_key_value_store()
+        crawler_1 = BasicCrawler()
+        crawler_kvs = await crawler_1.get_key_value_store()
+
+    assert actor_kvs is crawler_kvs

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,9 +13,9 @@ from pytest_httpserver import HTTPServer
 
 from apify_client import ApifyClientAsync
 from apify_shared.consts import ApifyEnvVars
-from crawlee import service_locator
 
 import apify._actor
+from apify._configuration import service_locator
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -51,16 +51,8 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
         service_locator._storage_client = None
         service_locator._storage_instance_manager = None
 
-        # Reset the retrieval flags.
-        service_locator._configuration_was_retrieved = False
-        service_locator._event_manager_was_retrieved = False
-        service_locator._storage_client_was_retrieved = False
-
         # Verify that the test environment was set up correctly.
         assert os.environ.get(ApifyEnvVars.LOCAL_STORAGE_DIR) == str(tmp_path)
-        assert service_locator._configuration_was_retrieved is False
-        assert service_locator._storage_client_was_retrieved is False
-        assert service_locator._event_manager_was_retrieved is False
 
     return _prepare_test_env
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,9 +13,9 @@ from pytest_httpserver import HTTPServer
 
 from apify_client import ApifyClientAsync
 from apify_shared.consts import ApifyEnvVars
+from crawlee import service_locator
 
 import apify._actor
-from apify._configuration import service_locator
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -49,7 +49,7 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
         service_locator._configuration = None
         service_locator._event_manager = None
         service_locator._storage_client = None
-        service_locator._storage_instance_manager = None
+        service_locator.storage_instance_manager.clear_cache()
 
         # Verify that the test environment was set up correctly.
         assert os.environ.get(ApifyEnvVars.LOCAL_STORAGE_DIR) == str(tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ toml = [
 [[package]]
 name = "crawlee"
 version = "0.6.13"
-source = { git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations-2#a1746f37014f9caccb8f2dbdeacf1e62244e1f09" }
+source = { git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations-2#07ffa190661b026d3fa077aea8e1bc745c48aea9" }
 dependencies = [
     { name = "cachetools" },
     { name = "colorama" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -76,7 +76,7 @@ requires-dist = [
     { name = "apify-client", specifier = ">=2.0.0,<3.0.0" },
     { name = "apify-shared", specifier = ">=2.0.0,<3.0.0" },
     { name = "cachetools", specifier = ">=5.5.0" },
-    { name = "crawlee", specifier = "==1.0.0rc1" },
+    { name = "crawlee", git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "impit", specifier = ">=0.5.3" },
     { name = "lazy-object-proxy", specifier = "<1.11.0" },
@@ -477,8 +477,8 @@ toml = [
 
 [[package]]
 name = "crawlee"
-version = "1.0.0rc1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.6.13"
+source = { git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations#86c42444123a9b08ad7a7aedc3713308712c7d2b" }
 dependencies = [
     { name = "cachetools" },
     { name = "colorama" },
@@ -492,10 +492,6 @@ dependencies = [
     { name = "tldextract" },
     { name = "typing-extensions" },
     { name = "yarl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/1d/31d7710b54c78d12cdc359f8f30478714768cfdab669f4464a8632bb5db6/crawlee-1.0.0rc1.tar.gz", hash = "sha256:bf644826a030fb01c1c525d7da1a73f4ce3fb89671eca9544aa0fccc5e9eaaa6", size = 24822393, upload-time = "2025-08-22T06:46:29.831Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/68/fcb616bd86782c1445ad8b6d3b5ec40ce970adcda755deb5cc9347ba9fb0/crawlee-1.0.0rc1-py3-none-any.whl", hash = "sha256:748e54aea1884b2cc49e4cebbfb1842159dd2b93ae17284cd947fa8a066d137f", size = 274346, upload-time = "2025-08-22T06:46:27.035Z" },
 ]
 
 [package.optional-dependencies]
@@ -1593,16 +1589,15 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.10.1"
+version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
-    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/d4/9dfbe238f45ad8b168f5c96ee49a3df0598ce18a0795a983b419949ce65b/pydantic_settings-2.6.1.tar.gz", hash = "sha256:e0f92546d8a9923cb8941689abf85d6601a8c19a23e97a34b2964a2e3f813ca0", size = 75646, upload-time = "2024-11-01T11:00:05.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235, upload-time = "2025-06-24T13:26:45.485Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f9/ff95fd7d760af42f647ea87f9b8a383d891cdb5e5dbd4613edaeb094252a/pydantic_settings-2.6.1-py3-none-any.whl", hash = "sha256:7fb0637c786a558d3103436278a7c4f1cfd29ba8973238a50c5bb9a55387da87", size = 28595, upload-time = "2024-11-01T11:00:02.64Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ toml = [
 [[package]]
 name = "crawlee"
 version = "0.6.13"
-source = { git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations#dd5f9146c17e04b05a814c6e0006f06ea8ded90f" }
+source = { git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations#430f2ad7e7d266ad35abe97b64a9709d81aab7f1" }
 dependencies = [
     { name = "cachetools" },
     { name = "colorama" },

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ toml = [
 [[package]]
 name = "crawlee"
 version = "0.6.13"
-source = { git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations#86c42444123a9b08ad7a7aedc3713308712c7d2b" }
+source = { git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations#dd5f9146c17e04b05a814c6e0006f06ea8ded90f" }
 dependencies = [
     { name = "cachetools" },
     { name = "colorama" },

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ requires-dist = [
     { name = "apify-client", specifier = ">=2.0.0,<3.0.0" },
     { name = "apify-shared", specifier = ">=2.0.0,<3.0.0" },
     { name = "cachetools", specifier = ">=5.5.0" },
-    { name = "crawlee", git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations" },
+    { name = "crawlee", git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations-2" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "impit", specifier = ">=0.5.3" },
     { name = "lazy-object-proxy", specifier = "<1.11.0" },
@@ -478,7 +478,7 @@ toml = [
 [[package]]
 name = "crawlee"
 version = "0.6.13"
-source = { git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations#430f2ad7e7d266ad35abe97b64a9709d81aab7f1" }
+source = { git = "https://github.com/apify/crawlee-python.git?rev=storage-clients-and-configurations-2#a1746f37014f9caccb8f2dbdeacf1e62244e1f09" }
 dependencies = [
     { name = "cachetools" },
     { name = "colorama" },


### PR DESCRIPTION
This PR is for testing in CI.
It is SDK related changes for the Crawlee branch storage-clients-and-configurations-2

TODO: Create a proper way of patching global service_locator to return Apify Configuration and not Crawlee configuration. Currently working hack is implemented, not very nice.