### PR TITLE
refactor: Delegate public url related functionality to client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
     "scraping",
 ]
 dependencies = [
-    "apify-client>=2.0.0,<3.0.0",
+    "apify-client>=2.2.0,<3.0.0",
     "apify-shared>=2.0.0,<3.0.0",
     "crawlee>=1.0.2,<2.0.0",
     "cachetools>=5.5.0",

--- a/src/apify/storage_clients/_apify/_utils.py
+++ b/src/apify/storage_clients/_apify/_utils.py
@@ -192,3 +192,30 @@ def unique_key_to_request_id(unique_key: str, *, request_id_length: int = 15) ->
 
     # Truncate the key to the desired length
     return url_safe_key[:request_id_length]
+
+
+def create_apify_client(configuration: Configuration) -> ApifyClientAsync:
+    """Create and return an ApifyClientAsync instance using the provided configuration."""
+    if not configuration.token:
+        raise ValueError(f'Apify storage client requires a valid token in Configuration (token={configuration.token}).')
+
+    api_url = configuration.api_base_url
+    if not api_url:
+        raise ValueError(f'Apify storage client requires a valid API URL in Configuration (api_url={api_url}).')
+
+    api_public_base_url = configuration.api_public_base_url
+    if not api_public_base_url:
+        raise ValueError(
+            'Apify storage client requires a valid API public base URL in Configuration '
+            f'(api_public_base_url={api_public_base_url}).'
+        )
+
+    # Create Apify client with the provided token and API URL.
+    return ApifyClientAsync(
+        token=configuration.token,
+        api_url=api_url,
+        api_public_url=api_public_base_url,
+        max_retries=8,
+        min_delay_between_retries_millis=500,
+        timeout_secs=360,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -73,7 +73,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "apify-client", specifier = ">=2.0.0,<3.0.0" },
+    { name = "apify-client", specifier = ">=2.2.0,<3.0.0" },
     { name = "apify-shared", specifier = ">=2.0.0,<3.0.0" },
     { name = "cachetools", specifier = ">=5.5.0" },
     { name = "crawlee", specifier = ">=1.0.2,<2.0.0" },
@@ -112,7 +112,7 @@ dev = [
 
 [[package]]
 name = "apify-client"
-version = "2.1.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apify-shared" },
@@ -120,9 +120,9 @@ dependencies = [
     { name = "impit" },
     { name = "more-itertools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/e5/0527749e9748faeb19ed38b05b1618507beacbc885711b9156b28966aea3/apify_client-2.1.0.tar.gz", hash = "sha256:328bc76eda161bed7211be6e4915833ebd56c87c11f623ab5276c5d718f970c8", size = 361484, upload-time = "2025-09-15T08:43:07.947Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/c3/52e441203019b492c7c9f14bd64361c72143bfb66209b742903f95e9012a/apify_client-2.2.0.tar.gz", hash = "sha256:5ac6a0d463b84a4c6785edb5d205ba34443919f87f859493205c8871e9aad9b9", size = 382205, upload-time = "2025-10-13T13:03:19.235Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/59/c7ec8577bb41bc33f4fa43f674f80aa3eb44e399fe448a8ba39d76ea75e4/apify_client-2.1.0-py3-none-any.whl", hash = "sha256:515a16b16ea3dba9cf05973a0900bb1ae8951c0154d1566c83ac6544d61af16c", size = 85485, upload-time = "2025-09-15T08:43:06.525Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ab/39acf2b24cb55e3202e2c1b6d34c34e16de647e14eee8b532c4fa467cd98/apify_client-2.2.0-py3-none-any.whl", hash = "sha256:8b70983fbf52790d9fbd6b567f5e93e084b2b3cdfa5e1f2af1122be37442d787", size = 85913, upload-time = "2025-10-13T13:03:17.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description
- Use the Apify client for creating a public URL. This was added in the latest release of the client:
  - https://github.com/apify/apify-client-python/pull/500
  - https://github.com/apify/apify-client-python/pull/506

- Refactor Apify storage creation to reduce code duplication

### Issues

- Closes: #612
- Related: #635