### PR TITLE
ci: Remove E2E tests concurrency group to allow parallel matrix jobs

### DIFF
--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -85,15 +85,7 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/master')
       }}
 
-    # E2E tests build and run Actors on the platform. The combination of max-parallel 2 with 16 pytest
-    # workers and a global concurrency group is a compromise between stability and performance - it keeps
-    # the platform's resource usage in check while still allowing reasonable test throughput.
-    concurrency:
-      group: e2e-tests
-      cancel-in-progress: false
-
     strategy:
-      max-parallel: 2
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.10", "3.14"]


### PR DESCRIPTION
- Relates: #785
- The Python SDK service account limits were increased as part of https://github.com/apify/apify-core/pull/25840.
- Removed max-parallel: 2, as it had no effect due to being overridden by the static concurrency group.
- Removed the static e2e-tests concurrency group to evaluate whether the new limits are sufficient. If not, we will either increase them further or introduce dedicated concurrency group limits.