### PR TITLE
chore: Replace calling reusable actions from `apify/workflows/...` to `apify/actions/...` [internal]

### DIFF
--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -2,7 +2,7 @@ name: Beta release
 
 on:
   # Runs when manually triggered from the GitHub UI, or dispatched from `on_master.yaml`
-  # via the `apify/workflows/execute-workflow` action for the automatic beta release on push to master.
+  # via the `apify/actions/execute-workflow` action for the automatic beta release on push to master.
   # Note: This workflow is intentionally NOT a reusable workflow (no `workflow_call`) because PyPI's
   # Trusted Publishing does not currently support reusable workflows.
   # See: https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
@@ -23,7 +23,7 @@ jobs:
       version_number: ${{ steps.release_prepare.outputs.version_number }}
       changelog: ${{ steps.release_prepare.outputs.changelog }}
     steps:
-      - uses: apify/workflows/git-cliff-release@main
+      - uses: apify/actions/git-cliff-release@v1.0.0
         id: release_prepare
         name: Release prepare
         with:
@@ -53,7 +53,7 @@ jobs:
       url: https://pypi.org/project/apify
     steps:
       - name: Prepare distribution
-        uses: apify/workflows/prepare-pypi-distribution@main
+        uses: apify/actions/prepare-pypi-distribution@v1.0.0
         with:
           package_name: apify
           is_prerelease: "yes"

--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -50,7 +50,7 @@ jobs:
         run: uv run poe install-dev
 
       - name: Install pnpm and website dependencies
-        uses: apify/workflows/pnpm-install@main
+        uses: apify/actions/pnpm-install@v1.0.0
         with:
           working-directory: website
 

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -43,7 +43,7 @@ jobs:
       changelog: ${{ steps.release_prepare.outputs.changelog }}
       release_notes: ${{ steps.release_prepare.outputs.release_notes }}
     steps:
-      - uses: apify/workflows/git-cliff-release@main
+      - uses: apify/actions/git-cliff-release@v1.0.0
         name: Release prepare
         id: release_prepare
         with:
@@ -91,7 +91,7 @@ jobs:
       url: https://pypi.org/project/apify
     steps:
       - name: Prepare distribution
-        uses: apify/workflows/prepare-pypi-distribution@main
+        uses: apify/actions/prepare-pypi-distribution@v1.0.0
         with:
           package_name: apify
           is_prerelease: ""

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -55,7 +55,7 @@ jobs:
         working-directory: .
 
       - name: Install pnpm and website dependencies
-        uses: apify/workflows/pnpm-install@main
+        uses: apify/actions/pnpm-install@v1.0.0
         with:
           working-directory: website
 

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -56,6 +56,6 @@ jobs:
       actions: write # Required by execute-workflow.
     steps:
       - name: Dispatch beta release workflow
-        uses: apify/workflows/execute-workflow@main
+        uses: apify/actions/execute-workflow@v1.0.0
         with:
           workflow: manual_release_beta.yaml


### PR DESCRIPTION
It was confusing that we have our custom GitHub actions in a repository called `workflows`. I've moved them to a new repository called `actions`, and this PR replaces the references to the actions to point to the new repository.

There are no functional changes, the actions just moved.