### PR TITLE
ci: Extract docs release into reusable `manual_release_docs.yaml` workflow

### DIFF
--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -1,13 +1,20 @@
-name: Doc release
+name: Release docs
 
 on:
   # Runs when manually triggered from the GitHub UI.
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to checkout (branch, tag, or SHA). Defaults to the default branch.
+        required: false
+        type: string
+        default: ""
 
   # Runs when invoked by another workflow.
   workflow_call:
     inputs:
       ref:
+        description: Git ref to checkout (branch, tag, or SHA)
         required: true
         type: string
 
@@ -17,11 +24,10 @@ permissions:
 env:
   NODE_VERSION: 22
   PYTHON_VERSION: 3.14
-  CHECKOUT_REF: ${{ github.event_name == 'workflow_call' && inputs.ref || github.ref }}
 
 jobs:
   release_docs:
-    name: Doc release
+    name: Release docs
     environment:
       name: github-pages
     permissions:
@@ -31,11 +37,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Determine checkout ref
+        id: resolve_ref
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          REF="${INPUT_REF:-$DEFAULT_BRANCH}"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-          ref: ${{ env.CHECKOUT_REF }}
+          ref: ${{ steps.resolve_ref.outputs.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -119,7 +119,7 @@ jobs:
       contents: write
       pages: write
       id-token: write
-    uses: ./.github/workflows/_release_docs.yaml
+    uses: ./.github/workflows/manual_release_docs.yaml
     with:
       # Use the version_docs commit to include both changelog and versioned docs.
       ref: ${{ needs.version_docs.outputs.version_docs_commitish }}

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -28,7 +28,7 @@ jobs:
       contents: write
       pages: write
       id-token: write
-    uses: ./.github/workflows/_release_docs.yaml
+    uses: ./.github/workflows/manual_release_docs.yaml
     with:
       # Use the same ref as the one that triggered the workflow.
       ref: ${{ github.ref }}
@@ -108,7 +108,7 @@ jobs:
       contents: write
       pages: write
       id-token: write
-    uses: ./.github/workflows/_release_docs.yaml
+    uses: ./.github/workflows/manual_release_docs.yaml
     with:
       # Use the ref from the changelog update to include the updated changelog.
       ref: ${{ needs.changelog_update.outputs.changelog_commitish }}


### PR DESCRIPTION
Follow-up to https://github.com/apify/apify-sdk-python/pull/857

## Summary

- Rename `_release_docs.yaml` to `manual_release_docs.yaml` to match the naming convention of other reusable workflows (`manual_version_docs.yaml`, `manual_release_stable.yaml`).
- Add an optional `ref` input to `workflow_dispatch` so it can be triggered from the GitHub UI with a specific ref (falling back to the default branch).
- Replace the `CHECKOUT_REF` env var approach with a `Determine checkout ref` step, consistent with `manual_version_docs.yaml`.
- Update all references in `manual_release_stable.yaml` and `on_master.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)