### PR TITLE
test: replace fixed sleep with poll_until_condition in test_cache_initialization

### DIFF
--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -986,9 +986,13 @@ async def test_cache_initialization(apify_token: str, monkeypatch: pytest.Monkey
         try:
             await rq.add_requests(requests)
 
-            # Check that it is correctly in the API
-            await asyncio.sleep(10)  # Wait to be sure that metadata are updated
-            metadata = cast('ApifyRequestQueueMetadata', await rq.get_metadata())
+            async def _get_rq_metadata() -> ApifyRequestQueueMetadata:
+                return cast('ApifyRequestQueueMetadata', await rq.get_metadata())
+
+            metadata = await poll_until_condition(
+                _get_rq_metadata,
+                lambda m: m.stats.write_count >= len(requests),
+            )
             stats_before = metadata.stats
             Actor.log.info(stats_before)
 
@@ -999,8 +1003,10 @@ async def test_cache_initialization(apify_token: str, monkeypatch: pytest.Monkey
             rq = await Actor.open_request_queue(name=request_queue_name, force_cloud=True)
             await rq.add_requests(requests)
 
-            await asyncio.sleep(10)  # Wait to be sure that metadata are updated
-            metadata = cast('ApifyRequestQueueMetadata', await rq.get_metadata())
+            metadata = await poll_until_condition(
+                _get_rq_metadata,
+                lambda m: m.stats.read_count - stats_before.read_count >= len(requests),
+            )
             stats_after = metadata.stats
             Actor.log.info(stats_after)
 


### PR DESCRIPTION
## Summary

Fixes flakiness in `test_cache_initialization` (integration tests, see [run 25099976014](https://github.com/apify/apify-sdk-python/actions/runs/25099976014)).

The test used fixed `asyncio.sleep(10)` waits to give Apify platform stats time to propagate. In CI, 10s wasn't always enough — `read_count` was still `0` after the second sleep, so the assertion failed even though the cache had been initialized correctly.

Switched to the existing `poll_until_condition` helper (already used elsewhere in this file for the same purpose). It calls `get_metadata` immediately, then polls every 5s up to a 60s timeout — faster in the happy path, more tolerant of platform lag in the slow path. Real regressions still fail the test; only the propagation-timing flake is masked.