### PR TITLE
fix: make the `ActorRun.stats` optional

### DIFF
--- a/src/apify/_models.py
+++ b/src/apify/_models.py
@@ -107,7 +107,7 @@ class ActorRun(BaseModel):
     is_status_message_terminal: Annotated[bool | None, Field(alias='isStatusMessageTerminal')] = None
     meta: Annotated[ActorRunMeta, Field(alias='meta')]
     # Optionality, does not correspond to the documentation about 'stats' - https://docs.apify.com/api/v2/actor-run-get
-    # But at the moment, `stats` may be missing from the API response.
+    # But at the moment, `stats` may be missing in the API response.
     stats: Annotated[ActorRunStats | None, Field(alias='stats')] = None
     options: Annotated[ActorRunOptions, Field(alias='options')]
     build_id: Annotated[str, Field(alias='buildId')]


### PR DESCRIPTION
This PR fixes a validation error for the response received from the endpoint - https://docs.apify.com/api/v2/actor-run-get
When, for some reason, the `stats` data is missing in the response. However, this does not comply with the API documentation.