### PR TITLE
chore: Defensively discard in-progress id on unexpected None from platform

### DIFF
--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -194,8 +194,9 @@ class ApifyRequestQueueSingleClient:
                 self._requests_in_progress.add(request_id)
                 request = await self._get_request_by_id(request_id)
                 if request is None:
-                    # Platform could not return the request (e.g. data propagation delay); do not
-                    # leak the id into `_requests_in_progress`, or `is_empty()` would never be True.
+                    # Defensive guard against an unexpected `None` from the platform: leaving the id in
+                    # `_requests_in_progress` would make `is_empty()` never settle and filter the id out of future
+                    # head reconciliations, with no recovery path for the caller.
                     self._requests_in_progress.discard(request_id)
                     continue
                 return request

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -192,7 +192,13 @@ class ApifyRequestQueueSingleClient:
             request_id = self._head_requests.pop()
             if request_id not in self._requests_in_progress and request_id not in self._requests_already_handled:
                 self._requests_in_progress.add(request_id)
-                return await self._get_request_by_id(request_id)
+                request = await self._get_request_by_id(request_id)
+                if request is None:
+                    # Platform could not return the request (e.g. data propagation delay); do not
+                    # leak the id into `_requests_in_progress`, or `is_empty()` would never be True.
+                    self._requests_in_progress.discard(request_id)
+                    continue
+                return request
         # No request locally and the ones returned from the platform are already in progress.
         return None
 

--- a/tests/unit/storage_clients/test_apify_request_queue_client.py
+++ b/tests/unit/storage_clients/test_apify_request_queue_client.py
@@ -84,20 +84,3 @@ async def test_list_head_limit(in_progress_count: int, expected_limit: int) -> N
     await client._list_head()
 
     api_client.list_head.assert_awaited_once_with(limit=expected_limit)
-
-
-async def test_fetch_next_request_does_not_leak_in_progress_on_none_response() -> None:
-    """Regression test: when ``get_request`` returns ``None`` for a head id (e.g. due to
-    platform data propagation delay), the id must not remain in ``_requests_in_progress``,
-    otherwise ``is_empty()`` can never become ``True`` again.
-    """
-    client, api_client = _make_single_client()
-    api_client.list_head = AsyncMock(return_value={'items': [], 'hadMultipleClients': False})
-    api_client.get_request = AsyncMock(return_value=None)
-    client._head_requests.append('missing-id')
-
-    result = await client.fetch_next_request()
-
-    assert result is None
-    assert 'missing-id' not in client._requests_in_progress
-    assert await client.is_empty()

--- a/tests/unit/storage_clients/test_apify_request_queue_client.py
+++ b/tests/unit/storage_clients/test_apify_request_queue_client.py
@@ -84,3 +84,20 @@ async def test_list_head_limit(in_progress_count: int, expected_limit: int) -> N
     await client._list_head()
 
     api_client.list_head.assert_awaited_once_with(limit=expected_limit)
+
+
+async def test_fetch_next_request_does_not_leak_in_progress_on_none_response() -> None:
+    """Regression test: when ``get_request`` returns ``None`` for a head id (e.g. due to
+    platform data propagation delay), the id must not remain in ``_requests_in_progress``,
+    otherwise ``is_empty()`` can never become ``True`` again.
+    """
+    client, api_client = _make_single_client()
+    api_client.list_head = AsyncMock(return_value={'items': [], 'hadMultipleClients': False})
+    api_client.get_request = AsyncMock(return_value=None)
+    client._head_requests.append('missing-id')
+
+    result = await client.fetch_next_request()
+
+    assert result is None
+    assert 'missing-id' not in client._requests_in_progress
+    assert await client.is_empty()


### PR DESCRIPTION
## Summary

Defensive guard in `ApifyRequestQueueSingleClient.fetch_next_request`: if `_get_request_by_id` unexpectedly returns `None` for an id just surfaced by `_list_head`, discard the id from `_requests_in_progress` before continuing to the next head entry. Without this guard, the id would be permanently stuck in `_requests_in_progress` — poisoning `is_empty()` forever and filtering the id out of every subsequent head reconciliation, with no public recovery path (the caller receives `None`, so has no `Request` to reclaim).

Found by code reading — no known real-world trigger under single-producer/single-consumer operation. Kept as a boundary check against unexpected platform responses.

## Test plan
- [x] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)