### PR TITLE
fix(scrapy): Close AsyncThread on scheduler open() failure

### DIFF
--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -61,6 +61,7 @@ class ApifyScheduler(BaseScheduler):
         try:
             self._rq = self._async_thread.run_coro(open_rq())
         except Exception:
+            self._async_thread.close()
             traceback.print_exc()
             raise
 


### PR DESCRIPTION
## Summary

- Close `AsyncThread` in the `except` block of `ApifyScheduler.open()` before re-raising, preventing a thread leak when `open_rq()` fails (Scrapy only calls `close()` after a successful `open()`).

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)