### PR TITLE
fix: stop silently swallowing exceptions in request queue

### DIFF
--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -235,8 +235,8 @@ class ApifyRequestQueueSharedClient:
                 processed_request=processed_request,
                 hydrated_request=request,
             )
-        except Exception as exc:
-            logger.debug(f'Error marking request {request.unique_key} as handled: {exc!s}')
+        except Exception:
+            logger.exception(f'Error marking request {request.unique_key} as handled')
             return None
         else:
             return processed_request
@@ -279,8 +279,8 @@ class ApifyRequestQueueSharedClient:
                 if forefront:
                     self._should_check_for_forefront_requests = True
 
-            except Exception as exc:
-                logger.debug(f'Error reclaiming request {request.unique_key}: {exc!s}')
+            except Exception:
+                logger.exception(f'Error reclaiming request {request.unique_key}')
                 return None
             else:
                 return processed_request

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -220,8 +220,8 @@ class ApifyRequestQueueSingleClient:
             self._requests_cache.pop(request_id)
             self._requests_in_progress.discard(request_id)
 
-        except Exception as exc:
-            logger.debug(f'Error marking request {request.unique_key} as handled: {exc!s}')
+        except Exception:
+            logger.exception(f'Error marking request {request.unique_key} as handled')
             return None
         else:
             return processed_request
@@ -263,8 +263,8 @@ class ApifyRequestQueueSingleClient:
                 self.metadata.handled_request_count -= 1
                 self.metadata.pending_request_count += 1
 
-        except Exception as exc:
-            logger.debug(f'Error reclaiming request {request.unique_key}: {exc!s}')
+        except Exception:
+            logger.exception(f'Error reclaiming request {request.unique_key}')
             return None
         else:
             return processed_request


### PR DESCRIPTION
## Summary
- Errors in `mark_request_as_handled` and `reclaim_request` in both the single and shared request queue clients were logged at `DEBUG` level, making API failures (network timeouts, auth errors, rate limits) effectively invisible
- Upgraded `logger.debug` to `logger.exception` in all 4 exception handlers so these errors are visible and include full tracebacks

## Test plan
- [x] Verify existing tests pass
- [x] Confirm that API errors in `_update_request` now produce visible log output with tracebacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)