### PR TITLE
ci: Use custom action to commit changes in CI instead of `git commit`

### DIFF
--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -72,7 +72,4 @@ jobs:
       pages: write
       id-token: write
     uses: ./.github/workflows/manual_release_docs.yaml
-    with:
-      # Use the ref from the changelog update to include the updated changelog.
-      ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
     secrets: inherit

--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -57,22 +57,12 @@ jobs:
       - name: Update docs theme
         run: uv run poe update-docs-theme
 
-      - name: Stage updated package.json and lockfile
-        id: stage
-        run: |
-          git pull --rebase --autostash
-          git add website/package.json website/pnpm-lock.yaml
-          if git diff --cached --quiet; then
-            echo "has-changes=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has-changes=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Commit the updated package.json and lockfile
-        if: steps.stage.outputs.has-changes == 'true'
-        uses: apify/workflows/commit@v0.44.0
+        uses: apify/actions/signed-commit@v1.0.0
         with:
-          commit-message: "chore: Automatic docs theme update [skip ci]"
+          message: "chore: Automatic docs theme update [skip ci]"
+          add: 'website/package.json website/pnpm-lock.yaml'
+          pull: '--rebase --autostash'
           github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
       - name: Build docs

--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -6,11 +6,6 @@ on:
 
   # Runs when invoked by another workflow.
   workflow_call:
-    inputs:
-      ref:
-        description: Git ref to checkout.
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -35,7 +30,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-          ref: ${{ inputs.ref || github.event.repository.default_branch }}
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -63,15 +57,23 @@ jobs:
       - name: Update docs theme
         run: uv run poe update-docs-theme
 
+      - name: Stage updated package.json and lockfile
+        id: stage
+        run: |
+          git pull --rebase --autostash
+          git add website/package.json website/pnpm-lock.yaml
+          if git diff --cached --quiet; then
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Commit the updated package.json and lockfile
-        uses: EndBug/add-and-commit@v10
+        if: steps.stage.outputs.has-changes == 'true'
+        uses: apify/workflows/commit@v0.44.0
         with:
-          add: website/package.json website/pnpm-lock.yaml
-          message: "chore: Automatic docs theme update [skip ci]"
-          default_author: github_actions
-          pull: '--rebase --autostash'
-          # `actions/checkout` detaches HEAD on SHA refs; EndBug needs a branch to push.
-          new_branch: ${{ github.event.repository.default_branch }}
+          commit-message: "chore: Automatic docs theme update [skip ci]"
+          github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
       - name: Build docs
         run: uv run poe build-docs

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -108,9 +108,6 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/manual_version_docs.yaml
-    with:
-      # Commit the version docs changes on top of the changelog commit.
-      ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
     secrets: inherit
 
   doc_release:
@@ -121,9 +118,6 @@ jobs:
       pages: write
       id-token: write
     uses: ./.github/workflows/manual_release_docs.yaml
-    with:
-      # Commit the docs release changes on top of the version docs commit.
-      ref: ${{ needs.version_docs.outputs.version_docs_commitish }}
     secrets: inherit
 
   trigger_docker_build:

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -95,21 +95,10 @@ jobs:
           pnpm exec docusaurus docs:version "$MAJOR_MINOR_VERSION"
           pnpm exec docusaurus api:version "$MAJOR_MINOR_VERSION"
 
-      - name: Stage versioned docs
-        id: stage
-        working-directory: .
-        run: |
-          git pull --rebase --autostash
-          git add website/versioned_docs website/versioned_sidebars website/versions.json
-          if git diff --cached --quiet; then
-            echo "has-changes=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has-changes=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Commit and push versioned docs
-        if: steps.stage.outputs.has-changes == 'true'
-        uses: apify/workflows/commit@v0.44.0
+        uses: apify/actions/signed-commit@v1.0.0
         with:
-          commit-message: "docs: Version docs for v${{ steps.snapshot.outputs.version }} [skip ci]"
+          message: "docs: Version docs for v${{ steps.snapshot.outputs.version }} [skip ci]"
+          add: 'website/versioned_docs website/versioned_sidebars website/versions.json'
+          pull: '--rebase --autostash'
           github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -6,15 +6,6 @@ on:
 
   # Runs when invoked by another workflow.
   workflow_call:
-    inputs:
-      ref:
-        description: Git ref to checkout.
-        required: true
-        type: string
-    outputs:
-      version_docs_commitish:
-        description: The commit SHA of the versioned docs commit.
-        value: ${{ jobs.version_docs.outputs.version_docs_commitish }}
 
 concurrency:
   group: version-docs
@@ -31,8 +22,6 @@ jobs:
   version_docs:
     name: Version docs
     runs-on: ubuntu-latest
-    outputs:
-      version_docs_commitish: ${{ steps.resolve_commitish.outputs.commitish }}
     permissions:
       contents: write
 
@@ -41,21 +30,10 @@ jobs:
         working-directory: website
 
     steps:
-      - name: Determine checkout ref
-        id: resolve_ref
-        working-directory: .
-        env:
-          INPUT_REF: ${{ inputs.ref }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: |
-          REF="${INPUT_REF:-$DEFAULT_BRANCH}"
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-          ref: ${{ inputs.ref || github.event.repository.default_branch }}
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -117,20 +95,21 @@ jobs:
           pnpm exec docusaurus docs:version "$MAJOR_MINOR_VERSION"
           pnpm exec docusaurus api:version "$MAJOR_MINOR_VERSION"
 
-      - name: Commit and push versioned docs
-        id: commit_versioned_docs
-        uses: EndBug/add-and-commit@v10
-        with:
-          add: website/versioned_docs website/versioned_sidebars website/versions.json
-          message: "docs: Version docs for v${{ steps.snapshot.outputs.version }} [skip ci]"
-          default_author: github_actions
-          # `actions/checkout` detaches HEAD on SHA refs; EndBug needs a branch to push.
-          new_branch: ${{ github.event.repository.default_branch }}
-          pull: '--rebase --autostash'
-
-      - name: Resolve output commitish
-        id: resolve_commitish
-        env:
-          COMMIT_SHA: ${{ steps.commit_versioned_docs.outputs.commit_long_sha }}
+      - name: Stage versioned docs
+        id: stage
+        working-directory: .
         run: |
-          echo "commitish=${COMMIT_SHA:-$(git rev-parse HEAD)}" >> "$GITHUB_OUTPUT"
+          git pull --rebase --autostash
+          git add website/versioned_docs website/versioned_sidebars website/versions.json
+          if git diff --cached --quiet; then
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push versioned docs
+        if: steps.stage.outputs.has-changes == 'true'
+        uses: apify/workflows/commit@v0.44.0
+        with:
+          commit-message: "docs: Version docs for v${{ steps.snapshot.outputs.version }} [skip ci]"
+          github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -25,9 +25,6 @@ jobs:
       pages: write
       id-token: write
     uses: ./.github/workflows/manual_release_docs.yaml
-    with:
-      # Use the same ref as the one that triggered the workflow.
-      ref: ${{ github.ref }}
     secrets: inherit
 
   code_checks:


### PR DESCRIPTION
We want to enforce commit signing for all commits in our repositories.
To do that, we need to make sure even commits created by CI workflows are signed.

It would be possible to sign using GPG keys, but that would require a lot of maintenance.

Instead, we can commit using the GitHub GraphQL API, which automatically signs commits.

This PR replaces direct `git commit` / `git push` usage (and third-party commit actions like `EndBug/add-and-commit`)
with the `apify/actions/signed-commit` action, which uses the GraphQL API under the hood.

As agreed on Slack, I'm also simplifying the workflows to always work on top of the default branch, rather than on a ref passed down through the input, as it should effectively be the same.