### PR TITLE
ci: dispatch beta release via execute-workflow instead of inlining

### DIFF
--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -1,12 +1,16 @@
 name: Beta release
 
 on:
-  # Runs when manually triggered from the GitHub UI.
-  # Note: This workflow is intentionally NOT a reusable workflow (no `workflow_call`) because PyPI's Trusted Publishing
-  # does not currently support reusable workflows. The same jobs are duplicated in `on_master.yaml` for the automatic
-  # beta release on push to master.
+  # Runs when manually triggered from the GitHub UI, or dispatched from `on_master.yaml`
+  # via the `apify/workflows/execute-workflow` action for the automatic beta release on push to master.
+  # Note: This workflow is intentionally NOT a reusable workflow (no `workflow_call`) because PyPI's
+  # Trusted Publishing does not currently support reusable workflows.
   # See: https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
   workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -2,10 +2,11 @@ name: Beta release
 
 on:
   # Runs when manually triggered from the GitHub UI.
+  # Note: This workflow is intentionally NOT a reusable workflow (no `workflow_call`) because PyPI's Trusted Publishing
+  # does not currently support reusable workflows. The same jobs are duplicated in `on_master.yaml` for the automatic
+  # beta release on push to master.
+  # See: https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
   workflow_dispatch:
-
-  # Runs when invoked by another workflow.
-  workflow_call:
 
 permissions:
   contents: read
@@ -16,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version_number: ${{ steps.release_prepare.outputs.version_number }}
-      tag_name: ${{ steps.release_prepare.outputs.tag_name }}
       changelog: ${{ steps.release_prepare.outputs.changelog }}
     steps:
       - uses: apify/workflows/git-cliff-release@main

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -45,10 +45,10 @@ jobs:
     uses: ./.github/workflows/_tests.yaml
     secrets: inherit
 
-  # The beta release jobs are intentionally inlined here (instead of calling `manual_release_beta.yaml` via `uses:`)
+  # The beta release is dispatched as a separate workflow run (instead of calling `manual_release_beta.yaml` via `uses:`)
   # because PyPI's Trusted Publishing does not currently support reusable workflows.
   # See: https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
-  release_prepare:
+  beta_release:
     # Run this only for "feat", "fix", "perf", "refactor" and "style" commits.
     if: >-
       startsWith(github.event.head_commit.message, 'feat') ||
@@ -56,63 +56,13 @@ jobs:
       startsWith(github.event.head_commit.message, 'perf') ||
       startsWith(github.event.head_commit.message, 'refactor') ||
       startsWith(github.event.head_commit.message, 'style')
-    name: Beta release / Release prepare
+    name: Beta release
     needs: [code_checks, tests]
     runs-on: ubuntu-latest
-    outputs:
-      version_number: ${{ steps.release_prepare.outputs.version_number }}
-      changelog: ${{ steps.release_prepare.outputs.changelog }}
+    permissions:
+      actions: write # Required by execute-workflow.
     steps:
-      - uses: apify/workflows/git-cliff-release@main
-        id: release_prepare
-        name: Release prepare
+      - name: Dispatch beta release workflow
+        uses: apify/workflows/execute-workflow@main
         with:
-          release_type: prerelease
-          existing_changelog_path: CHANGELOG.md
-
-  changelog_update:
-    name: Beta release / Changelog update
-    needs: [release_prepare]
-    permissions:
-      contents: write
-    uses: apify/workflows/.github/workflows/python_bump_and_update_changelog.yaml@main
-    with:
-      version_number: ${{ needs.release_prepare.outputs.version_number }}
-      changelog: ${{ needs.release_prepare.outputs.changelog }}
-    secrets: inherit
-
-  pypi_publish:
-    name: Beta release / PyPI publish
-    needs: [release_prepare, changelog_update]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write # Required for OIDC authentication.
-    environment:
-      name: pypi
-      url: https://pypi.org/project/apify
-    steps:
-      - name: Prepare distribution
-        uses: apify/workflows/prepare-pypi-distribution@main
-        with:
-          package_name: apify
-          is_prerelease: "yes"
-          version_number: ${{ needs.release_prepare.outputs.version_number }}
-          ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
-
-      # Publish the package to PyPI using PyPA official GitHub action with OIDC authentication.
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-  doc_release_post_publish:
-    name: Beta release / Doc release post publish
-    needs: [changelog_update, pypi_publish]
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
-    uses: ./.github/workflows/manual_release_docs.yaml
-    with:
-      # Use the ref from the changelog update to include the updated changelog.
-      ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
-    secrets: inherit
+          workflow: manual_release_beta.yaml

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -45,7 +45,10 @@ jobs:
     uses: ./.github/workflows/_tests.yaml
     secrets: inherit
 
-  beta_release:
+  # The beta release jobs are intentionally inlined here (instead of calling `manual_release_beta.yaml` via `uses:`)
+  # because PyPI's Trusted Publishing does not currently support reusable workflows.
+  # See: https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
+  release_prepare:
     # Run this only for "feat", "fix", "perf", "refactor" and "style" commits.
     if: >-
       startsWith(github.event.head_commit.message, 'feat') ||
@@ -53,11 +56,63 @@ jobs:
       startsWith(github.event.head_commit.message, 'perf') ||
       startsWith(github.event.head_commit.message, 'refactor') ||
       startsWith(github.event.head_commit.message, 'style')
-    name: Beta release
+    name: Beta release / Release prepare
     needs: [code_checks, tests]
+    runs-on: ubuntu-latest
+    outputs:
+      version_number: ${{ steps.release_prepare.outputs.version_number }}
+      changelog: ${{ steps.release_prepare.outputs.changelog }}
+    steps:
+      - uses: apify/workflows/git-cliff-release@main
+        id: release_prepare
+        name: Release prepare
+        with:
+          release_type: prerelease
+          existing_changelog_path: CHANGELOG.md
+
+  changelog_update:
+    name: Beta release / Changelog update
+    needs: [release_prepare]
     permissions:
       contents: write
-      id-token: write
+    uses: apify/workflows/.github/workflows/python_bump_and_update_changelog.yaml@main
+    with:
+      version_number: ${{ needs.release_prepare.outputs.version_number }}
+      changelog: ${{ needs.release_prepare.outputs.changelog }}
+    secrets: inherit
+
+  pypi_publish:
+    name: Beta release / PyPI publish
+    needs: [release_prepare, changelog_update]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write # Required for OIDC authentication.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/apify
+    steps:
+      - name: Prepare distribution
+        uses: apify/workflows/prepare-pypi-distribution@main
+        with:
+          package_name: apify
+          is_prerelease: "yes"
+          version_number: ${{ needs.release_prepare.outputs.version_number }}
+          ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
+
+      # Publish the package to PyPI using PyPA official GitHub action with OIDC authentication.
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  doc_release_post_publish:
+    name: Beta release / Doc release post publish
+    needs: [changelog_update, pypi_publish]
+    permissions:
+      contents: write
       pages: write
-    uses: ./.github/workflows/manual_release_beta.yaml
+      id-token: write
+    uses: ./.github/workflows/manual_release_docs.yaml
+    with:
+      # Use the ref from the changelog update to include the updated changelog.
+      ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
     secrets: inherit


### PR DESCRIPTION
Replaces the inlined beta release jobs in `on_master.yaml` with a single job that dispatches `manual_release_beta.yaml` via `apify/workflows/execute-workflow@main`. The dispatched run is a regular `workflow_dispatch` (not a reusable workflow call), so PyPI's Trusted Publishing accepts the OIDC token, and the duplication is gone.

Also adds a `concurrency: release` group to `manual_release_beta.yaml` so two rapid pushes to master cannot race on the version bump and PyPI publish.

Same pattern as `apify-client-js`, `apify-sdk-js`, `apify-cli`, and `crawlee`.