### PR TITLE
chore: use cache.get() in shared RQ mark_request_as_handled

### DIFF
--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -216,7 +216,7 @@ class ApifyRequestQueueSharedClient:
         if request.handled_at is None:
             request.handled_at = datetime.now(tz=timezone.utc)
 
-        if cached_request := self._requests_cache[request_id]:
+        if cached_request := self._requests_cache.get(request_id):
             cached_request.was_already_handled = request.was_already_handled
         try:
             # Update the request in the API


### PR DESCRIPTION
## Summary

- `ApifyRequestQueueSharedClient.mark_request_as_handled` looked up the request id with `self._requests_cache[request_id]`, which raises `KeyError` when the entry is missing (LRU eviction, or a request constructed outside this client's fetch flow). The lookup sits one line above the `try/except`, so the error propagates out of the method.
- The analogous code in `_request_queue_single_client.py:204` already uses `.get()`; this change brings the shared client in line.
- Low real-world impact given the 1M-entry cache ceiling, so treating it as a cleanup rather than a fix — no behavior change on the hot path.