### PR TITLE
chore(docs): fix codeowner patterns

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Documentation codeowner
 
-/docs/*.md @szaganek
-/docs/*.mdx @szaganek
+/docs/**/*.md @szaganek
+/docs/**/*.mdx @szaganek


### PR DESCRIPTION
Current patterns don't cover the docs tree.