### PR TITLE
fix: Use hashed request_id as cache key in shared RQ client reclaim_request

### DIFF
--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -267,9 +267,9 @@ class ApifyRequestQueueSharedClient:
                     self.metadata.pending_request_count += 1
 
                 # Update the cache
-                cache_key = request.unique_key
+                request_id = unique_key_to_request_id(request.unique_key)
                 self._cache_request(
-                    cache_key,
+                    request_id,
                     processed_request,
                     hydrated_request=request,
                 )


### PR DESCRIPTION
## Summary

- In `ApifyRequestQueueSharedClient.reclaim_request`, the cache key was set to `request.unique_key` (raw URL string) instead of the hashed `request_id` (via `unique_key_to_request_id`)
- Every other `_cache_request` call in the class uses the hashed `request_id`, creating an inconsistency that causes orphaned cache entries
- After reclaiming, future cache lookups by `request_id` would miss the reclaimed request, potentially causing re-fetches or incorrect processing

## Test plan

- [x] CI passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>