### PR TITLE
test: prevent storage directory leak from randomized env vars test

### DIFF
--- a/tests/unit/actor/test_actor_env_helpers.py
+++ b/tests/unit/actor/test_actor_env_helpers.py
@@ -22,6 +22,8 @@ from apify_shared.consts import (
 from apify import Actor
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import pytest
 
 
@@ -31,11 +33,12 @@ async def test_actor_is_not_at_home_when_local() -> None:
         assert is_at_home is False
 
 
-async def test_get_env_with_randomized_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_get_env_with_randomized_env_vars(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     ignored_env_vars = {
         ApifyEnvVars.SDK_LATEST_VERSION,
         ApifyEnvVars.LOG_FORMAT,
         ApifyEnvVars.LOG_LEVEL,
+        ApifyEnvVars.LOCAL_STORAGE_DIR,
         ActorEnvVars.STANDBY_PORT,
         ApifyEnvVars.PERSIST_STORAGE,
     }
@@ -126,6 +129,10 @@ async def test_get_env_with_randomized_env_vars(monkeypatch: pytest.MonkeyPatch)
     expected_get_env[ApifyEnvVars.DEDICATED_CPUS.name.lower()] = float(
         expected_get_env[ApifyEnvVars.DEDICATED_CPUS.name.lower()]
     )
+
+    # LOCAL_STORAGE_DIR is excluded from randomization to avoid creating directories in the project root.
+    # Its value is set by the _isolate_test_environment fixture to tmp_path.
+    expected_get_env[ApifyEnvVars.LOCAL_STORAGE_DIR.name.lower()] = str(tmp_path)
 
     await Actor.init()
     assert Actor.get_env() == expected_get_env


### PR DESCRIPTION
## Summary
- `test_get_env_with_randomized_env_vars` was overriding `APIFY_LOCAL_STORAGE_DIR` with a random 10-char string (e.g. `KAHL8QER2W`), causing `Actor.init()` to create a leftover storage directory in the project root on every test run
- Excluded `LOCAL_STORAGE_DIR` from randomization and set the expected value to the `tmp_path` provided by the `_isolate_test_environment` fixture

## Test plan
- [x] `uv run poe lint` passes
- [x] `uv run poe unit-tests` passes (249 tests)
- [x] No leftover directories created in the project root after test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)