### PR TITLE
fix(scrapy): Tolerate malformed HTTP cache items and delete expired ones

### DIFF
--- a/src/apify/scrapy/extensions/_httpcache.py
+++ b/src/apify/scrapy/extensions/_httpcache.py
@@ -86,11 +86,11 @@ class ApifyCacheStorage:
                         gzip_time = read_gzip_time(value)
                     except Exception as e:
                         logger.warning(f'Malformed cache item {item.key}: {e}')
-                        await self._kvs.set_value(item.key, None)
+                        await self._kvs.delete_value(item.key)
                     else:
                         if self._expiration_secs < current_time - gzip_time:
                             logger.debug(f'Expired cache item {item.key}')
-                            await self._kvs.set_value(item.key, None)
+                            await self._kvs.delete_value(item.key)
                         else:
                             logger.debug(f'Valid cache item {item.key}')
                     if i == self._expiration_max_items:
@@ -127,15 +127,23 @@ class ApifyCacheStorage:
 
         if current_time is None:
             current_time = int(time())
-        if 0 < self._expiration_secs < current_time - read_gzip_time(value):
-            logger.debug('Cache expired', extra={'request': request})
+
+        try:
+            if 0 < self._expiration_secs < current_time - read_gzip_time(value):
+                logger.debug('Cache expired', extra={'request': request})
+                return None
+
+            data = from_gzip(value)
+            url = data['url']
+            status = data['status']
+            headers = Headers(data['headers'])
+            body = data['body']
+        except Exception as e:
+            # A corrupt or incompatible cache item (e.g. a legacy or foreign serialization format) must
+            # degrade to a cache miss rather than break the whole download.
+            logger.warning(f'Ignoring malformed cache item {key}: {e}')
             return None
 
-        data = from_gzip(value)
-        url = data['url']
-        status = data['status']
-        headers = Headers(data['headers'])
-        body = data['body']
         respcls = responsetypes.from_args(headers=headers, url=url, body=body)
 
         logger.debug('Cache hit', extra={'request': request})

--- a/tests/unit/scrapy/extensions/test_httpcache.py
+++ b/tests/unit/scrapy/extensions/test_httpcache.py
@@ -1,8 +1,13 @@
+import asyncio
+import gzip
 from time import time
+from typing import Any
 
 import pytest
+from scrapy import Request
+from scrapy.settings import Settings
 
-from apify.scrapy.extensions._httpcache import from_gzip, get_kvs_name, read_gzip_time, to_gzip
+from apify.scrapy.extensions._httpcache import ApifyCacheStorage, from_gzip, get_kvs_name, read_gzip_time, to_gzip
 
 FIXTURE_DICT = {'name': 'Alice'}
 
@@ -69,3 +74,55 @@ def test_get_kvs_name(spider_name: str, expected: str) -> None:
 def test_get_kvs_name_raises(spider_name: str) -> None:
     with pytest.raises(ValueError, match=r'Unsupported spider name'):
         assert get_kvs_name(spider_name)
+
+
+# Helpers for driving `ApifyCacheStorage.retrieve_response` without a real KVS or event loop thread.
+
+
+class _FakeAsyncThread:
+    def run_coro(self, coro: Any, *_: Any, **__: Any) -> Any:
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+
+class _FakeKvs:
+    def __init__(self, value: bytes | None) -> None:
+        self._value = value
+
+    async def get_value(self, _: str) -> bytes | None:
+        return self._value
+
+
+class _FakeFingerprinter:
+    def fingerprint(self, _: Request) -> bytes:
+        return b'\xab\xcd'
+
+
+def _make_storage(value: bytes | None) -> ApifyCacheStorage:
+    storage = ApifyCacheStorage(Settings({'HTTPCACHE_EXPIRATION_SECS': 0}))
+    storage._async_thread = _FakeAsyncThread()  # ty: ignore[invalid-assignment]
+    storage._kvs = _FakeKvs(value)  # ty: ignore[invalid-assignment]
+    storage._fingerprinter = _FakeFingerprinter()  # ty: ignore[invalid-assignment]
+    return storage
+
+
+def test_retrieve_response_returns_cached_response() -> None:
+    data = {'status': 200, 'url': 'https://example.com', 'headers': {}, 'body': b'hello'}
+    storage = _make_storage(to_gzip(data))
+
+    response = storage.retrieve_response(None, Request('https://example.com'))  # ty: ignore[invalid-argument-type]
+
+    assert response is not None
+    assert response.status == 200
+    assert response.body == b'hello'
+
+
+def test_retrieve_response_ignores_malformed_item() -> None:
+    # A gzip-wrapped JSON payload is a legacy/foreign cache format that the pickle reader cannot
+    # load. Such an item must degrade to a cache miss instead of raising and breaking the download.
+    storage = _make_storage(gzip.compress(b'{"status": 200}'))
+
+    assert storage.retrieve_response(None, Request('https://example.com')) is None  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
### What

Make the Scrapy `ApifyCacheStorage` resilient to cache entries it cannot deserialize, and fix the cleanup so it actually removes stale entries.

- `retrieve_response` now treats any undecodable cache item as a cache miss (`return None`) instead of letting the exception propagate. Previously a single bad entry raised out of the cache middleware and turned every request (including the initial robots.txt fetch) into a download error, so the spider scraped nothing.
- `close_spider`/`expire_kvs` now use `delete_value` instead of `set_value(..., None)` to purge expired/malformed items. Under apify-client v3, `set_value(..., None)` no longer deletes the record — it stores a JSON `null` — so bad items were never cleaned up and piled up in the shared key-value store.

### Why

The e2e test `test_actor_scrapy_title_spider` was failing with `assert 0 >= 9`. The HTTP cache (a persistent named KVS keyed only by spider name, shared across all branches/runs) contained legacy `gzip(JSON)` entries written by another branch's experiments. The pickle-based reader hit them and raised `UnpicklingError: invalid load key, '{'`, which broke the whole crawl. The ineffective `set_value(..., None)` cleanup meant the store could never self-heal.

### Tests

Added two `retrieve_response` unit tests: a malformed `gzip(JSON)` entry resolves to a cache miss, and a valid entry still returns a proper response.
