### PR TITLE
docs: Fix incorrect status message deduplication claim

### DIFF
--- a/docs/02_concepts/01_actor_lifecycle.mdx
+++ b/docs/02_concepts/01_actor_lifecycle.mdx
@@ -97,7 +97,7 @@ Before triggering a reboot, persist any essential state externally (e.g., to the
 
 ## Status message
 
-[Status messages](https://docs.apify.com/platform/actors/development/programming-interface/status-messages) are lightweight, human-readable progress indicators displayed with the Actor run in the Apify Console. Use them to communicate high-level phases or milestones, such as "Fetching list", "Processed 120/500 pages", or "Uploading results". When running locally, the SDK logs the status message instead of sending it to the platform.
+[Status messages](https://docs.apify.com/platform/actors/development/programming-interface/status-messages) are lightweight, human-readable progress indicators displayed with the Actor run in Apify Console. Use them to communicate high-level phases or milestones, such as "Fetching list", "Processed 120/500 pages", or "Uploading results". When running locally, the SDK logs the status message instead of sending it to the platform.
 
 Update the status only when the user's understanding of progress changes - avoid frequent updates for every processed item. Detailed information should go to logs or storages (dataset, key-value store) instead.
 

--- a/docs/02_concepts/01_actor_lifecycle.mdx
+++ b/docs/02_concepts/01_actor_lifecycle.mdx
@@ -97,11 +97,9 @@ Before triggering a reboot, persist any essential state externally (e.g., to the
 
 ## Status message
 
-[Status messages](https://docs.apify.com/platform/actors/development/programming-interface/status-messages) are lightweight, human-readable progress indicators displayed with the Actor run on the Apify platform (separate from logs). Use them to communicate high-level phases or milestones, such as "Fetching list", "Processed 120/500 pages", or "Uploading results".
+[Status messages](https://docs.apify.com/platform/actors/development/programming-interface/status-messages) are lightweight, human-readable progress indicators displayed with the Actor run in the Apify Console. Use them to communicate high-level phases or milestones, such as "Fetching list", "Processed 120/500 pages", or "Uploading results". When running locally, the SDK logs the status message instead of sending it to the platform.
 
 Update the status only when the user's understanding of progress changes - avoid frequent updates for every processed item. Detailed information should go to logs or storages (dataset, key-value store) instead.
-
-The SDK optimizes updates by sending an API request only when the message text changes, so repeating the same message incurs no additional cost.
 
 <RunnableCodeBlock className="language-python" language="python">{StatusMessageExample}</RunnableCodeBlock>
 

--- a/website/versioned_docs/version-3.3/02_concepts/01_actor_lifecycle.mdx
+++ b/website/versioned_docs/version-3.3/02_concepts/01_actor_lifecycle.mdx
@@ -97,7 +97,7 @@ Before triggering a reboot, persist any essential state externally (e.g., to the
 
 ## Status message
 
-[Status messages](https://docs.apify.com/platform/actors/development/programming-interface/status-messages) are lightweight, human-readable progress indicators displayed with the Actor run in the Apify Console. Use them to communicate high-level phases or milestones, such as "Fetching list", "Processed 120/500 pages", or "Uploading results". When running locally, the SDK logs the status message instead of sending it to the platform.
+[Status messages](https://docs.apify.com/platform/actors/development/programming-interface/status-messages) are lightweight, human-readable progress indicators displayed with the Actor run in Apify Console. Use them to communicate high-level phases or milestones, such as "Fetching list", "Processed 120/500 pages", or "Uploading results". When running locally, the SDK logs the status message instead of sending it to the platform.
 
 Update the status only when the user's understanding of progress changes - avoid frequent updates for every processed item. Detailed information should go to logs or storages (dataset, key-value store) instead.
 

--- a/website/versioned_docs/version-3.3/02_concepts/01_actor_lifecycle.mdx
+++ b/website/versioned_docs/version-3.3/02_concepts/01_actor_lifecycle.mdx
@@ -97,11 +97,9 @@ Before triggering a reboot, persist any essential state externally (e.g., to the
 
 ## Status message
 
-[Status messages](https://docs.apify.com/platform/actors/development/programming-interface/status-messages) are lightweight, human-readable progress indicators displayed with the Actor run on the Apify platform (separate from logs). Use them to communicate high-level phases or milestones, such as "Fetching list", "Processed 120/500 pages", or "Uploading results".
+[Status messages](https://docs.apify.com/platform/actors/development/programming-interface/status-messages) are lightweight, human-readable progress indicators displayed with the Actor run in the Apify Console. Use them to communicate high-level phases or milestones, such as "Fetching list", "Processed 120/500 pages", or "Uploading results". When running locally, the SDK logs the status message instead of sending it to the platform.
 
 Update the status only when the user's understanding of progress changes - avoid frequent updates for every processed item. Detailed information should go to logs or storages (dataset, key-value store) instead.
-
-The SDK optimizes updates by sending an API request only when the message text changes, so repeating the same message incurs no additional cost.
 
 <RunnableCodeBlock className="language-python" language="python">{StatusMessageExample}</RunnableCodeBlock>
 


### PR DESCRIPTION
- Remove the incorrect claim that the SDK deduplicates status message API calls (it doesn't — `set_status_message()` always calls the API)
- Replace the misleading "(separate from logs)" note with accurate behavior: when running locally, the SDK logs the status message instead of sending it to the platform
- Apply the same fix to the versioned docs snapshot
- Context: flagged during review of apify/apify-sdk-js#586 by @barjin