### PR TITLE
fix(website): Align Run on Apify button

### DIFF
--- a/website/src/components/RunnableCodeBlock.module.css
+++ b/website/src/components/RunnableCodeBlock.module.css
@@ -1,6 +1,6 @@
 .button {
     display: inline-block;
-    padding: 3px 10px;
+    padding: 4px 10px;
     position: absolute;
     top: calc(var(--ifm-pre-padding) / 2);
     right: 9px;
@@ -14,6 +14,7 @@
     opacity: 0.7;
     font-weight: 600;
     width: 155px;
+    margin-top: 1px;
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
Before
<img width="314" height="223" alt="image" src="https://github.com/user-attachments/assets/599e4cb7-7821-4f07-8fab-7fcb669e4c2e" />

After
<img width="370" height="264" alt="image" src="https://github.com/user-attachments/assets/5669332c-dfb3-4d23-b9bb-169dcc8e4554" />

bugs duty, reported 
https://apify.slack.com/archives/C0L33UM7Z/p1763628427303849
