### PR TITLE
fix: preserve `max_total_charge_usd=0` instead of treating it as unlimited

### DIFF
--- a/src/apify/_charging.py
+++ b/src/apify/_charging.py
@@ -159,7 +159,9 @@ class ChargingManagerImplementation(ChargingManager):
     LOCAL_CHARGING_LOG_DATASET_NAME = 'charging-log'
 
     def __init__(self, configuration: Configuration, client: ApifyClientAsync) -> None:
-        self._max_total_charge_usd = configuration.max_total_charge_usd or Decimal('inf')
+        self._max_total_charge_usd = (
+            configuration.max_total_charge_usd if configuration.max_total_charge_usd is not None else Decimal('inf')
+        )
         self._configuration = configuration
         self._is_at_home = configuration.is_at_home
         self._actor_run_id = configuration.actor_run_id
@@ -413,7 +415,11 @@ class ChargingManagerImplementation(ChargingManager):
             return _FetchedPricingInfoDict(
                 pricing_info=self._configuration.actor_pricing_info,
                 charged_event_counts=self._configuration.charged_event_counts,
-                max_total_charge_usd=self._configuration.max_total_charge_usd or Decimal('inf'),
+                max_total_charge_usd=(
+                    self._configuration.max_total_charge_usd
+                    if self._configuration.max_total_charge_usd is not None
+                    else Decimal('inf')
+                ),
             )
 
         # Fall back to API call
@@ -436,7 +442,11 @@ class ChargingManagerImplementation(ChargingManager):
         return _FetchedPricingInfoDict(
             pricing_info=None,
             charged_event_counts={},
-            max_total_charge_usd=self._configuration.max_total_charge_usd or Decimal('inf'),
+            max_total_charge_usd=(
+                self._configuration.max_total_charge_usd
+                if self._configuration.max_total_charge_usd is not None
+                else Decimal('inf')
+            ),
         )
 
     def _get_event_price(self, event_name: str) -> Decimal:

--- a/tests/unit/actor/test_charging_manager.py
+++ b/tests/unit/actor/test_charging_manager.py
@@ -247,6 +247,36 @@ async def test_get_max_total_charge_usd(mock_client: MagicMock) -> None:
         assert cm.get_max_total_charge_usd() == Decimal('42.50')
 
 
+async def test_max_total_charge_usd_zero_blocks_charging(mock_client: MagicMock) -> None:
+    """Test max_total_charge_usd=0 is preserved and blocks all charging (not silently converted to inf)."""
+    pricing_info = _make_ppe_pricing_info({'search': Decimal('0.01')})
+    config = _make_config(
+        test_pay_per_event=True,
+        actor_pricing_info=pricing_info,
+        charged_event_counts={},
+        max_total_charge_usd=Decimal(0),
+    )
+    cm = ChargingManagerImplementation(config, mock_client)
+    async with cm:
+        assert cm.get_max_total_charge_usd() == Decimal(0)
+        assert cm.is_event_charge_limit_reached('search') is True
+        result = await cm.charge('search', count=5)
+        assert result.charged_count == 0
+        assert result.event_charge_limit_reached is True
+
+
+async def test_max_total_charge_usd_zero_preserved_without_pricing(mock_client: MagicMock) -> None:
+    """Test max_total_charge_usd=0 is preserved through the no-pricing fallback path."""
+    config = _make_config(
+        max_total_charge_usd=Decimal(0),
+        actor_pricing_info=None,
+        charged_event_counts={},
+    )
+    cm = ChargingManagerImplementation(config, mock_client)
+    async with cm:
+        assert cm.get_max_total_charge_usd() == Decimal(0)
+
+
 async def test_compute_push_data_limit_no_ppe(mock_client: MagicMock) -> None:
     """Returns items_count when no PPE pricing is configured (prices are zero)."""
     config = _make_config(actor_pricing_info=None, charged_event_counts={})


### PR DESCRIPTION
## Summary

`configuration.max_total_charge_usd or Decimal('inf')` at `src/apify/_charging.py:162`, `:416`, and `:439` treats `Decimal(0)` as falsy and silently replaces it with `Decimal('inf')`. A user who explicitly sets `max_total_charge_usd=0` (or `ACTOR_MAX_TOTAL_CHARGE_USD=0`) to disable charging ends up with **unlimited** charging — the opposite of the intended behavior.

The configuration layer already preserves `0` as a distinct value (and `test_max_total_charge_usd_zero_is_preserved` asserts this), so the invariant is thrown away only at the charging manager boundary.

Replaced the three occurrences with an explicit `… if … is not None else Decimal('inf')` check, matching the already-correct pattern used on the API-fetch path (line 438).

🤖 Generated with [Claude Code](https://claude.com/claude-code)