### PR TITLE
fix: tolerate non-UTF-8 bodies in ApifyRequestList remote sources

### DIFF
--- a/src/apify/request_loaders/_apify_request_list.py
+++ b/src/apify/request_loaders/_apify_request_list.py
@@ -140,7 +140,7 @@ class ApifyRequestList(RequestList):
         """Fetch a remote URL and extract links from the response body."""
         http_response = await http_client.send_request(method='GET', url=request_input.requests_from_url)
         response_body = await http_response.read()
-        matches = re.finditer(URL_NO_COMMAS_REGEX, response_body.decode('utf-8'))
+        matches = re.finditer(URL_NO_COMMAS_REGEX, response_body.decode('utf-8', errors='replace'))
 
         return [
             Request.from_url(

--- a/tests/unit/actor/test_request_list.py
+++ b/tests/unit/actor/test_request_list.py
@@ -190,6 +190,22 @@ async def test_request_list_open_from_url_additional_inputs(httpserver: HTTPServ
     assert request.user_data == expected_user_data
 
 
+async def test_request_list_open_from_url_non_utf8_body(httpserver: HTTPServer) -> None:
+    """Test that a non-UTF-8 response body does not crash ApifyRequestList.open."""
+    expected_url = 'https://www.someurl.com'
+    # latin-1 encoded body containing non-ASCII bytes (0xE9 = 'é') that would raise
+    # UnicodeDecodeError under strict utf-8 decoding.
+    response_body = f'café {expected_url} naïve'.encode('latin-1')
+    httpserver.expect_oneshot_request('/file.txt').respond_with_data(status=200, response_data=response_body)
+
+    request_list = await ApifyRequestList.open(
+        request_list_sources_input=[{'requestsFromUrl': httpserver.url_for('/file.txt'), 'method': 'GET'}]
+    )
+    request = await request_list.fetch_next_request()
+    assert request is not None
+    assert request.url == expected_url
+
+
 async def test_request_list_open_name() -> None:
     name = 'some_name'
     request_list = await ApifyRequestList.open(name=name)


### PR DESCRIPTION
## Summary

- `ApifyRequestList._process_remote_url` decoded remote `requestsFromUrl` response bodies with `response_body.decode('utf-8')` in strict mode. Any source returning non-UTF-8 bytes (latin-1, Windows-1252, binary, etc.) raised `UnicodeDecodeError`, and because `_fetch_requests_from_url` uses `asyncio.gather` without `return_exceptions=True`, the error propagated out of `ApifyRequestList.open` and crashed Actor startup — taking well-formed sibling sources down with it.
- Switch the decode to `errors='replace'`. `URL_NO_COMMAS_REGEX` only matches ASCII, so replacing invalid bytes with U+FFFD doesn't change which URLs are extracted; it just avoids the crash.
- Added a regression test that serves a latin-1 body containing `0xE9` and asserts the embedded URL is still extracted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)