### PR TITLE
test: raise `call_with_exp_backoff` retry budget for flaky shared RQ tests

### DIFF
--- a/tests/integration/_utils.py
+++ b/tests/integration/_utils.py
@@ -18,7 +18,7 @@ async def call_with_exp_backoff(
     fn: Callable[[], Awaitable[T]],
     *,
     rq_access_mode: Literal['single', 'shared'],
-    max_retries: int = 3,
+    max_retries: int = 5,
 ) -> T | None:
     """Call an async callable with exponential backoff retries until it returns a truthy value.
 


### PR DESCRIPTION
### Description

`test_request_ordering_with_mixed_operations[shared]` failed on CI because `fetch_next_request` returned `None` after all retries. The test already wraps the call in `call_with_exp_backoff`, but the helper's default `max_retries=3` only allows 1+2+4 = 7s of backoff — shared RQ propagation delay (see #808) occasionally exceeds that.

Raising the default to `max_retries=5` extends the worst-case wait to 1+2+4+8+16 = 31s. No cost in the happy path (returns on the first successful call), and the change benefits all 37 call sites of the helper.

Failed CI run: https://github.com/apify/apify-sdk-python/actions/runs/24673724360/job/72151584275

🤖 Generated with [Claude Code](https://claude.com/claude-code)