### PR TITLE
test: extend retry window for synthetic PPE event propagation

### DIFF
--- a/tests/e2e/test_actor_charge.py
+++ b/tests/e2e/test_actor_charge.py
@@ -171,7 +171,6 @@ async def test_actor_push_data_charges_both_events(
     """Test that push_data charges both the explicit event and the synthetic apify-default-dataset-item event."""
     run = await run_actor(ppe_push_data_actor)
 
-    # Refetch until the platform gets its act together.
     # Use a longer retry window (120 attempts x 1 s) for synthetic events like `apify-default-dataset-item`:
     # the platform computes them from dataset writes asynchronously, so they propagate more slowly than
     # explicit charges (which are reflected immediately via the charge endpoint).
@@ -203,7 +202,6 @@ async def test_actor_push_data_combined_budget_limit(
     """
     run = await run_actor(ppe_push_data_actor, max_total_charge_usd=Decimal('0.20'))
 
-    # Refetch until the platform gets its act together.
     # Use a longer retry window (120 attempts x 1 s) for synthetic events like `apify-default-dataset-item`:
     # the platform computes them from dataset writes asynchronously, so they propagate more slowly than
     # explicit charges (which are reflected immediately via the charge endpoint).

--- a/tests/e2e/test_actor_charge.py
+++ b/tests/e2e/test_actor_charge.py
@@ -171,8 +171,11 @@ async def test_actor_push_data_charges_both_events(
     """Test that push_data charges both the explicit event and the synthetic apify-default-dataset-item event."""
     run = await run_actor(ppe_push_data_actor)
 
-    # Refetch until the platform gets its act together
-    for is_last_attempt, _ in retry_counter(30):
+    # Refetch until the platform gets its act together.
+    # Use a longer retry window (120 attempts x 1 s) for synthetic events like `apify-default-dataset-item`:
+    # the platform computes them from dataset writes asynchronously, so they propagate more slowly than
+    # explicit charges (which are reflected immediately via the charge endpoint).
+    for is_last_attempt, _ in retry_counter(120):
         await asyncio.sleep(1)
         updated_run = await apify_client_async.run(run.id).get()
         run = ActorRun.model_validate(updated_run)
@@ -200,8 +203,11 @@ async def test_actor_push_data_combined_budget_limit(
     """
     run = await run_actor(ppe_push_data_actor, max_total_charge_usd=Decimal('0.20'))
 
-    # Refetch until the platform gets its act together
-    for is_last_attempt, _ in retry_counter(30):
+    # Refetch until the platform gets its act together.
+    # Use a longer retry window (120 attempts x 1 s) for synthetic events like `apify-default-dataset-item`:
+    # the platform computes them from dataset writes asynchronously, so they propagate more slowly than
+    # explicit charges (which are reflected immediately via the charge endpoint).
+    for is_last_attempt, _ in retry_counter(120):
         await asyncio.sleep(1)
         updated_run = await apify_client_async.run(run.id).get()
         run = ActorRun.model_validate(updated_run)


### PR DESCRIPTION
## Summary

- Increased `retry_counter(30)` to `retry_counter(120)` in `test_actor_push_data_charges_both_events` and `test_actor_push_data_combined_budget_limit`
- Synthetic events like `apify-default-dataset-item` are computed by the platform from dataset writes asynchronously — unlike explicit charges (which hit the charge endpoint directly and reflect immediately), these take longer to propagate into `charged_event_counts`
- The existing 30-second window was insufficient; 2 minutes gives the platform enough time

**Failed CI run that triggered this fix:**
- https://github.com/apify/apify-sdk-python/actions/runs/24509008169/job/71634833762?pr=863

🤖 Generated with [Claude Code](https://claude.com/claude-code)