### PR TITLE
feat: add `ACTOR_PERMISSION_LEVEL` to the configuration

### DIFF
--- a/src/apify/_configuration.py
+++ b/src/apify/_configuration.py
@@ -64,7 +64,6 @@ class Configuration(CrawleeConfiguration):
     actor_permission_level: Annotated[
         str | None,
         Field(
-            alias='actor_permission_level',
             description='Permission level the Actor is run under.',
         ),
     ] = None


### PR DESCRIPTION
This adds the `ACTOR_PERMISSION_LEVEL` environmental variable as `actor_permission_level` to the Configuration,

Closes #690 