### PR TITLE
ci: run docs versioning commands through uv run

### DIFF
--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -120,10 +120,12 @@ jobs:
             echo "No existing versions found for major $MAJOR_VERSION, nothing to remove"
           fi
 
-          # Build API reference and create Docusaurus version snapshots.
+          # Build API reference and create Docusaurus version snapshots. The Docusaurus commands must run
+          # through `uv run` so that the project virtual environment is on PATH — the typedoc-api plugin
+          # spawns `python` to generate the API reference dump and needs `pydoc-markdown` to be importable.
           bash build_api_reference.sh
-          pnpm exec docusaurus docs:version "$MAJOR_MINOR_VERSION"
-          pnpm exec docusaurus api:version "$MAJOR_MINOR_VERSION"
+          uv run pnpm exec docusaurus docs:version "$MAJOR_MINOR_VERSION"
+          uv run pnpm exec docusaurus api:version "$MAJOR_MINOR_VERSION"
 
       - name: Commit and push versioned docs
         uses: apify/actions/signed-commit@v1.2.0


### PR DESCRIPTION
## Summary

The `Version docs` job has failed on both the 3.4.0 and 3.4.1 releases, which also skipped the dependent `Doc release` job — the docs site is still stuck on 3.3 (version dropdown and `Version: 3.3` badge).

Root cause: the pnpm migration (#855) changed the snapshot step from `uv run npx docusaurus ...` to plain `pnpm exec docusaurus ...`, dropping the `uv run` wrapper. The `@apify/docusaurus-plugin-typedoc-api` plugin spawns a bare `python` to generate the API reference dump (`generate_ast.py`), which needs `pydoc-markdown` from the project venv. Without `uv run`, the venv is not on PATH, the script fails (the plugin only checks for spawn errors, not the exit code), and the job dies later with `ENOENT: pydoc-markdown-dump.json` — exactly what the logs of runs [26631120750](https://github.com/apify/apify-sdk-python/actions/runs/26631120750) and [25363849495](https://github.com/apify/apify-sdk-python/actions/runs/25363849495) show.

This restores the `uv run` wrapper (consistent with the `build-docs` poe task, which is why doc deploys themselves still worked) and adds a comment explaining why it is needed. Verified locally: the snapshot sequence fails without `uv run` and passes with it.

Follow-up (separate from this PR): the fix needs to be cherry-picked to `release-v3`, `Version docs` re-dispatched there with version `3.4.1`, `Release docs` re-dispatched, and the snapshot synced back to master.