### PR TITLE
fix: Fix f-string bugs in charging log message

### DIFF
--- a/src/apify/_charging.py
+++ b/src/apify/_charging.py
@@ -279,8 +279,8 @@ class ChargingManagerImplementation(ChargingManager):
         if charged_count < count:
             subject = 'instance' if count == 1 else 'instances'
             logger.info(
-                f"Charging {count} ${subject} of '{event_name}' event would exceed max_total_charge_usd "
-                '- only {charged_count} events were charged'
+                f"Charging {count} {subject} of '{event_name}' event would exceed max_total_charge_usd "
+                f'- only {charged_count} events were charged'
             )
 
         max_charge_count = self.calculate_max_event_charge_count_within_limit(event_name)


### PR DESCRIPTION
## Summary

- Fixed `${subject}` → `{subject}` in the charging log message — the `$` prefix caused the variable to be printed literally instead of interpolated.
  - @janbuchar, please confirm this is correct now
- Added missing `f` prefix to the continuation string so `{charged_count}` gets properly interpolated.

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)