### PR TITLE
chore: Add rspack.core <1.6.0 constarint to avoid docs build issues

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,6 +12,7 @@
                 "@docusaurus/faster": "^3.8.1",
                 "@docusaurus/plugin-client-redirects": "^3.8.1",
                 "@docusaurus/preset-classic": "^3.8.1",
+                "@rspack/core": "<1.6.0",
                 "@signalwire/docusaurus-plugin-llms-txt": "^1.2.2",
                 "clsx": "^2.0.0",
                 "docusaurus-gtm-plugin": "^0.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -34,7 +34,8 @@
         "raw-loader": "^4.0.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "unist-util-visit": "^5.0.0"
+        "unist-util-visit": "^5.0.0",
+        "@rspack/core": "<1.6.0"
     },
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.4.0",


### PR DESCRIPTION
Temporarily add `rspack.core` <1.6.0 constraint to avoid docs build issues.

Should be reverted later: https://github.com/apify/apify-sdk-python/issues/659 
