### PR TITLE
fix: Bump typing-extensions floor to 4.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "lazy-object-proxy>=1.11.0",
     "more_itertools>=10.2.0",
     "pydantic>=2.11.0",
-    "typing-extensions>=4.1.0",
+    "typing-extensions>=4.4.0",
     "websockets>=14.0",
     "yarl>=1.18.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -92,7 +92,7 @@ requires-dist = [
     { name = "more-itertools", specifier = ">=10.2.0" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "scrapy", marker = "extra == 'scrapy'", specifier = ">=2.14.0" },
-    { name = "typing-extensions", specifier = ">=4.1.0" },
+    { name = "typing-extensions", specifier = ">=4.4.0" },
     { name = "websockets", specifier = ">=14.0" },
     { name = "yarl", specifier = ">=1.18.0" },
 ]


### PR DESCRIPTION
The codebase imports `override` from `typing_extensions` in ten modules (and `Unpack` in `events/_apify_event_manager.py`), but `override` was only added in typing_extensions 4.4.0. With the previous `>=4.1.0` floor, a minimal dependency resolution fails at import time. This bumps the floor to `>=4.4.0`, the accurate minimum for the features actually used.