### PR TITLE
fix: avoid InvalidStateError on mid-stream platform websocket disconnect

### DIFF
--- a/src/apify/events/_apify_event_manager.py
+++ b/src/apify/events/_apify_event_manager.py
@@ -136,5 +136,5 @@ class ApifyEventManager(EventManager):
                         logger.exception('Cannot parse Actor event', extra={'raw_message': message})
         except Exception:
             logger.exception('Error in websocket connection')
-            if self._connected_to_platform_websocket is not None:
+            if self._connected_to_platform_websocket is not None and not self._connected_to_platform_websocket.done():
                 self._connected_to_platform_websocket.set_result(False)

--- a/tests/unit/events/test_apify_event_manager.py
+++ b/tests/unit/events/test_apify_event_manager.py
@@ -30,14 +30,12 @@ async def _platform_ws_server(
 ) -> AsyncGenerator[tuple[set[websockets.asyncio.server.ServerConnection], asyncio.Event]]:
     """Create a local WebSocket server that simulates Apify platform events.
 
-    Binds explicitly to ``127.0.0.1`` instead of ``localhost`` so that only a
-    single IPv4 socket is created.  On Windows, ``localhost`` resolves to both
-    ``127.0.0.1`` *and* ``::1``, and the OS may assign **different** random
-    ports to each address — causing the client to connect to the wrong port.
+    Binds explicitly to `127.0.0.1` instead of `localhost` so that only a single IPv4 socket is created. On Windows,
+    `localhost` resolves to both `127.0.0.1` *and* `::1`, and the OS may assign **different** random ports to each
+    address — causing the client to connect to the wrong port.
 
-    Yields a ``(connected_ws_clients, client_connected_event)`` tuple.  After
-    opening an `ApifyEventManager`, ``await client_connected_event.wait()``
-    before sending any messages to guarantee the server handler has registered
+    Yields a `(connected_ws_clients, client_connected_event)` tuple. After opening an `ApifyEventManager`,
+    `await client_connected_event.wait()` before sending any messages to guarantee the server handler has registered
     the connection.
     """
     connected_ws_clients: set[websockets.asyncio.server.ServerConnection] = set()
@@ -314,6 +312,33 @@ async def test_migrating_event_triggers_persist_state(monkeypatch: pytest.Monkey
         # MIGRATING should also trigger a PERSIST_STATE with is_migrating=True
         migration_persist_events = [c for c in persist_calls if hasattr(c, 'is_migrating') and c.is_migrating]
         assert len(migration_persist_events) >= 1
+
+
+async def test_websocket_mid_stream_disconnect_does_not_raise_invalid_state_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: a mid-stream websocket disconnect after a successful connect must not raise InvalidStateError.
+
+    The `_connected_to_platform_websocket` future is resolved to `True` on successful connect. If the websocket
+    later drops, the outer `except` in `_process_platform_messages` must not call `set_result(False)` on the
+    already-resolved future.
+    """
+    async with (
+        _platform_ws_server(monkeypatch) as (connected_ws_clients, client_connected),
+        ApifyEventManager(Configuration.get_global_configuration()) as event_manager,
+    ):
+        await client_connected.wait()
+
+        # Force an abnormal close from the server so the client's `async for` raises ConnectionClosedError.
+        for ws in list(connected_ws_clients):
+            await ws.close(code=1011, reason='Simulated server error')
+
+        task = event_manager._process_platform_messages_task
+        assert task is not None
+        await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+
+        exc = task.exception()
+        assert not isinstance(exc, asyncio.InvalidStateError), f'Task raised InvalidStateError: {exc}'
 
 
 async def test_malformed_message_logs_exception(

--- a/tests/unit/events/test_apify_event_manager.py
+++ b/tests/unit/events/test_apify_event_manager.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 import pytest
 import websockets
 import websockets.asyncio.server
+import websockets.exceptions
 
 from apify_shared.consts import ActorEnvVars
 from crawlee.events._types import Event
@@ -315,7 +316,7 @@ async def test_migrating_event_triggers_persist_state(monkeypatch: pytest.Monkey
 
 
 async def test_websocket_mid_stream_disconnect_does_not_raise_invalid_state_error(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Regression: a mid-stream websocket disconnect after a successful connect must not raise InvalidStateError.
 
@@ -339,6 +340,13 @@ async def test_websocket_mid_stream_disconnect_does_not_raise_invalid_state_erro
 
         exc = task.exception()
         assert not isinstance(exc, asyncio.InvalidStateError), f'Task raised InvalidStateError: {exc}'
+
+        # Confirm the test actually exercised the disconnect path — the outer `except` in
+        # `_process_platform_messages` should have logged a `ConnectionClosedError`.
+        logged_exc_types = [
+            record.exc_info[0] for record in caplog.records if record.exc_info and record.exc_info[0] is not None
+        ]
+        assert any(issubclass(exc_type, websockets.exceptions.ConnectionClosedError) for exc_type in logged_exc_types)
 
 
 async def test_malformed_message_logs_exception(


### PR DESCRIPTION
## Summary

Guard `set_result(False)` in `ApifyEventManager._process_platform_messages` with a `done()` check. Previously, a websocket disconnect *after* a successful connect would try to re-resolve the already-resolved `_connected_to_platform_websocket` future, raising `InvalidStateError` and masking the original `ConnectionClosedError` in logs.

Adds a regression test that forces a mid-stream abnormal close from the server and asserts the background task does not surface `InvalidStateError`.