### PR TITLE
fix: Avoid charge calls with count=0

### DIFF
--- a/src/apify/_charging.py
+++ b/src/apify/_charging.py
@@ -226,7 +226,8 @@ class ChargingManagerImplementation(ChargingManager):
         # START OF CRITICAL SECTION - no awaits here
 
         # Determine the maximum amount of events that can be charged within the budget
-        charged_count = min(count, self.calculate_max_event_charge_count_within_limit(event_name) or count)
+        max_chargeable = self.calculate_max_event_charge_count_within_limit(event_name)
+        charged_count = min(count, max_chargeable if max_chargeable is not None else count)
 
         if charged_count == 0:
             return ChargeResult(


### PR DESCRIPTION
- follow up to https://github.com/apify/apify-sdk-python/pull/664
- I haven't managed to reproduce the actual bug with a test yet, so that will happen later
