### PR TITLE
docs: expand .rules.md with commit type guidance

### DIFF
--- a/.rules.md
+++ b/.rules.md
@@ -51,6 +51,13 @@ uv run poe e2e-tests
 - Tests are exempt from docstring rules (`D`), assert warnings (`S101`), and private member access (`SLF001`)
 - Unused imports are allowed in `__init__.py` files (re-exports)
 - **Pre-commit hooks**: lint check + type check run automatically on commit
+- **Commits**: [Conventional Commits](https://www.conventionalcommits.org/) format. Choose the type based on *what* changed, not just *why*:
+  - `feat:` / `fix:` / `perf:` / `refactor:` / `style:` — **source code only**; these trigger a release and appear in the changelog
+  - `test:` — test additions or changes (no release triggered)
+  - `docs:` — documentation changes; also triggers a doc release on master
+  - `ci:` — CI/workflow changes
+  - `chore:` — dependency bumps, tooling, and other housekeeping
+  - `build:` — build system changes
 
 ## Architecture
 


### PR DESCRIPTION
Clarifies which Conventional Commit types (`feat`/`fix`/`perf`/`refactor`/`style`) trigger a release and must be used for source code only, and maps the remaining types (`test:`, `docs:`, `ci:`, `chore:`, `build:`) to their correct scope.