### PR TITLE
chore: Bump Pytest from 8.4.2 to 9.0.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dev = [
     "pytest-httpserver<2.0.0",
     "pytest-timeout<3.0.0",
     "pytest-xdist<4.0.0",
-    "pytest<9.0.0",
+    "pytest<10.0.0",
     "ruff~=0.15.0",
     "setuptools", # setuptools are used by pytest but not explicitly required
     "ty~=0.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-04-07T08:38:48.471940825Z"
+exclude-newer = "2026-04-13T06:19:12.464268138Z"
 exclude-newer-span = "PT24H"
 
 [[package]]
@@ -105,7 +105,7 @@ dev = [
     { name = "poethepoet", specifier = "<1.0.0" },
     { name = "pre-commit", specifier = "<5.0.0" },
     { name = "pydoc-markdown", specifier = "<5.0.0" },
-    { name = "pytest", specifier = "<9.0.0" },
+    { name = "pytest", specifier = "<10.0.0" },
     { name = "pytest-asyncio", specifier = "<2.0.0" },
     { name = "pytest-cov", specifier = "<8.0.0" },
     { name = "pytest-httpserver", specifier = "<2.0.0" },
@@ -2049,7 +2049,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/d5/7b/65f55513d3c769fd6
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2060,9 +2060,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.4.2 to 9.0.3
- Relaxes the upper bound constraint from `<9.0.0` to `<10.0.0`
- Includes fix for [CVE-2025-71176](https://github.com/pytest-dev/pytest/issues/14343) (use of insecure temporary directory)

Same update as https://github.com/apify/apify-client-python/pull/721

### Why wasn't this done by Renovate?

Renovate [opened a PR](https://github.com/apify/apify-sdk-python/pull/670) for pytest v9 back on 2025-11-10, but the `uv lock` resolution failed because `pytest-asyncio~=1.2.0` at the time required `pytest>=8.2,<9` — making it incompatible with pytest 9. The PR was closed, and Renovate's ignore logic kicked in:

> Because you closed this PR without merging, Renovate will ignore this update. You will not get PRs for *any* future `9.x` releases.

Since then, `pytest-asyncio` has released a version compatible with pytest 9, resolving the conflict. But Renovate never retried because its "close = ignore forever" behavior blocked all future `9.x` PRs. A manual upgrade (this PR) is needed to unblock Renovate for future pytest updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)