### PR TITLE
ci: rebase before pushing the docs theme update commit

### DIFF
--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -69,6 +69,7 @@ jobs:
           add: website/package.json website/pnpm-lock.yaml
           message: "chore: Automatic docs theme update [skip ci]"
           default_author: github_actions
+          pull: '--rebase --autostash'
           # `actions/checkout` detaches HEAD on SHA refs; EndBug needs a branch to push.
           new_branch: ${{ github.event.repository.default_branch }}
 


### PR DESCRIPTION
## Summary
Add `pull: '--rebase --autostash'` to the `EndBug/add-and-commit` step in `manual_release_docs.yaml` so the docs-theme commit survives a concurrent ref update on the default branch.

## Context
Same race that bit `apify/apify-client-js` in [run 25114327598](https://github.com/apify/apify-client-js/actions/runs/25114327598/job/73597522121):

```
remote rejected (cannot lock ref 'refs/heads/master': is at <new> but expected <old>)
```

The bypass logs `remote: Bypassed rule violations for refs/heads/master` — so it's not permissions, it's just non-fast-forward because something landed on master between checkout and push.

The sibling `manual_version_docs.yaml` already uses `pull: '--rebase --autostash'`; this aligns `manual_release_docs.yaml` with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)