### PR TITLE
fix: Correct inverted return value in Scrapy scheduler enqueue_request

### DIFF
--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -136,7 +136,7 @@ class ApifyScheduler(BaseScheduler):
             raise
 
         logger.debug(f'rq.add_request result: {result}')
-        return bool(result.was_already_present)
+        return not bool(result.was_already_present)
 
     def next_request(self) -> Request | None:
         """Fetch the next request from the scheduler.


### PR DESCRIPTION
## Summary

- The `enqueue_request` method in `ApifyScheduler` was returning `bool(result.was_already_present)`, which incorrectly returned `True` for duplicates and `False` for newly enqueued requests
- Per Scrapy's `BaseScheduler` contract, `enqueue_request` should return `True` when the request was **successfully stored** (new) and `False` when rejected (duplicate)
  - See https://docs.scrapy.org/en/latest/topics/scheduler.html#scrapy.core.scheduler.BaseScheduler.enqueue_request
- One-line fix: `return not bool(result.was_already_present)`

## Test plan

- [x] CI passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>