### PR TITLE
ci: Extract docs versioning into reusable `manual_version_docs.yaml` workflow

### DIFF
--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -105,68 +105,12 @@ jobs:
   version_docs:
     name: Version docs
     needs: [release_prepare, changelog_update, pypi_publish]
-    runs-on: ubuntu-latest
-    outputs:
-      version_docs_commitish: ${{ steps.commit_versioned_docs.outputs.commit_long_sha }}
     permissions:
       contents: write
-    env:
-      NODE_VERSION: 22
-      PYTHON_VERSION: 3.14
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-          ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Python dependencies
-        run: uv run poe install-dev
-
-      - name: Install website dependencies
-        run: |
-          cd website
-          corepack enable
-          yarn install
-
-      - name: Snapshot the current version
-        run: |
-          cd website
-          VERSION="$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('../pyproject.toml').read_text())['project']['version'])")"
-          MAJOR_MINOR="$(echo "$VERSION" | cut -d. -f1-2)"
-          export MAJOR_MINOR
-          # Remove existing version if present (patch releases override)
-          rm -rf "versioned_docs/version-${MAJOR_MINOR}"
-          rm -rf "versioned_sidebars/version-${MAJOR_MINOR}-sidebars.json"
-          jq 'map(select(. != env.MAJOR_MINOR))' versions.json > tmp.json && mv tmp.json versions.json
-          # Build API reference and create version snapshots
-          bash build_api_reference.sh
-          npx docusaurus docs:version "$MAJOR_MINOR"
-          npx docusaurus api:version "$MAJOR_MINOR"
-
-      - name: Commit and push versioned docs
-        id: commit_versioned_docs
-        uses: EndBug/add-and-commit@v10
-        with:
-          add: "website/versioned_docs website/versioned_sidebars website/versions.json"
-          message: "docs: version ${{ needs.release_prepare.outputs.version_number }} docs [skip ci]"
-          default_author: github_actions
+    uses: ./.github/workflows/manual_version_docs.yaml
+    with:
+      ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
+    secrets: inherit
 
   doc_release:
     name: Doc release

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -84,15 +84,15 @@ jobs:
           yarn install
 
           # Extract version from pyproject.toml.
-          VERSION="$(uv version --short)"
-          MAJOR_MINOR="$(echo "$VERSION" | cut -d. -f1-2)"
-          MAJOR="$(echo "$VERSION" | cut -d. -f1)"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Version: $VERSION, Major.Minor: $MAJOR_MINOR, Major: $MAJOR"
+          FULL_VERSION="$(uv version --short)"
+          MAJOR_MINOR_VERSION="$(echo "$FULL_VERSION" | cut -d. -f1-2)"
+          MAJOR_VERSION="$(echo "$FULL_VERSION" | cut -d. -f1)"
+          echo "version=$FULL_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $FULL_VERSION, Major.Minor: $MAJOR_MINOR_VERSION, Major: $MAJOR_VERSION"
 
           # Find the existing version for this major in versions.json (if any).
           if [[ -f versions.json ]]; then
-            OLD_VERSION="$(jq -r --arg major "$MAJOR" '.[] | select(startswith($major + "."))' versions.json | head -1)"
+            OLD_VERSION="$(jq -r --arg major "$MAJOR_VERSION" '.[] | select(startswith($major + "."))' versions.json | head -1)"
           else
             OLD_VERSION=""
             echo "[]" > versions.json
@@ -100,18 +100,18 @@ jobs:
 
           # Remove only the specific old version for this major (if found).
           if [[ -n "$OLD_VERSION" ]]; then
-            echo "Removing old version $OLD_VERSION for major $MAJOR"
+            echo "Removing old version $OLD_VERSION for major $MAJOR_VERSION"
             rm -rf "versioned_docs/version-${OLD_VERSION}"
             rm -f "versioned_sidebars/version-${OLD_VERSION}-sidebars.json"
             jq --arg old "$OLD_VERSION" '[.[] | select(. != $old)]' versions.json > tmp.json && mv tmp.json versions.json
           else
-            echo "No existing version found for major $MAJOR, nothing to remove"
+            echo "No existing version found for major $MAJOR_VERSION, nothing to remove"
           fi
 
           # Build API reference and create Docusaurus version snapshots.
           bash build_api_reference.sh
-          uv run npx docusaurus docs:version "$MAJOR_MINOR"
-          uv run npx docusaurus api:version "$MAJOR_MINOR"
+          uv run npx docusaurus docs:version "$MAJOR_MINOR_VERSION"
+          uv run npx docusaurus api:version "$MAJOR_MINOR_VERSION"
 
       - name: Commit and push versioned docs
         id: commit_versioned_docs

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -30,7 +30,7 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: 22
+  NODE_VERSION: "22"
   PYTHON_VERSION: "3.14"
 
 jobs:

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -87,25 +87,22 @@ jobs:
           MAJOR="$(echo "$VERSION" | cut -d. -f1)"
           echo "Version: $VERSION, Major.Minor: $MAJOR_MINOR, Major: $MAJOR"
 
-          # Remove ALL existing versions for this major (not just exact major.minor match).
-          for dir in "versioned_docs/version-${MAJOR}."*; do
-            if [[ -d "$dir" ]]; then
-              echo "Removing $dir"
-              rm -rf "$dir"
-            fi
-          done
-          for file in "versioned_sidebars/version-${MAJOR}."*-sidebars.json; do
-            if [[ -f "$file" ]]; then
-              echo "Removing $file"
-              rm -f "$file"
-            fi
-          done
-
-          # Update versions.json to remove entries for this major version.
+          # Find the existing version for this major in versions.json (if any).
           if [[ -f versions.json ]]; then
-            jq --arg major "$MAJOR" '[.[] | select((split(".")[0]) != $major)]' versions.json > tmp.json && mv tmp.json versions.json
+            OLD_VERSION="$(jq -r --arg major "$MAJOR" '.[] | select(startswith($major + "."))' versions.json | head -1)"
           else
+            OLD_VERSION=""
             echo "[]" > versions.json
+          fi
+
+          # Remove only the specific old version for this major (if found).
+          if [[ -n "$OLD_VERSION" ]]; then
+            echo "Removing old version $OLD_VERSION for major $MAJOR"
+            rm -rf "versioned_docs/version-${OLD_VERSION}"
+            rm -f "versioned_sidebars/version-${OLD_VERSION}-sidebars.json"
+            jq --arg old "$OLD_VERSION" '[.[] | select(. != $old)]' versions.json > tmp.json && mv tmp.json versions.json
+          else
+            echo "No existing version found for major $MAJOR, nothing to remove"
           fi
 
           # Build API reference and create Docusaurus version snapshots.

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -46,7 +46,7 @@ jobs:
         id: resolve_ref
         run: |
           REF="${{ inputs.ref }}"
-          if [ -z "$REF" ]; then
+          if [[ -z "$REF" ]]; then
             REF="${{ github.event.repository.default_branch }}"
           fi
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
@@ -89,20 +89,20 @@ jobs:
 
           # Remove ALL existing versions for this major (not just exact major.minor match).
           for dir in "versioned_docs/version-${MAJOR}."*; do
-            if [ -d "$dir" ]; then
+            if [[ -d "$dir" ]]; then
               echo "Removing $dir"
               rm -rf "$dir"
             fi
           done
           for file in "versioned_sidebars/version-${MAJOR}."*-sidebars.json; do
-            if [ -f "$file" ]; then
+            if [[ -f "$file" ]]; then
               echo "Removing $file"
               rm -f "$file"
             fi
           done
 
           # Update versions.json to remove entries for this major version.
-          if [ -f versions.json ]; then
+          if [[ -f versions.json ]]; then
             jq --arg major "$MAJOR" '[.[] | select((split(".")[0]) != $major)]' versions.json > tmp.json && mv tmp.json versions.json
           else
             echo "[]" > versions.json
@@ -132,7 +132,7 @@ jobs:
         id: resolve_commitish
         run: |
           SHA="${{ steps.commit_versioned_docs.outputs.commit_long_sha }}"
-          if [ -z "$SHA" ]; then
+          if [[ -z "$SHA" ]]; then
             SHA="$(git rev-parse HEAD)"
           fi
           echo "commitish=$SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -90,22 +90,25 @@ jobs:
           echo "version=$FULL_VERSION" >> "$GITHUB_OUTPUT"
           echo "Version: $FULL_VERSION, Major.Minor: $MAJOR_MINOR_VERSION, Major: $MAJOR_VERSION"
 
-          # Find the existing version for this major in versions.json (if any).
+          # Find the existing versions for this major in versions.json (if any).
           if [[ -f versions.json ]]; then
-            OLD_VERSION="$(jq -r --arg major "$MAJOR_VERSION" '.[] | select(startswith($major + "."))' versions.json | head -1)"
+            OLD_VERSIONS="$(jq -r --arg major "$MAJOR_VERSION" '.[] | select(startswith($major + "."))' versions.json)"
           else
-            OLD_VERSION=""
+            OLD_VERSIONS=""
             echo "[]" > versions.json
           fi
 
-          # Remove only the specific old version for this major (if found).
-          if [[ -n "$OLD_VERSION" ]]; then
-            echo "Removing old version $OLD_VERSION for major $MAJOR_VERSION"
-            rm -rf "versioned_docs/version-${OLD_VERSION}"
-            rm -f "versioned_sidebars/version-${OLD_VERSION}-sidebars.json"
-            jq --arg old "$OLD_VERSION" '[.[] | select(. != $old)]' versions.json > tmp.json && mv tmp.json versions.json
+          # Remove all old versions for this major (if found).
+          if [[ -n "$OLD_VERSIONS" ]]; then
+            while IFS= read -r OLD_VERSION; do
+              [[ -z "$OLD_VERSION" ]] && continue
+              echo "Removing old version $OLD_VERSION for major $MAJOR_VERSION"
+              rm -rf "versioned_docs/version-${OLD_VERSION}"
+              rm -f "versioned_sidebars/version-${OLD_VERSION}-sidebars.json"
+            done <<< "$OLD_VERSIONS"
+            jq --arg major "$MAJOR_VERSION" 'map(select(startswith($major + ".") | not))' versions.json > tmp.json && mv tmp.json versions.json
           else
-            echo "No existing version found for major $MAJOR_VERSION, nothing to remove"
+            echo "No existing versions found for major $MAJOR_VERSION, nothing to remove"
           fi
 
           # Build API reference and create Docusaurus version snapshots.

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -92,13 +92,13 @@ jobs:
           echo "Version: $VERSION, Major.Minor: $MAJOR_MINOR, Major: $MAJOR"
 
           # Remove ALL existing versions for this major (not just exact major.minor match).
-          for dir in versioned_docs/version-${MAJOR}.*; do
+          for dir in "versioned_docs/version-${MAJOR}."*; do
             if [ -d "$dir" ]; then
               echo "Removing $dir"
               rm -rf "$dir"
             fi
           done
-          for file in versioned_sidebars/version-${MAJOR}.*-sidebars.json; do
+          for file in "versioned_sidebars/version-${MAJOR}."*-sidebars.json; do
             if [ -f "$file" ]; then
               echo "Removing $file"
               rm -f "$file"

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -112,13 +112,6 @@ jobs:
           uv run npx docusaurus docs:version "$MAJOR_MINOR"
           uv run npx docusaurus api:version "$MAJOR_MINOR"
 
-          # Clean up non-docs artifacts from the snapshot.
-          rm -f "versioned_docs/version-${MAJOR_MINOR}/changelog.md"
-          rm -f "versioned_docs/version-${MAJOR_MINOR}/pyproject.toml"
-          rm -f "versioned_docs/version-${MAJOR_MINOR}/.gitignore"
-          rm -rf "versioned_docs/version-${MAJOR_MINOR}/.ruff_cache"
-          rm -rf "versioned_docs/version-${MAJOR_MINOR}/.ty_cache"
-
       - name: Commit and push versioned docs
         id: commit_versioned_docs
         uses: EndBug/add-and-commit@v10

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -1,0 +1,142 @@
+name: Version docs
+
+on:
+  # Runs when manually triggered from the GitHub UI.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to checkout (branch, tag, or SHA). Defaults to the default branch."
+        required: false
+        type: string
+        default: ""
+
+  # Runs when invoked by another workflow.
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to checkout (branch, tag, or SHA)"
+        required: true
+        type: string
+    outputs:
+      version_docs_commitish:
+        description: "The commit SHA of the versioned docs commit"
+        value: ${{ jobs.version_docs.outputs.version_docs_commitish }}
+
+concurrency:
+  group: version-docs
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  version_docs:
+    name: Version docs
+    runs-on: ubuntu-latest
+    outputs:
+      version_docs_commitish: ${{ steps.resolve_commitish.outputs.commitish }}
+    permissions:
+      contents: write
+    env:
+      NODE_VERSION: 22
+      PYTHON_VERSION: "3.14"
+
+    steps:
+      - name: Determine checkout ref
+        id: resolve_ref
+        run: |
+          REF="${{ inputs.ref }}"
+          if [ -z "$REF" ]; then
+            REF="${{ github.event.repository.default_branch }}"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+          ref: ${{ steps.resolve_ref.outputs.ref }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up uv package manager
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python dependencies
+        run: uv run poe install-dev
+
+      - name: Install website dependencies
+        run: |
+          cd website
+          corepack enable
+          yarn install
+
+      - name: Snapshot the current version
+        run: |
+          cd website
+
+          # Extract version from pyproject.toml.
+          VERSION="$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('../pyproject.toml').read_text())['project']['version'])")"
+          MAJOR_MINOR="$(echo "$VERSION" | cut -d. -f1-2)"
+          MAJOR="$(echo "$VERSION" | cut -d. -f1)"
+          echo "Version: $VERSION, Major.Minor: $MAJOR_MINOR, Major: $MAJOR"
+
+          # Remove ALL existing versions for this major (not just exact major.minor match).
+          for dir in versioned_docs/version-${MAJOR}.*; do
+            if [ -d "$dir" ]; then
+              echo "Removing $dir"
+              rm -rf "$dir"
+            fi
+          done
+          for file in versioned_sidebars/version-${MAJOR}.*-sidebars.json; do
+            if [ -f "$file" ]; then
+              echo "Removing $file"
+              rm -f "$file"
+            fi
+          done
+
+          # Update versions.json to remove entries for this major version.
+          if [ -f versions.json ]; then
+            jq --arg major "$MAJOR" '[.[] | select((split(".")[0]) != $major)]' versions.json > tmp.json && mv tmp.json versions.json
+          else
+            echo "[]" > versions.json
+          fi
+
+          # Build API reference and create Docusaurus version snapshots.
+          bash build_api_reference.sh
+          uv run npx docusaurus docs:version "$MAJOR_MINOR"
+          uv run npx docusaurus api:version "$MAJOR_MINOR"
+
+          # Clean up non-docs artifacts from the snapshot.
+          rm -f "versioned_docs/version-${MAJOR_MINOR}/changelog.md"
+          rm -f "versioned_docs/version-${MAJOR_MINOR}/pyproject.toml"
+          rm -f "versioned_docs/version-${MAJOR_MINOR}/.gitignore"
+          rm -rf "versioned_docs/version-${MAJOR_MINOR}/.ruff_cache"
+          rm -rf "versioned_docs/version-${MAJOR_MINOR}/.ty_cache"
+
+      - name: Commit and push versioned docs
+        id: commit_versioned_docs
+        uses: EndBug/add-and-commit@v10
+        with:
+          add: "website/versioned_docs website/versioned_sidebars website/versions.json"
+          message: "docs: version docs [skip ci]"
+          default_author: github_actions
+
+      - name: Resolve output commitish
+        id: resolve_commitish
+        run: |
+          SHA="${{ steps.commit_versioned_docs.outputs.commit_long_sha }}"
+          if [ -z "$SHA" ]; then
+            SHA="$(git rev-parse HEAD)"
+          fi
+          echo "commitish=$SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Git ref to checkout (branch, tag, or SHA). Defaults to the default branch."
+        description: Git ref to checkout (branch, tag, or SHA). Defaults to the default branch.
         required: false
         type: string
         default: ""
@@ -14,12 +14,12 @@ on:
   workflow_call:
     inputs:
       ref:
-        description: "Git ref to checkout (branch, tag, or SHA)"
+        description: Git ref to checkout (branch, tag, or SHA)
         required: true
         type: string
     outputs:
       version_docs_commitish:
-        description: "The commit SHA of the versioned docs commit"
+        description: The commit SHA of the versioned docs commit
         value: ${{ jobs.version_docs.outputs.version_docs_commitish }}
 
 concurrency:
@@ -29,6 +29,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  NODE_VERSION: 22
+  PYTHON_VERSION: "3.14"
+
 jobs:
   version_docs:
     name: Version docs
@@ -37,9 +41,6 @@ jobs:
       version_docs_commitish: ${{ steps.resolve_commitish.outputs.commitish }}
     permissions:
       contents: write
-    env:
-      NODE_VERSION: 22
-      PYTHON_VERSION: "3.14"
 
     steps:
       - name: Determine checkout ref
@@ -116,7 +117,7 @@ jobs:
         id: commit_versioned_docs
         uses: EndBug/add-and-commit@v10
         with:
-          add: "website/versioned_docs website/versioned_sidebars website/versions.json"
+          add: website/versioned_docs website/versioned_sidebars website/versions.json
           message: "docs: Version docs for v${{ steps.snapshot.outputs.version }} [skip ci]"
           default_author: github_actions
 

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -84,7 +84,7 @@ jobs:
           yarn install
 
           # Extract version from pyproject.toml.
-          VERSION="$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('../pyproject.toml').read_text())['project']['version'])")"
+          VERSION="$(uv version --short)"
           MAJOR_MINOR="$(echo "$VERSION" | cut -d. -f1-2)"
           MAJOR="$(echo "$VERSION" | cut -d. -f1)"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -45,11 +45,11 @@ jobs:
     steps:
       - name: Determine checkout ref
         id: resolve_ref
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          REF="${{ inputs.ref }}"
-          if [[ -z "$REF" ]]; then
-            REF="${{ github.event.repository.default_branch }}"
-          fi
+          REF="${INPUT_REF:-$DEFAULT_BRANCH}"
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
@@ -126,9 +126,7 @@ jobs:
 
       - name: Resolve output commitish
         id: resolve_commitish
+        env:
+          COMMIT_SHA: ${{ steps.commit_versioned_docs.outputs.commit_long_sha }}
         run: |
-          SHA="${{ steps.commit_versioned_docs.outputs.commit_long_sha }}"
-          if [[ -z "$SHA" ]]; then
-            SHA="$(git rev-parse HEAD)"
-          fi
-          echo "commitish=$SHA" >> "$GITHUB_OUTPUT"
+          echo "commitish=${COMMIT_SHA:-$(git rev-parse HEAD)}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -76,6 +76,7 @@ jobs:
         run: uv run poe install-dev
 
       - name: Snapshot the current version
+        id: snapshot
         run: |
           cd website
           corepack enable
@@ -85,6 +86,7 @@ jobs:
           VERSION="$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('../pyproject.toml').read_text())['project']['version'])")"
           MAJOR_MINOR="$(echo "$VERSION" | cut -d. -f1-2)"
           MAJOR="$(echo "$VERSION" | cut -d. -f1)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION, Major.Minor: $MAJOR_MINOR, Major: $MAJOR"
 
           # Find the existing version for this major in versions.json (if any).
@@ -122,7 +124,7 @@ jobs:
         uses: EndBug/add-and-commit@v10
         with:
           add: "website/versioned_docs website/versioned_sidebars website/versions.json"
-          message: "docs: version docs [skip ci]"
+          message: "docs: Version docs for v${{ steps.snapshot.outputs.version }} [skip ci]"
           default_author: github_actions
 
       - name: Resolve output commitish

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -75,15 +75,11 @@ jobs:
       - name: Install Python dependencies
         run: uv run poe install-dev
 
-      - name: Install website dependencies
+      - name: Snapshot the current version
         run: |
           cd website
           corepack enable
           yarn install
-
-      - name: Snapshot the current version
-        run: |
-          cd website
 
           # Extract version from pyproject.toml.
           VERSION="$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('../pyproject.toml').read_text())['project']['version'])")"

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ Session.vim
 # Docs
 docs/changelog.md
 website/versioned_docs/*/changelog.md
+website/versioned_docs/*/pyproject.toml
+website/versioned_docs/*/.gitignore
 
 # Website build artifacts, node dependencies
 website/build

--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,6 @@ Session.vim
 docs/changelog.md
 website/versioned_docs/*/changelog.md
 website/versioned_docs/*/pyproject.toml
-website/versioned_docs/*/.gitignore
 
 # Website build artifacts, node dependencies
 website/build


### PR DESCRIPTION
## Summary

- Extract the inline `version_docs` job from `manual_release_stable.yaml` into a standalone `manual_version_docs.yaml` workflow
- The new workflow can be triggered manually (for docs fixes) or called from the release pipeline
- Fix `api:version` ENOENT bug by running docusaurus commands through `uv run` (Python deps not available to bare `npx`)
- Clean up ALL versions for the same major version, not just exact major.minor match
- Remove non-docs artifacts (pyproject.toml, .gitignore, caches) from versioned doc snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)