### PR TITLE
chore: add patch_propagate_logger fixture

### DIFF
--- a/tests/unit/actor/test_actor_helpers.py
+++ b/tests/unit/actor/test_actor_helpers.py
@@ -122,7 +122,6 @@ async def test_abort_actor_run(apify_client_async_patcher: ApifyClientAsyncPatch
 # NOTE: The following methods are properly tested using integrations tests.
 
 
-@pytest.mark.skip(reason='There are issues with log propagation to caplog, see issue #462.')
 async def test_metamorph_fails_locally(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level('WARNING')
     async with Actor:
@@ -133,7 +132,6 @@ async def test_metamorph_fails_locally(caplog: pytest.LogCaptureFixture) -> None
     assert 'Actor.metamorph() is only supported when running on the Apify platform.' in caplog.records[0].message
 
 
-@pytest.mark.skip(reason='There are issues with log propagation to caplog, see issue #462.')
 async def test_reboot_fails_locally(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level('WARNING')
     async with Actor:
@@ -144,7 +142,6 @@ async def test_reboot_fails_locally(caplog: pytest.LogCaptureFixture) -> None:
     assert 'Actor.reboot() is only supported when running on the Apify platform.' in caplog.records[0].message
 
 
-@pytest.mark.skip(reason='There are issues with log propagation to caplog, see issue #462.')
 async def test_add_webhook_fails_locally(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level('WARNING')
     async with Actor:
@@ -157,7 +154,6 @@ async def test_add_webhook_fails_locally(caplog: pytest.LogCaptureFixture) -> No
     assert 'Actor.add_webhook() is only supported when running on the Apify platform.' in caplog.records[0].message
 
 
-@pytest.mark.skip(reason='There are issues with log propagation to caplog, see issue #462.')
 async def test_set_status_message_locally(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level('INFO')
     async with Actor:
@@ -169,7 +165,6 @@ async def test_set_status_message_locally(caplog: pytest.LogCaptureFixture) -> N
     assert '[Status message]: test-status-message' in matching_records[0].message
 
 
-@pytest.mark.skip(reason='There are issues with log propagation to caplog, see issue #462.')
 async def test_set_terminal_status_message_locally(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level('INFO')
     async with Actor:

--- a/tests/unit/actor/test_actor_log.py
+++ b/tests/unit/actor/test_actor_log.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import contextlib
 import logging
-
-import pytest
+from typing import TYPE_CHECKING
 
 from apify import Actor
 from apify.log import logger
 
+if TYPE_CHECKING:
+    import pytest
 
-@pytest.mark.skip(reason='There are issues with log propagation to caplog, see issue #462.')
+
 async def test_actor_logs_messages_correctly(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger='apify')
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,10 +16,31 @@ from apify_shared.consts import ApifyEnvVars
 from crawlee import service_locator
 
 import apify._actor
+import apify.log
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
+    from logging import Logger
     from pathlib import Path
+
+
+@pytest.fixture
+def patch_propagate_logger(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Patch enabling `propagate` for the crawlee logger.
+
+    This is necessary for tests requiring log interception using `caplog`.
+    """
+
+    original_configure_logger = apify.log.configure_logger
+
+    def propagate_logger(logger: Logger, **kwargs: Any) -> None:
+        original_configure_logger(logger, **kwargs)
+        logger.propagate = True
+
+    monkeypatch.setattr('crawlee._log_config.configure_logger', propagate_logger)
+    monkeypatch.setattr(apify.log, 'configure_logger', propagate_logger)
+    yield
+    monkeypatch.undo()
 
 
 @pytest.fixture
@@ -66,7 +87,10 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
 
 
 @pytest.fixture(autouse=True)
-def _isolate_test_environment(prepare_test_env: Callable[[], None]) -> None:
+def _isolate_test_environment(
+    prepare_test_env: Callable[[], None],
+    patch_propagate_logger: None,  # noqa: ARG001
+) -> None:
     """Isolate the testing environment by resetting global state before and after each test.
 
     This fixture ensures that each test starts with a clean slate and that any modifications during the test

--- a/tests/unit/events/test_apify_event_manager.py
+++ b/tests/unit/events/test_apify_event_manager.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-@pytest.mark.skip(reason='There are issues with log propagation to caplog, see issue #462.')
 async def test_lifecycle_local(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger='apify')
     config = Configuration.get_global_configuration()

--- a/tests/unit/test_proxy_configuration.py
+++ b/tests/unit/test_proxy_configuration.py
@@ -472,10 +472,8 @@ async def test_initialize_prefering_password_from_env_over_calling_api(
 
 
 @pytest.mark.usefixtures('patched_impit_client')
-@pytest.mark.skip(reason='There are issues with log propagation to caplog, see issue #462.')
 async def test_initialize_with_manual_password_different_than_user_one(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
     httpserver: HTTPServer,
     patched_apify_client: ApifyClientAsync,
 ) -> None:
@@ -501,10 +499,6 @@ async def test_initialize_with_manual_password_different_than_user_one(
     assert proxy_configuration._password == different_dummy_password
     assert proxy_configuration.is_man_in_the_middle is True
 
-    assert len(caplog.records) == 1
-    assert caplog.records[0].levelname == 'WARNING'
-    assert 'The Apify Proxy password you provided belongs to a different user' in caplog.records[0].message
-
 
 @pytest.mark.usefixtures('patched_impit_client')
 async def test_initialize_when_not_connected(monkeypatch: pytest.MonkeyPatch, httpserver: HTTPServer) -> None:
@@ -526,7 +520,6 @@ async def test_initialize_when_not_connected(monkeypatch: pytest.MonkeyPatch, ht
         await proxy_configuration.initialize()
 
 
-@pytest.mark.skip(reason='There are issues with log propagation to caplog, see issue #462.')
 async def test_initialize_when_status_page_unavailable(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, httpserver: HTTPServer
 ) -> None:


### PR DESCRIPTION
### Description

- Add patch_propagate_logger fixture.

### Issues

- Closes: #462

### Testing

Updated the `test_initialize_with_manual_password_different_than_user_one` test, as it did not correspond to the changes made earlier in #468. 

