### PR TITLE
test: install matching Chromium in e2e playwright Dockerfile

### DIFF
--- a/tests/e2e/test_crawlee/actor_source/playwright.Dockerfile
+++ b/tests/e2e/test_crawlee/actor_source/playwright.Dockerfile
@@ -6,4 +6,8 @@ RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --force-reinstall -r requirements.txt
 
+# Reinstall the Chromium binary so it matches the just-installed Playwright version
+# (the base image's pre-installed browser can lag behind a newer Playwright pulled via crawlee[playwright]).
+RUN playwright install chromium
+
 CMD ["sh", "-c", "python server.py & python -m src"]


### PR DESCRIPTION
## Summary

The e2e `playwright.Dockerfile` does `pip install --force-reinstall -r requirements.txt`, which can pull a newer Playwright via `crawlee[playwright]` than the one pre-installed in the `apify/actor-python-playwright` base image. When that happens, the matching Chromium binary isn't on disk and the Actor fails at browser launch with:

```
BrowserType.launch_persistent_context: Executable doesn't exist at /pw-browsers/chromium_headless_shell-1223/chrome-headless-shell-linux64/chrome-headless-shell
```

This broke both `test_playwright_crawler` and `test_adaptive_playwright_crawler` on master after a fresh crawlee/playwright release. Failing CI run: https://github.com/apify/apify-sdk-python/actions/runs/26033470032/job/76525272306

## Fix

Run `playwright install chromium` after the pip force-reinstall so the browser binary always matches the just-installed Playwright version, regardless of how stale the base image's bundled Chromium is.