### PR TITLE
test: retry flaky webhook E2E test on platform-side timeouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dev = [
     "pytest-asyncio<2.0.0",
     "pytest-cov<8.0.0",
     "pytest-httpserver<2.0.0",
-    "pytest-rerunfailures<16.0.0",
+    "pytest-rerunfailures<17.0.0",
     "pytest-timeout<3.0.0",
     "pytest-xdist<4.0.0",
     "pytest<10.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ dev = [
     "pytest-asyncio<2.0.0",
     "pytest-cov<8.0.0",
     "pytest-httpserver<2.0.0",
+    "pytest-rerunfailures<16.0.0",
     "pytest-timeout<3.0.0",
     "pytest-xdist<4.0.0",
     "pytest<10.0.0",

--- a/tests/e2e/test_actor_api_helpers.py
+++ b/tests/e2e/test_actor_api_helpers.py
@@ -389,11 +389,9 @@ async def test_actor_reboots_successfully(
     assert reboot_counter['value'] == 2
 
 
-# This E2E test relies on the Apify platform delivering a webhook (fired by the client Actor's `ACTOR_RUN_SUCCEEDED`
-# event) to the server Actor's container. The server Actor blocks until that webhook arrives, so when platform-side
-# delivery is delayed past the run timeout, the server run ends as `TIMED-OUT` and the test fails. This is a
-# platform-timing flake outside the SDK's control, so we retry it a couple of times before giving up.
-@pytest.mark.flaky(reruns=2)
+# Flaky: the server Actor blocks until the platform delivers the client's `ACTOR_RUN_SUCCEEDED` webhook; when
+# delivery is delayed past the run timeout, the run ends as `TIMED-OUT`. Platform-side, outside our control, so retry.
+@pytest.mark.flaky(reruns=3)
 async def test_actor_adds_webhook_and_receives_event(
     make_actor: MakeActorFunction,
     run_actor: RunActorFunction,

--- a/tests/e2e/test_actor_api_helpers.py
+++ b/tests/e2e/test_actor_api_helpers.py
@@ -4,6 +4,8 @@ import asyncio
 import json
 from typing import TYPE_CHECKING
 
+import pytest
+
 from apify_shared.consts import ActorPermissionLevel
 from crawlee._utils.crypto import crypto_random_object_id
 
@@ -387,6 +389,11 @@ async def test_actor_reboots_successfully(
     assert reboot_counter['value'] == 2
 
 
+# This E2E test relies on the Apify platform delivering a webhook (fired by the client Actor's `ACTOR_RUN_SUCCEEDED`
+# event) to the server Actor's container. The server Actor blocks until that webhook arrives, so when platform-side
+# delivery is delayed past the run timeout, the server run ends as `TIMED-OUT` and the test fails. This is a
+# platform-timing flake outside the SDK's control, so we retry it a couple of times before giving up.
+@pytest.mark.flaky(reruns=2)
 async def test_actor_adds_webhook_and_receives_event(
     make_actor: MakeActorFunction,
     run_actor: RunActorFunction,

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ dev = [
     { name = "pytest-asyncio", specifier = "<2.0.0" },
     { name = "pytest-cov", specifier = "<8.0.0" },
     { name = "pytest-httpserver", specifier = "<2.0.0" },
-    { name = "pytest-rerunfailures", specifier = "<16.0.0" },
+    { name = "pytest-rerunfailures", specifier = "<17.0.0" },
     { name = "pytest-timeout", specifier = "<3.0.0" },
     { name = "pytest-xdist", specifier = "<4.0.0" },
     { name = "ruff", specifier = "~=0.15.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -72,6 +72,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-httpserver" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
@@ -114,6 +115,7 @@ dev = [
     { name = "pytest-asyncio", specifier = "<2.0.0" },
     { name = "pytest-cov", specifier = "<8.0.0" },
     { name = "pytest-httpserver", specifier = "<2.0.0" },
+    { name = "pytest-rerunfailures", specifier = "<16.0.0" },
     { name = "pytest-timeout", specifier = "<3.0.0" },
     { name = "pytest-xdist", specifier = "<4.0.0" },
     { name = "ruff", specifier = "~=0.15.0" },
@@ -1925,6 +1927,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/17/ad187f46998814014f7cda309de700b87c0eb4b2e111e18bc8c819be7116/pytest_httpserver-1.1.5.tar.gz", hash = "sha256:dc3d82e1fe00e491829d8939c549bf4bd9b39a260f87113c619b9d517c2f8ff1", size = 70974, upload-time = "2026-02-14T13:27:23.412Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/df/0bdf90b84c6a586a9fd2b509523a3ab26b1cc1b1dba2fb62a32e4411ea9e/pytest_httpserver-1.1.5-py3-none-any.whl", hash = "sha256:ee83feb587ab652c0c6729598db2820e9048233bac8df756818b7845a1621d0a", size = 23330, upload-time = "2026-02-14T13:27:22.119Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/78/e6e358545537a8e82c4dc91e72ec0d6f80546a3786dd27c76b06ca09db77/pytest_rerunfailures-15.1.tar.gz", hash = "sha256:c6040368abd7b8138c5b67288be17d6e5611b7368755ce0465dda0362c8ece80", size = 26981, upload-time = "2025-05-08T06:36:33.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/30/11d836ff01c938969efa319b4ebe2374ed79d28043a12bfc908577aab9f3/pytest_rerunfailures-15.1-py3-none-any.whl", hash = "sha256:f674c3594845aba8b23c78e99b1ff8068556cc6a8b277f728071fdc4f4b0b355", size = 13274, upload-time = "2025-05-08T06:36:32.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The E2E test `test_actor_adds_webhook_and_receives_event` is flaky. The server Actor blocks until the Apify platform delivers the webhook fired by the client Actor's `ACTOR_RUN_SUCCEEDED` event; when platform-side delivery is delayed past the server run's 600s timeout, the run ends as `TIMED-OUT` and the assertion fails. This has been observed on both `master` (run 26950690902) and an unrelated docs PR (run 26959362332) on the same day, each burning the full timeout with no delivery.

There is no test-logic root cause to fix — the latency is platform-side and outside the SDK's control. This adds `pytest-rerunfailures` and marks the test `@pytest.mark.flaky(reruns=3)`, so a transient delivery hiccup is retried instead of failing CI. A comment on the test documents the failure mode.