### PR TITLE
fix: Fix type of `cloud_storage_client` in `SmartApifyStorageClient`

### DIFF
--- a/src/apify/storage_clients/_apify/_models.py
+++ b/src/apify/storage_clients/_apify/_models.py
@@ -120,7 +120,7 @@ class RequestQueueStats(BaseModel):
     """The number of request queue reads."""
 
     storage_bytes: Annotated[int, Field(alias='storageBytes', default=0)]
-    """Storage size in Bytes."""
+    """Storage size in bytes."""
 
     write_count: Annotated[int, Field(alias='writeCount', default=0)]
     """The number of request queue writes."""


### PR DESCRIPTION
The type of `cloud_storage_client` in `SmartApifyStorageClient` should be `StorageClient`, not just `ApifyStorageClient`, as we want to support using other storage clients on the Apify platform as well.

Other minor changes:
- I've also updated the method order for consistency: constants -> public -> private.
- `ApifyStorageClient` is in `single` access mode by default.
