### PR TITLE
test: update `test_request_deduplication_edge_cases`

### DIFF
--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -743,11 +743,9 @@ async def test_request_deduplication_edge_cases(request_queue_apify: RequestQueu
 
     results = list[bool]()
     for url, expected_duplicate in urls_and_deduplication_expectations:
-        # add_request may transiently return None due to platform-side issues, retry up to 3 times.
-        for _ in range(3):
-            result = await rq.add_request(url)
-            if result is not None:
-                break  # Successfully added.
+        # In shared mode, `add_request` may transiently return None until the operation propagates,
+        # so poll with backoff until it returns a result.
+        result = await poll_until_condition(lambda url=url: rq.add_request(url), lambda result: result is not None)
 
         assert result is not None
         results.append(result.was_already_present)

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -723,14 +723,8 @@ async def test_persistence_across_operations(
     assert final_handled == 15, f'final_handled={final_handled}'
 
 
-async def test_request_deduplication_edge_cases(
-    request_queue_apify: RequestQueue, request: pytest.FixtureRequest
-) -> None:
+async def test_request_deduplication_edge_cases(request_queue_apify: RequestQueue) -> None:
     """Test edge cases in request deduplication."""
-    rq_access_mode = request.node.callspec.params.get('request_queue_apify')
-    if rq_access_mode == 'shared':
-        pytest.skip(reason='Test is flaky, see https://github.com/apify/apify-sdk-python/issues/786')
-
     rq = request_queue_apify
     Actor.log.info('Request queue opened')
 
@@ -749,7 +743,12 @@ async def test_request_deduplication_edge_cases(
 
     results = list[bool]()
     for url, expected_duplicate in urls_and_deduplication_expectations:
-        result = await rq.add_request(url)
+        # add_request may transiently return None due to platform-side issues, retry up to 3 times.
+        for _ in range(3):
+            result = await rq.add_request(url)
+            if result is not None:
+                break  # Successfully added.
+
         assert result is not None
         results.append(result.was_already_present)
         assert result.was_already_present == expected_duplicate, (

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,14 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-04-26T08:17:16.734666375Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "PT24H"
+
+[options.exclude-newer-package]
+apify-fingerprint-datapoints = false
+crawlee = false
+apify-shared = false
+apify-client = false
 
 [[package]]
 name = "annotated-types"

--- a/uv.lock
+++ b/uv.lock
@@ -3,14 +3,8 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-04-26T08:17:16.734666375Z"
 exclude-newer-span = "PT24H"
-
-[options.exclude-newer-package]
-apify-fingerprint-datapoints = false
-crawlee = false
-apify-shared = false
-apify-client = false
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
Closes: #786

Re-enables `test_request_deduplication_edge_cases` in shared mode (previously skipped as flaky).

The flakiness came from `add_request` occasionally returning `None` transiently due to platform-side propagation in shared request-queue mode. Instead of a fixed retry loop with no delay between attempts, the test now uses the `poll_until_condition` helper, which polls `add_request` with backoff until it returns a result (or times out). This gives transient `None` results time to clear and is consistent with how other integration tests handle eventually-consistent API state.