### PR TITLE
test: deflake test_pre_existing_request_with_user_data in single RQ mode

### DIFF
--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -1137,7 +1137,6 @@ async def test_rq_long_url(
 async def test_pre_existing_request_with_user_data(
     request_queue_apify: RequestQueue,
     apify_client_async: ApifyClientAsync,
-    rq_poll_timeout: int,
 ) -> None:
     """Test that pre-existing requests with user data are fully fetched.
 
@@ -1154,8 +1153,10 @@ async def test_pre_existing_request_with_user_data(
     rq_client = apify_client_async.request_queue(request_queue_id=rq.id)
     await rq_client.add_request(req.model_dump(by_alias=True))
 
-    # Fetch the request by the client under test.
-    request_obtained = await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2)
+    # Fetch the request by the client under test. It was added by a different producer, so single-mode immediate
+    # consistency (which only covers the client's own writes) does not apply: poll until the write propagates,
+    # the same way shared mode does, rather than relying on `rq_poll_timeout` (0 in single mode).
+    request_obtained = await poll_until_condition(rq.fetch_next_request, timeout=30, backoff_factor=2)
     assert request_obtained is not None
     # Test that custom_data is preserved in user_data (custom_data should be subset of obtained user_data)
     assert custom_data.items() <= request_obtained.user_data.items()


### PR DESCRIPTION
## Summary

Deflakes `test_pre_existing_request_with_user_data[single]`, which intermittently failed in CI with `assert None is not None` (e.g. [this run](https://github.com/apify/apify-sdk-python/actions/runs/27278256135/job/80565251501)).

## Root cause

The test adds a request via a **different producer** (the raw `apify_client_async` client), then fetches it with the single-mode client under test. In single mode the `rq_poll_timeout` fixture is `0`, so `poll_until_condition` calls `fetch_next_request` exactly once — a single `list_head` API call with no retry. Single-mode "reads are immediately consistent" only holds for the client's *own* writes; an external producer's write that hasn't yet propagated to `list_head` returns `None`, and with zero retries the assertion fails.

## Fix

Poll with a generous 30s ceiling regardless of access mode (matching what shared mode already does), instead of `rq_poll_timeout=0`. The now-unused `rq_poll_timeout` parameter is dropped. The `[shared]` parametrization already used `timeout=30` and was unaffected.