### PR TITLE
fix: respect explicit zero custom_after_sleep in metamorph and reboot

### DIFF
--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -1166,7 +1166,7 @@ class _ActorType:
             self.log.error('Actor.metamorph() is only supported when running on the Apify platform.')
             return
 
-        if not custom_after_sleep:
+        if custom_after_sleep is None:
             custom_after_sleep = self.configuration.metamorph_after_sleep
 
         # If is_at_home() is True, configuration.actor_run_id is always set
@@ -1208,7 +1208,7 @@ class _ActorType:
 
         self._is_rebooting = True
 
-        if not custom_after_sleep:
+        if custom_after_sleep is None:
             custom_after_sleep = self.configuration.metamorph_after_sleep
 
         # Call all the listeners for the PERSIST_STATE and MIGRATING events, and wait for them to finish.

--- a/tests/unit/actor/test_actor_helpers.py
+++ b/tests/unit/actor/test_actor_helpers.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -419,4 +420,40 @@ async def test_reboot_proceeds_when_event_listener_exceeds_timeout(
     assert any('Pre-reboot event listeners did not finish within timeout' in r.message for r in caplog.records)
 
     # The reboot API call proceeded despite the hanging listener.
+    assert len(apify_client_async_patcher.calls['run']['reboot']) == 1
+
+
+async def test_metamorph_with_zero_custom_after_sleep_does_not_sleep(
+    apify_client_async_patcher: ApifyClientAsyncPatcher,
+) -> None:
+    """Test that an explicit `custom_after_sleep=timedelta(0)` is not replaced by the default sleep duration."""
+    apify_client_async_patcher.patch('run', 'metamorph', return_value=None)
+
+    async with Actor:
+        Actor.configuration.is_at_home = True
+        Actor.configuration.actor_run_id = 'some-run-id'
+
+        with patch('asyncio.sleep', new=AsyncMock()) as sleep_mock:
+            await Actor.metamorph('target-actor-id', custom_after_sleep=timedelta(0))
+
+        sleep_mock.assert_not_awaited()
+
+    assert len(apify_client_async_patcher.calls['run']['metamorph']) == 1
+
+
+async def test_reboot_with_zero_custom_after_sleep_does_not_sleep(
+    apify_client_async_patcher: ApifyClientAsyncPatcher,
+) -> None:
+    """Test that an explicit `custom_after_sleep=timedelta(0)` is not replaced by the default sleep duration."""
+    apify_client_async_patcher.patch('run', 'reboot', return_value=None)
+
+    async with Actor:
+        Actor.configuration.is_at_home = True
+        Actor.configuration.actor_run_id = 'some-run-id'
+
+        with patch('asyncio.sleep', new=AsyncMock()) as sleep_mock:
+            await Actor.reboot(custom_after_sleep=timedelta(0))
+
+        sleep_mock.assert_not_awaited()
+
     assert len(apify_client_async_patcher.calls['run']['reboot']) == 1


### PR DESCRIPTION
## Description

- `Actor.metamorph()` and `Actor.reboot()` used a falsy check on `custom_after_sleep`, so an explicit `timedelta(0)` was treated as unset and silently replaced with the 5-minute default (`Configuration.metamorph_after_sleep`).
- Changed both checks to `is None`, so an explicit zero now skips the after-sleep entirely, while omitting the argument (or passing `None`) still uses the default.
- Added unit tests covering both methods, asserting that no sleep happens for `timedelta(0)` and that the underlying API call is still made.