### PR TITLE
fix: pass name instead of id for name param in SmartApifyStorageClient

### DIFF
--- a/src/apify/storage_clients/_smart_apify/_storage_client.py
+++ b/src/apify/storage_clients/_smart_apify/_storage_client.py
@@ -74,7 +74,7 @@ class SmartApifyStorageClient(StorageClient):
         configuration: CrawleeConfiguration | None = None,
     ) -> DatasetClient:
         return await self.get_suitable_storage_client().create_dataset_client(
-            id=id, name=id, alias=alias, configuration=configuration
+            id=id, name=name, alias=alias, configuration=configuration
         )
 
     @override
@@ -87,7 +87,7 @@ class SmartApifyStorageClient(StorageClient):
         configuration: CrawleeConfiguration | None = None,
     ) -> KeyValueStoreClient:
         return await self.get_suitable_storage_client().create_kvs_client(
-            id=id, name=id, alias=alias, configuration=configuration
+            id=id, name=name, alias=alias, configuration=configuration
         )
 
     @override
@@ -100,7 +100,7 @@ class SmartApifyStorageClient(StorageClient):
         configuration: CrawleeConfiguration | None = None,
     ) -> RequestQueueClient:
         return await self.get_suitable_storage_client().create_rq_client(
-            id=id, name=id, alias=alias, configuration=configuration
+            id=id, name=name, alias=alias, configuration=configuration
         )
 
     def get_suitable_storage_client(self, *, force_cloud: bool = False) -> StorageClient:


### PR DESCRIPTION
## Summary
- All three `create_*_client` methods in `SmartApifyStorageClient` (`create_dataset_client`, `create_kvs_client`, `create_rq_client`) were passing `name=id` instead of `name=name`
- This silently discarded the user-provided `name` argument and used the `id` value (often `None`) instead, breaking name-based storage opening entirely
- Simple copy-paste fix: `name=id` -> `name=name` in all three methods

## Test plan
- [ ] Verify existing tests pass
- [ ] Test opening a storage by name via `SmartApifyStorageClient` and confirm it resolves to the correct named storage instead of default

🤖 Generated with [Claude Code](https://claude.com/claude-code)