### PR TITLE
test: fix flaky request-reclaim tests with poll_until_condition

### DIFF
--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -260,8 +260,9 @@ async def test_request_reclaim_functionality(
 
     Actor.log.info('Request reclaimed successfully')
 
-    # Should be able to fetch the same request again.
-    request2 = await call_with_exp_backoff(rq.fetch_next_request, rq_access_mode=rq_access_mode)
+    # Should be able to fetch the same request again. A reclaimed request may take a moment to reappear
+    # at the queue head (eventually-consistent API state), even in single mode, so poll until it does.
+    request2 = await poll_until_condition(rq.fetch_next_request, lambda result: result is not None)
 
     assert request2 is not None
     assert request2.url == fetched_request.url

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -301,8 +301,9 @@ async def test_request_reclaim_with_forefront(
     await rq.reclaim_request(first_request, forefront=True)
     Actor.log.info('Request reclaimed to forefront')
 
-    # The reclaimed request should be fetched first again.
-    next_request = await call_with_exp_backoff(rq.fetch_next_request, rq_access_mode=rq_access_mode)
+    # The reclaimed request should be fetched first again. A reclaimed request may take a moment to reappear
+    # at the queue head (eventually-consistent API state), even in single mode, so poll until it does.
+    next_request = await poll_until_condition(rq.fetch_next_request, lambda result: result is not None)
 
     assert next_request is not None
     assert next_request.url == first_request.url


### PR DESCRIPTION
Fixes flaky integration tests caused by the eventually-consistent request queue API behavior after `reclaim_request`.

## The race

After `reclaim_request`, an immediate `fetch_next_request` could return `None`: a reclaimed request takes a moment to reappear at the queue head (eventually-consistent API state), and in `single` mode `call_with_exp_backoff` calls the function exactly once with no retry. This caused intermittent `assert None is not None` failures.

## Fixes

Two tests share this exact shape — `reclaim_request` followed by an immediate fetch-and-assert. Both now use the mode-agnostic `poll_until_condition` helper, which polls `fetch_next_request` until it returns a request (or times out), covering both `single` and `shared` modes:

- `test_request_reclaim_functionality` — the originally observed flake.
- `test_request_reclaim_with_forefront` — the same latent flake, found by sweeping the test suite for the same pattern.

Observed failure: https://github.com/apify/apify-sdk-python/actions/runs/26645106359/job/78528385633
