### PR TITLE
test: retry transiently failed Actor builds in e2e make_actor fixture

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 _TOKEN_ENV_VAR = 'APIFY_TEST_USER_API_TOKEN'
 _API_URL_ENV_VAR = 'APIFY_INTEGRATION_TESTS_API_URL'
 _SDK_ROOT_PATH = Path(__file__).parent.parent.parent.resolve()
+_MAX_BUILD_ATTEMPTS = 2
 
 
 @pytest.fixture(scope='session')
@@ -321,10 +322,21 @@ def make_actor(
 
         actor_client = client.actor(created_actor.id)
 
-        print(f'Building Actor {actor_name}...')
-        build_result = await actor_client.build(version_number='0.0')
-        build_client = client.build(build_result.id)
-        build_client_result = await build_client.wait_for_finish(wait_duration=timedelta(seconds=600))
+        # Building the Actor on the platform involves network-dependent steps (installing system packages and
+        # Python dependencies in the Docker image), so a build can occasionally fail transiently. Retry a failed
+        # build once before giving up.
+        build_client_result = None
+        for attempt in range(1, _MAX_BUILD_ATTEMPTS + 1):
+            print(f'Building Actor {actor_name} (attempt {attempt}/{_MAX_BUILD_ATTEMPTS})...')
+            build_result = await actor_client.build(version_number='0.0')
+            build_client = client.build(build_result.id)
+            build_client_result = await build_client.wait_for_finish(wait_duration=timedelta(seconds=600))
+
+            if build_client_result is not None and build_client_result.status == 'SUCCEEDED':
+                break
+
+            build_status = build_client_result.status if build_client_result else None
+            print(f'Build {build_result.id} of Actor {actor_name} finished with status {build_status}')
 
         assert build_client_result is not None
         assert build_client_result.status == 'SUCCEEDED'


### PR DESCRIPTION
The E2E test `test_custom_pipeline_spider` failed in [this CI run](https://github.com/apify/apify-sdk-python/actions/runs/27349338721/job/80806536023) because the Actor build on the platform finished with status `FAILED`. This was a platform-side transient: the same commit passed the full E2E job on Python 3.11, and in the failing job the four sibling Scrapy tests built Actors with identical build inputs (same Dockerfile and `requirements.txt`) successfully. The build does not depend on the test's source files (they are only copied into the image), but it does run network-dependent steps (`apt-get update`, `pip install --force-reinstall`), which occasionally fail.

The `make_actor` fixture now retries a failed platform build once before asserting, which covers this flake class for all E2E tests. A deterministic build break still fails after two attempts, and the failed build ID is printed for debugging.