### PR TITLE
chore: access model_fields from class instead of instance

### DIFF
--- a/src/apify/_configuration.py
+++ b/src/apify/_configuration.py
@@ -505,7 +505,7 @@ class Configuration(CrawleeConfiguration):
         # Due to known Pydantic issue https://github.com/pydantic/pydantic/issues/9516, creating new instance of
         # Configuration from existing one in situation where environment can have some fields set by alias is very
         # unpredictable. Use the stable workaround.
-        for name in configuration.model_fields:
+        for name in type(configuration).model_fields:
             setattr(apify_configuration, name, getattr(configuration, name))
 
         return apify_configuration


### PR DESCRIPTION
## Summary

- Access `model_fields` from the class (`type(configuration).model_fields`) instead of the instance (`configuration.model_fields`) in `Configuration.from_configuration`

Since Pydantic V2.11, accessing `model_fields` on an instance emits a `PydanticDeprecatedSince211` deprecation warning (to be removed in V3.0).

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)