### PR TITLE
fix: commit request queue dedup cache only after batch_add_requests succeeds

### DIFF
--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -107,6 +107,20 @@ class ApifyRequestQueueSharedClient:
                 )
 
             else:
+                # Optimistically add the new request to the cache so that concurrent producers deduplicate
+                # against this in-flight request instead of re-sending it to the platform. Rolled back below if
+                # the `batch_add_requests` call fails, otherwise the never-sent request would poison the cache
+                # and a later retry of the same request would be silently deduplicated and lost.
+                processed_request = ProcessedRequest(
+                    id=request_id,
+                    unique_key=request.unique_key,
+                    was_already_present=True,
+                    was_already_handled=request.was_already_handled,
+                )
+                self._cache_request(
+                    request_id,
+                    processed_request,
+                )
                 new_requests.append(request)
 
         if new_requests:
@@ -114,10 +128,17 @@ class ApifyRequestQueueSharedClient:
             requests_dict = [request.model_dump(by_alias=True) for request in new_requests]
 
             # Send requests to API.
-            batch_response = await self._api_client.batch_add_requests(
-                requests=requests_dict,
-                forefront=forefront,
-            )
+            try:
+                batch_response = await self._api_client.batch_add_requests(
+                    requests=requests_dict,
+                    forefront=forefront,
+                )
+            except Exception:
+                # The platform never received these requests, so roll back the optimistic cache writes to keep
+                # a later retry from being deduplicated away.
+                for request in new_requests:
+                    self._requests_cache.pop(unique_key_to_request_id(request.unique_key), None)
+                raise
 
             batch_response_dict = batch_response.model_dump(by_alias=True)
             api_response = AddRequestsResponse.model_validate(batch_response_dict)
@@ -125,25 +146,10 @@ class ApifyRequestQueueSharedClient:
             # Add the locally known already present processed requests based on the local cache.
             api_response.processed_requests.extend(already_present_requests)
 
-            # Commit only requests the platform actually accepted to the local cache. Caching before the call
-            # would deduplicate a later retry of a request that never reached the platform, silently losing it.
-            unprocessed_ids = {
-                unique_key_to_request_id(unprocessed_request.unique_key)
-                for unprocessed_request in api_response.unprocessed_requests
-            }
-            for request in new_requests:
-                request_id = unique_key_to_request_id(request.unique_key)
-                if request_id in unprocessed_ids:
-                    continue
-                self._cache_request(
-                    request_id,
-                    ProcessedRequest(
-                        id=request_id,
-                        unique_key=request.unique_key,
-                        was_already_present=True,
-                        was_already_handled=request.was_already_handled,
-                    ),
-                )
+            # Remove unprocessed requests from the cache
+            for unprocessed_request in api_response.unprocessed_requests:
+                unprocessed_request_id = unique_key_to_request_id(unprocessed_request.unique_key)
+                self._requests_cache.pop(unprocessed_request_id, None)
 
         else:
             api_response = AddRequestsResponse.model_validate(

--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -107,17 +107,6 @@ class ApifyRequestQueueSharedClient:
                 )
 
             else:
-                # Add new request to the cache.
-                processed_request = ProcessedRequest(
-                    id=request_id,
-                    unique_key=request.unique_key,
-                    was_already_present=True,
-                    was_already_handled=request.was_already_handled,
-                )
-                self._cache_request(
-                    request_id,
-                    processed_request,
-                )
                 new_requests.append(request)
 
         if new_requests:
@@ -136,10 +125,25 @@ class ApifyRequestQueueSharedClient:
             # Add the locally known already present processed requests based on the local cache.
             api_response.processed_requests.extend(already_present_requests)
 
-            # Remove unprocessed requests from the cache
-            for unprocessed_request in api_response.unprocessed_requests:
-                unprocessed_request_id = unique_key_to_request_id(unprocessed_request.unique_key)
-                self._requests_cache.pop(unprocessed_request_id, None)
+            # Commit only requests the platform actually accepted to the local cache. Caching before the call
+            # would deduplicate a later retry of a request that never reached the platform, silently losing it.
+            unprocessed_ids = {
+                unique_key_to_request_id(unprocessed_request.unique_key)
+                for unprocessed_request in api_response.unprocessed_requests
+            }
+            for request in new_requests:
+                request_id = unique_key_to_request_id(request.unique_key)
+                if request_id in unprocessed_ids:
+                    continue
+                self._cache_request(
+                    request_id,
+                    ProcessedRequest(
+                        id=request_id,
+                        unique_key=request.unique_key,
+                        was_already_present=True,
+                        was_already_handled=request.was_already_handled,
+                    ),
+                )
 
         else:
             api_response = AddRequestsResponse.model_validate(

--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -8,15 +8,15 @@ from typing import TYPE_CHECKING, Any, Final
 
 from cachetools import LRUCache
 
-from crawlee.storage_clients.models import (
-    AddRequestsResponse,
-    ProcessedRequest,
-    RequestQueueMetadata,
-    UnprocessedRequest,
-)
+from crawlee.storage_clients.models import AddRequestsResponse, ProcessedRequest, RequestQueueMetadata
 
 from ._models import ApifyRequestQueueMetadata, CachedRequest, RequestQueueHead
-from ._utils import to_crawlee_request, unique_key_to_request_id
+from ._utils import (
+    resolve_awaited_in_flight,
+    settle_pending_addition,
+    to_crawlee_request,
+    unique_key_to_request_id,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Sequence
@@ -175,7 +175,9 @@ class ApifyRequestQueueSharedClient:
                 # it did not, so they retry instead of reporting false success.
                 for request in new_requests:
                     request_id = unique_key_to_request_id(request.unique_key)
-                    self._settle_pending_addition(request_id, committed=request_id in committed_request_ids)
+                    settle_pending_addition(
+                        self._requests_being_added, request_id, committed=request_id in committed_request_ids
+                    )
 
         else:
             api_response = AddRequestsResponse.model_validate(
@@ -183,7 +185,7 @@ class ApifyRequestQueueSharedClient:
             )
 
         # Fold in requests a concurrent call was already adding.
-        await self._resolve_awaited_in_flight(awaited_in_flight, api_response)
+        await resolve_awaited_in_flight(awaited_in_flight, api_response)
 
         logger.debug(
             f'Tried to add new requests: {len(new_requests)}, '
@@ -201,42 +203,6 @@ class ApifyRequestQueueSharedClient:
         self.metadata.pending_request_count += new_request_count
 
         return api_response
-
-    def _settle_pending_addition(self, request_id: str, *, committed: bool) -> None:
-        """Resolve the in-flight add marker for a request, unblocking any concurrent producers awaiting it.
-
-        Args:
-            request_id: ID of the request whose in-flight add has settled.
-            committed: Whether the request was committed to the platform.
-        """
-        future = self._requests_being_added.pop(request_id, None)
-        if future is not None and not future.done():
-            future.set_result(committed)
-
-    @staticmethod
-    async def _resolve_awaited_in_flight(
-        awaited_in_flight: list[tuple[Request, asyncio.Future[bool]]],
-        api_response: AddRequestsResponse,
-    ) -> None:
-        """Await concurrent in-flight adds of these requests and fold the outcome into `api_response`.
-
-        Requests the concurrent add committed are reported as already present; the rest are reported unprocessed
-        so the caller retries them rather than receiving false success.
-        """
-        for request, future in awaited_in_flight:
-            if await future:
-                api_response.processed_requests.append(
-                    ProcessedRequest(
-                        id=unique_key_to_request_id(request.unique_key),
-                        unique_key=request.unique_key,
-                        was_already_present=True,
-                        was_already_handled=request.was_already_handled,
-                    )
-                )
-            else:
-                api_response.unprocessed_requests.append(
-                    UnprocessedRequest(unique_key=request.unique_key, url=request.url, method=request.method)
-                )
 
     async def get_request(self, unique_key: str) -> Request | None:
         """Specific implementation of this method for the RQ shared access mode."""

--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -79,9 +79,14 @@ class ApifyRequestQueueSharedClient:
         self._requests_being_added: dict[str, asyncio.Future[bool]] = {}
         """In-flight `add_batch_of_requests` markers, keyed by request ID.
 
+        Coordinates only concurrent `add_batch_of_requests` calls sharing this one client instance (e.g. several
+        producer coroutines adding requests in the same process). It does not coordinate separate client instances
+        or processes, which each keep their own markers; deduplication across clients still relies on the platform.
+
         Each future resolves once the platform call that is adding the request settles: `True` if the request was
-        committed, `False` otherwise. Concurrent producers of the same request await it instead of re-sending,
-        which preserves deduplication while still avoiding false success when the original add fails.
+        committed, `False` otherwise. A concurrent call adding the same request awaits the future instead of
+        re-sending it, which avoids a duplicate platform write while still avoiding false success when the original
+        add fails.
         """
 
         self._queue_has_locked_requests: bool | None = None
@@ -128,7 +133,7 @@ class ApifyRequestQueueSharedClient:
                 awaited_in_flight.append((request, self._requests_being_added[request_id]))
 
             else:
-                # Register an in-flight marker so concurrent producers dedupe against it; caching is deferred
+                # Register an in-flight marker so a concurrent call dedupes against it; caching is deferred
                 # until the platform confirms the request was accepted (see below).
                 new_requests.append(request)
                 self._requests_being_added[request_id] = loop.create_future()
@@ -170,7 +175,7 @@ class ApifyRequestQueueSharedClient:
                 # Add the locally known already present processed requests based on the local cache.
                 api_response.processed_requests.extend(already_present_requests)
             finally:
-                # Release the in-flight markers we registered. Committed requests tell concurrent producers the
+                # Release the in-flight markers we registered. Committed requests tell concurrent callers the
                 # request reached the platform; everything else (unprocessed, API error, cancellation) tells them
                 # it did not, so they retry instead of reporting false success.
                 for request in new_requests:

--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -107,20 +107,7 @@ class ApifyRequestQueueSharedClient:
                 )
 
             else:
-                # Optimistically add the new request to the cache so that concurrent producers deduplicate
-                # against this in-flight request instead of re-sending it to the platform. Rolled back below if
-                # the `batch_add_requests` call fails, otherwise the never-sent request would poison the cache
-                # and a later retry of the same request would be silently deduplicated and lost.
-                processed_request = ProcessedRequest(
-                    id=request_id,
-                    unique_key=request.unique_key,
-                    was_already_present=True,
-                    was_already_handled=request.was_already_handled,
-                )
-                self._cache_request(
-                    request_id,
-                    processed_request,
-                )
+                # Defer caching until the platform confirms the request was accepted (see below).
                 new_requests.append(request)
 
         if new_requests:
@@ -128,28 +115,36 @@ class ApifyRequestQueueSharedClient:
             requests_dict = [request.model_dump(by_alias=True) for request in new_requests]
 
             # Send requests to API.
-            try:
-                batch_response = await self._api_client.batch_add_requests(
-                    requests=requests_dict,
-                    forefront=forefront,
-                )
-            except Exception:
-                # The platform never received these requests, so roll back the optimistic cache writes to keep
-                # a later retry from being deduplicated away.
-                for request in new_requests:
-                    self._requests_cache.pop(unique_key_to_request_id(request.unique_key), None)
-                raise
+            batch_response = await self._api_client.batch_add_requests(
+                requests=requests_dict,
+                forefront=forefront,
+            )
 
             batch_response_dict = batch_response.model_dump(by_alias=True)
             api_response = AddRequestsResponse.model_validate(batch_response_dict)
 
+            # Commit only the requests the platform actually accepted to the local dedup cache. Caching is done
+            # after `batch_add_requests` succeeds (not before) so that a failed call leaves no entry behind:
+            # caching first would poison the cache and a later retry of the same request would be silently
+            # deduplicated and lost. It also keeps a concurrent producer from observing an uncommitted in-flight
+            # entry and returning false success while this call is still in flight.
+            unprocessed_unique_keys = {request.unique_key for request in api_response.unprocessed_requests}
+            for request in new_requests:
+                if request.unique_key in unprocessed_unique_keys:
+                    continue
+                request_id = unique_key_to_request_id(request.unique_key)
+                self._cache_request(
+                    request_id,
+                    ProcessedRequest(
+                        id=request_id,
+                        unique_key=request.unique_key,
+                        was_already_present=True,
+                        was_already_handled=request.was_already_handled,
+                    ),
+                )
+
             # Add the locally known already present processed requests based on the local cache.
             api_response.processed_requests.extend(already_present_requests)
-
-            # Remove unprocessed requests from the cache
-            for unprocessed_request in api_response.unprocessed_requests:
-                unprocessed_request_id = unique_key_to_request_id(unprocessed_request.unique_key)
-                self._requests_cache.pop(unprocessed_request_id, None)
 
         else:
             api_response = AddRequestsResponse.model_validate(

--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, Any, Final
 
 from cachetools import LRUCache
 
-from crawlee.storage_clients.models import AddRequestsResponse, ProcessedRequest, RequestQueueMetadata
+from crawlee.storage_clients.models import (
+    AddRequestsResponse,
+    ProcessedRequest,
+    RequestQueueMetadata,
+    UnprocessedRequest,
+)
 
 from ._models import ApifyRequestQueueMetadata, CachedRequest, RequestQueueHead
 from ._utils import to_crawlee_request, unique_key_to_request_id
@@ -71,6 +76,14 @@ class ApifyRequestQueueSharedClient:
         self._requests_cache: LRUCache[str, CachedRequest] = LRUCache(maxsize=cache_size)
         """LRU cache storing request objects, keyed by request ID."""
 
+        self._requests_being_added: dict[str, asyncio.Future[bool]] = {}
+        """In-flight `add_batch_of_requests` markers, keyed by request ID.
+
+        Each future resolves once the platform call that is adding the request settles: `True` if the request was
+        committed, `False` otherwise. Concurrent producers of the same request await it instead of re-sending,
+        which preserves deduplication while still avoiding false success when the original add fails.
+        """
+
         self._queue_has_locked_requests: bool | None = None
         """Whether the queue contains requests currently locked by other clients."""
 
@@ -87,9 +100,13 @@ class ApifyRequestQueueSharedClient:
         forefront: bool = False,
     ) -> AddRequestsResponse:
         """Specific implementation of this method for the RQ shared access mode."""
+        loop = asyncio.get_running_loop()
         # Do not try to add previously added requests to avoid pointless expensive calls to API
         new_requests: list[Request] = []
         already_present_requests: list[ProcessedRequest] = []
+        # Requests a concurrent `add_batch_of_requests` call is already sending. We await its outcome instead of
+        # re-sending them, as (request, that call's in-flight future) pairs.
+        awaited_in_flight: list[tuple[Request, asyncio.Future[bool]]] = []
 
         for request in requests:
             request_id = unique_key_to_request_id(request.unique_key)
@@ -106,50 +123,67 @@ class ApifyRequestQueueSharedClient:
                     )
                 )
 
+            elif request_id in self._requests_being_added:
+                # A concurrent call is already adding this request; await its outcome rather than re-sending it.
+                awaited_in_flight.append((request, self._requests_being_added[request_id]))
+
             else:
-                # Defer caching until the platform confirms the request was accepted (see below).
+                # Register an in-flight marker so concurrent producers dedupe against it; caching is deferred
+                # until the platform confirms the request was accepted (see below).
                 new_requests.append(request)
+                self._requests_being_added[request_id] = loop.create_future()
 
         if new_requests:
             # Prepare requests for API by converting to dictionaries.
             requests_dict = [request.model_dump(by_alias=True) for request in new_requests]
 
-            # Send requests to API.
-            batch_response = await self._api_client.batch_add_requests(
-                requests=requests_dict,
-                forefront=forefront,
-            )
-
-            batch_response_dict = batch_response.model_dump(by_alias=True)
-            api_response = AddRequestsResponse.model_validate(batch_response_dict)
-
-            # Commit only the requests the platform actually accepted to the local dedup cache. Caching is done
-            # after `batch_add_requests` succeeds (not before) so that a failed call leaves no entry behind:
-            # caching first would poison the cache and a later retry of the same request would be silently
-            # deduplicated and lost. It also keeps a concurrent producer from observing an uncommitted in-flight
-            # entry and returning false success while this call is still in flight.
-            unprocessed_unique_keys = {request.unique_key for request in api_response.unprocessed_requests}
-            for request in new_requests:
-                if request.unique_key in unprocessed_unique_keys:
-                    continue
-                request_id = unique_key_to_request_id(request.unique_key)
-                self._cache_request(
-                    request_id,
-                    ProcessedRequest(
-                        id=request_id,
-                        unique_key=request.unique_key,
-                        was_already_present=True,
-                        was_already_handled=request.was_already_handled,
-                    ),
+            committed_request_ids: set[str] = set()
+            try:
+                # Send requests to API.
+                batch_response = await self._api_client.batch_add_requests(
+                    requests=requests_dict,
+                    forefront=forefront,
                 )
 
-            # Add the locally known already present processed requests based on the local cache.
-            api_response.processed_requests.extend(already_present_requests)
+                batch_response_dict = batch_response.model_dump(by_alias=True)
+                api_response = AddRequestsResponse.model_validate(batch_response_dict)
+
+                # Commit only the requests the platform actually accepted to the local dedup cache. Caching after
+                # the call succeeds (not before) keeps a failed call from poisoning the cache and silently
+                # deduplicating a later retry of the same request.
+                unprocessed_unique_keys = {request.unique_key for request in api_response.unprocessed_requests}
+                for request in new_requests:
+                    if request.unique_key in unprocessed_unique_keys:
+                        continue
+                    request_id = unique_key_to_request_id(request.unique_key)
+                    self._cache_request(
+                        request_id,
+                        ProcessedRequest(
+                            id=request_id,
+                            unique_key=request.unique_key,
+                            was_already_present=True,
+                            was_already_handled=request.was_already_handled,
+                        ),
+                    )
+                    committed_request_ids.add(request_id)
+
+                # Add the locally known already present processed requests based on the local cache.
+                api_response.processed_requests.extend(already_present_requests)
+            finally:
+                # Release the in-flight markers we registered. Committed requests tell concurrent producers the
+                # request reached the platform; everything else (unprocessed, API error, cancellation) tells them
+                # it did not, so they retry instead of reporting false success.
+                for request in new_requests:
+                    request_id = unique_key_to_request_id(request.unique_key)
+                    self._settle_pending_addition(request_id, committed=request_id in committed_request_ids)
 
         else:
             api_response = AddRequestsResponse.model_validate(
                 {'unprocessedRequests': [], 'processedRequests': already_present_requests}
             )
+
+        # Fold in requests a concurrent call was already adding.
+        await self._resolve_awaited_in_flight(awaited_in_flight, api_response)
 
         logger.debug(
             f'Tried to add new requests: {len(new_requests)}, '
@@ -167,6 +201,42 @@ class ApifyRequestQueueSharedClient:
         self.metadata.pending_request_count += new_request_count
 
         return api_response
+
+    def _settle_pending_addition(self, request_id: str, *, committed: bool) -> None:
+        """Resolve the in-flight add marker for a request, unblocking any concurrent producers awaiting it.
+
+        Args:
+            request_id: ID of the request whose in-flight add has settled.
+            committed: Whether the request was committed to the platform.
+        """
+        future = self._requests_being_added.pop(request_id, None)
+        if future is not None and not future.done():
+            future.set_result(committed)
+
+    @staticmethod
+    async def _resolve_awaited_in_flight(
+        awaited_in_flight: list[tuple[Request, asyncio.Future[bool]]],
+        api_response: AddRequestsResponse,
+    ) -> None:
+        """Await concurrent in-flight adds of these requests and fold the outcome into `api_response`.
+
+        Requests the concurrent add committed are reported as already present; the rest are reported unprocessed
+        so the caller retries them rather than receiving false success.
+        """
+        for request, future in awaited_in_flight:
+            if await future:
+                api_response.processed_requests.append(
+                    ProcessedRequest(
+                        id=unique_key_to_request_id(request.unique_key),
+                        unique_key=request.unique_key,
+                        was_already_present=True,
+                        was_already_handled=request.was_already_handled,
+                    )
+                )
+            else:
+                api_response.unprocessed_requests.append(
+                    UnprocessedRequest(unique_key=request.unique_key, url=request.url, method=request.method)
+                )
 
     async def get_request(self, unique_key: str) -> Request | None:
         """Specific implementation of this method for the RQ shared access mode."""

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -8,14 +8,14 @@ from typing import TYPE_CHECKING, Final
 
 from cachetools import LRUCache
 
-from crawlee.storage_clients.models import (
-    AddRequestsResponse,
-    ProcessedRequest,
-    RequestQueueMetadata,
-    UnprocessedRequest,
-)
+from crawlee.storage_clients.models import AddRequestsResponse, ProcessedRequest, RequestQueueMetadata
 
-from ._utils import to_crawlee_request, unique_key_to_request_id
+from ._utils import (
+    resolve_awaited_in_flight,
+    settle_pending_addition,
+    to_crawlee_request,
+    unique_key_to_request_id,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -198,7 +198,9 @@ class ApifyRequestQueueSingleClient:
                 # it did not, so they retry instead of reporting false success.
                 for request in new_requests:
                     request_id = unique_key_to_request_id(request.unique_key)
-                    self._settle_pending_addition(request_id, committed=request_id in committed_request_ids)
+                    settle_pending_addition(
+                        self._requests_being_added, request_id, committed=request_id in committed_request_ids
+                    )
 
         else:
             api_response = AddRequestsResponse(
@@ -207,7 +209,7 @@ class ApifyRequestQueueSingleClient:
             )
 
         # Fold in requests a concurrent call was already adding.
-        await self._resolve_awaited_in_flight(awaited_in_flight, api_response)
+        await resolve_awaited_in_flight(awaited_in_flight, api_response)
 
         # Update assumed total count for newly added requests.
         new_request_count = 0
@@ -218,42 +220,6 @@ class ApifyRequestQueueSingleClient:
         self.metadata.pending_request_count += new_request_count
 
         return api_response
-
-    def _settle_pending_addition(self, request_id: str, *, committed: bool) -> None:
-        """Resolve the in-flight add marker for a request, unblocking any concurrent producers awaiting it.
-
-        Args:
-            request_id: ID of the request whose in-flight add has settled.
-            committed: Whether the request was committed to the platform.
-        """
-        future = self._requests_being_added.pop(request_id, None)
-        if future is not None and not future.done():
-            future.set_result(committed)
-
-    @staticmethod
-    async def _resolve_awaited_in_flight(
-        awaited_in_flight: list[tuple[Request, asyncio.Future[bool]]],
-        api_response: AddRequestsResponse,
-    ) -> None:
-        """Await concurrent in-flight adds of these requests and fold the outcome into `api_response`.
-
-        Requests the concurrent add committed are reported as already present; the rest are reported unprocessed
-        so the caller retries them rather than receiving false success.
-        """
-        for request, future in awaited_in_flight:
-            if await future:
-                api_response.processed_requests.append(
-                    ProcessedRequest(
-                        id=unique_key_to_request_id(request.unique_key),
-                        unique_key=request.unique_key,
-                        was_already_present=True,
-                        was_already_handled=request.was_already_handled,
-                    )
-                )
-            else:
-                api_response.unprocessed_requests.append(
-                    UnprocessedRequest(unique_key=request.unique_key, url=request.url, method=request.method)
-                )
 
     async def get_request(self, unique_key: str) -> Request | None:
         """Specific implementation of this method for the RQ single access mode."""

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from collections import deque
 from datetime import UTC, datetime
 from logging import getLogger
@@ -139,33 +140,43 @@ class ApifyRequestQueueSingleClient:
                 # Push the request to the platform. Probably not there, or we are not aware of it
                 new_requests.append(request)
 
+                # Optimistically update local caches so that concurrent producers deduplicate against these
+                # in-flight requests instead of re-sending them to the platform. Rolled back below if the
+                # `batch_add_requests` call fails, otherwise the never-sent requests would poison the cache and
+                # a later retry of the same request would be silently deduplicated and lost.
+                self._requests_cache[request_id] = request
+                if forefront:
+                    self._head_requests.append(request_id)
+                else:
+                    self._head_requests.appendleft(request_id)
+
         if new_requests:
             # Prepare requests for API by converting to dictionaries.
             requests_dict = [request.model_dump(by_alias=True) for request in new_requests]
 
             # Send requests to API.
-            batch_response = await self._api_client.batch_add_requests(requests=requests_dict, forefront=forefront)
+            try:
+                batch_response = await self._api_client.batch_add_requests(requests=requests_dict, forefront=forefront)
+            except Exception:
+                # The platform never received these requests, so roll back the optimistic cache writes to keep
+                # a later retry from being deduplicated away.
+                for request in new_requests:
+                    request_id = unique_key_to_request_id(request.unique_key)
+                    self._requests_cache.pop(request_id, None)
+                    with contextlib.suppress(ValueError):
+                        self._head_requests.remove(request_id)
+                raise
+
             batch_response_dict = batch_response.model_dump(by_alias=True)
             api_response = AddRequestsResponse.model_validate(batch_response_dict)
 
             # Add the locally known already present processed requests based on the local cache.
             api_response.processed_requests.extend(already_present_requests)
 
-            # Commit only requests the platform actually accepted to the local caches. Caching before the call
-            # would deduplicate a later retry of a request that never reached the platform, silently losing it.
-            unprocessed_ids = {
-                unique_key_to_request_id(unprocessed_request.unique_key)
-                for unprocessed_request in api_response.unprocessed_requests
-            }
-            for request in new_requests:
-                request_id = unique_key_to_request_id(request.unique_key)
-                if request_id in unprocessed_ids:
-                    continue
-                self._requests_cache[request_id] = request
-                if forefront:
-                    self._head_requests.append(request_id)
-                else:
-                    self._head_requests.appendleft(request_id)
+            # Remove unprocessed requests from the cache
+            for unprocessed_request in api_response.unprocessed_requests:
+                request_id = unique_key_to_request_id(unprocessed_request.unique_key)
+                self._requests_cache.pop(request_id, None)
 
         else:
             api_response = AddRequestsResponse(

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections import deque
 from datetime import UTC, datetime
 from logging import getLogger
@@ -7,7 +8,12 @@ from typing import TYPE_CHECKING, Final
 
 from cachetools import LRUCache
 
-from crawlee.storage_clients.models import AddRequestsResponse, ProcessedRequest, RequestQueueMetadata
+from crawlee.storage_clients.models import (
+    AddRequestsResponse,
+    ProcessedRequest,
+    RequestQueueMetadata,
+    UnprocessedRequest,
+)
 
 from ._utils import to_crawlee_request, unique_key_to_request_id
 
@@ -90,6 +96,14 @@ class ApifyRequestQueueSingleClient:
         Tracked locally to accurately determine when the queue is empty for this single consumer.
         """
 
+        self._requests_being_added: dict[str, asyncio.Future[bool]] = {}
+        """In-flight `add_batch_of_requests` markers, keyed by request ID.
+
+        Each future resolves once the platform call that is adding the request settles: `True` if the request was
+        committed, `False` otherwise. Concurrent producers of the same request await it instead of re-sending,
+        which preserves deduplication while still avoiding false success when the original add fails.
+        """
+
         self._initialized_caches = False
         """Flag indicating whether local caches have been populated from existing queue contents.
 
@@ -108,8 +122,12 @@ class ApifyRequestQueueSingleClient:
             await self._init_caches()
             self._initialized_caches = True
 
+        loop = asyncio.get_running_loop()
         new_requests: list[Request] = []
         already_present_requests: list[ProcessedRequest] = []
+        # Requests a concurrent `add_batch_of_requests` call is already sending. We await its outcome instead of
+        # re-sending them, as (request, that call's in-flight future) pairs.
+        awaited_in_flight: list[tuple[Request, asyncio.Future[bool]]] = []
 
         for request in requests:
             # Calculate id for request
@@ -135,44 +153,61 @@ class ApifyRequestQueueSingleClient:
                         was_already_handled=request.was_already_handled,
                     )
                 )
+            # Check if a concurrent call is already adding this request, and await its outcome rather than
+            # re-sending it.
+            elif request_id in self._requests_being_added:
+                awaited_in_flight.append((request, self._requests_being_added[request_id]))
             else:
-                # Push the request to the platform. Probably not there, or we are not aware of it.
-                # Defer caching until the platform confirms the request was accepted (see below).
+                # Push the request to the platform. Probably not there, or we are not aware of it. Register an
+                # in-flight marker so concurrent producers dedupe against it; caching is deferred until the
+                # platform confirms the request was accepted (see below).
                 new_requests.append(request)
+                self._requests_being_added[request_id] = loop.create_future()
 
         if new_requests:
             # Prepare requests for API by converting to dictionaries.
             requests_dict = [request.model_dump(by_alias=True) for request in new_requests]
 
-            # Send requests to API.
-            batch_response = await self._api_client.batch_add_requests(requests=requests_dict, forefront=forefront)
-            batch_response_dict = batch_response.model_dump(by_alias=True)
-            api_response = AddRequestsResponse.model_validate(batch_response_dict)
+            committed_request_ids: set[str] = set()
+            try:
+                # Send requests to API.
+                batch_response = await self._api_client.batch_add_requests(requests=requests_dict, forefront=forefront)
+                batch_response_dict = batch_response.model_dump(by_alias=True)
+                api_response = AddRequestsResponse.model_validate(batch_response_dict)
 
-            # Commit only the requests the platform actually accepted to the local caches. Caching is done after
-            # `batch_add_requests` succeeds (not before) so that a failed call leaves no entry behind: caching
-            # first would poison the cache and a later retry of the same request would be silently deduplicated
-            # and lost. It also keeps a concurrent producer from observing an uncommitted in-flight entry and
-            # returning false success while this call is still in flight.
-            unprocessed_unique_keys = {request.unique_key for request in api_response.unprocessed_requests}
-            for request in new_requests:
-                if request.unique_key in unprocessed_unique_keys:
-                    continue
-                request_id = unique_key_to_request_id(request.unique_key)
-                self._requests_cache[request_id] = request
-                if forefront:
-                    self._head_requests.append(request_id)
-                else:
-                    self._head_requests.appendleft(request_id)
+                # Commit only the requests the platform actually accepted to the local caches. Caching after the
+                # call succeeds (not before) keeps a failed call from poisoning the cache and silently
+                # deduplicating a later retry of the same request.
+                unprocessed_unique_keys = {request.unique_key for request in api_response.unprocessed_requests}
+                for request in new_requests:
+                    if request.unique_key in unprocessed_unique_keys:
+                        continue
+                    request_id = unique_key_to_request_id(request.unique_key)
+                    self._requests_cache[request_id] = request
+                    if forefront:
+                        self._head_requests.append(request_id)
+                    else:
+                        self._head_requests.appendleft(request_id)
+                    committed_request_ids.add(request_id)
 
-            # Add the locally known already present processed requests based on the local cache.
-            api_response.processed_requests.extend(already_present_requests)
+                # Add the locally known already present processed requests based on the local cache.
+                api_response.processed_requests.extend(already_present_requests)
+            finally:
+                # Release the in-flight markers we registered. Committed requests tell concurrent producers the
+                # request reached the platform; everything else (unprocessed, API error, cancellation) tells them
+                # it did not, so they retry instead of reporting false success.
+                for request in new_requests:
+                    request_id = unique_key_to_request_id(request.unique_key)
+                    self._settle_pending_addition(request_id, committed=request_id in committed_request_ids)
 
         else:
             api_response = AddRequestsResponse(
                 unprocessed_requests=[],
                 processed_requests=already_present_requests,
             )
+
+        # Fold in requests a concurrent call was already adding.
+        await self._resolve_awaited_in_flight(awaited_in_flight, api_response)
 
         # Update assumed total count for newly added requests.
         new_request_count = 0
@@ -183,6 +218,42 @@ class ApifyRequestQueueSingleClient:
         self.metadata.pending_request_count += new_request_count
 
         return api_response
+
+    def _settle_pending_addition(self, request_id: str, *, committed: bool) -> None:
+        """Resolve the in-flight add marker for a request, unblocking any concurrent producers awaiting it.
+
+        Args:
+            request_id: ID of the request whose in-flight add has settled.
+            committed: Whether the request was committed to the platform.
+        """
+        future = self._requests_being_added.pop(request_id, None)
+        if future is not None and not future.done():
+            future.set_result(committed)
+
+    @staticmethod
+    async def _resolve_awaited_in_flight(
+        awaited_in_flight: list[tuple[Request, asyncio.Future[bool]]],
+        api_response: AddRequestsResponse,
+    ) -> None:
+        """Await concurrent in-flight adds of these requests and fold the outcome into `api_response`.
+
+        Requests the concurrent add committed are reported as already present; the rest are reported unprocessed
+        so the caller retries them rather than receiving false success.
+        """
+        for request, future in awaited_in_flight:
+            if await future:
+                api_response.processed_requests.append(
+                    ProcessedRequest(
+                        id=unique_key_to_request_id(request.unique_key),
+                        unique_key=request.unique_key,
+                        was_already_present=True,
+                        was_already_handled=request.was_already_handled,
+                    )
+                )
+            else:
+                api_response.unprocessed_requests.append(
+                    UnprocessedRequest(unique_key=request.unique_key, url=request.url, method=request.method)
+                )
 
     async def get_request(self, unique_key: str) -> Request | None:
         """Specific implementation of this method for the RQ single access mode."""

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -99,9 +99,14 @@ class ApifyRequestQueueSingleClient:
         self._requests_being_added: dict[str, asyncio.Future[bool]] = {}
         """In-flight `add_batch_of_requests` markers, keyed by request ID.
 
+        Coordinates only concurrent `add_batch_of_requests` calls sharing this one client instance (e.g. several
+        producer coroutines adding requests in the same process). It does not coordinate separate client instances
+        or processes, which each keep their own markers; deduplication across clients still relies on the platform.
+
         Each future resolves once the platform call that is adding the request settles: `True` if the request was
-        committed, `False` otherwise. Concurrent producers of the same request await it instead of re-sending,
-        which preserves deduplication while still avoiding false success when the original add fails.
+        committed, `False` otherwise. A concurrent call adding the same request awaits the future instead of
+        re-sending it, which avoids a duplicate platform write while still avoiding false success when the original
+        add fails.
         """
 
         self._initialized_caches = False
@@ -159,7 +164,7 @@ class ApifyRequestQueueSingleClient:
                 awaited_in_flight.append((request, self._requests_being_added[request_id]))
             else:
                 # Push the request to the platform. Probably not there, or we are not aware of it. Register an
-                # in-flight marker so concurrent producers dedupe against it; caching is deferred until the
+                # in-flight marker so a concurrent call dedupes against it; caching is deferred until the
                 # platform confirms the request was accepted (see below).
                 new_requests.append(request)
                 self._requests_being_added[request_id] = loop.create_future()
@@ -193,7 +198,7 @@ class ApifyRequestQueueSingleClient:
                 # Add the locally known already present processed requests based on the local cache.
                 api_response.processed_requests.extend(already_present_requests)
             finally:
-                # Release the in-flight markers we registered. Committed requests tell concurrent producers the
+                # Release the in-flight markers we registered. Committed requests tell concurrent callers the
                 # request reached the platform; everything else (unprocessed, API error, cancellation) tells them
                 # it did not, so they retry instead of reporting false success.
                 for request in new_requests:

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 from collections import deque
 from datetime import UTC, datetime
 from logging import getLogger
@@ -137,46 +136,37 @@ class ApifyRequestQueueSingleClient:
                     )
                 )
             else:
-                # Push the request to the platform. Probably not there, or we are not aware of it
+                # Push the request to the platform. Probably not there, or we are not aware of it.
+                # Defer caching until the platform confirms the request was accepted (see below).
                 new_requests.append(request)
-
-                # Optimistically update local caches so that concurrent producers deduplicate against these
-                # in-flight requests instead of re-sending them to the platform. Rolled back below if the
-                # `batch_add_requests` call fails, otherwise the never-sent requests would poison the cache and
-                # a later retry of the same request would be silently deduplicated and lost.
-                self._requests_cache[request_id] = request
-                if forefront:
-                    self._head_requests.append(request_id)
-                else:
-                    self._head_requests.appendleft(request_id)
 
         if new_requests:
             # Prepare requests for API by converting to dictionaries.
             requests_dict = [request.model_dump(by_alias=True) for request in new_requests]
 
             # Send requests to API.
-            try:
-                batch_response = await self._api_client.batch_add_requests(requests=requests_dict, forefront=forefront)
-            except Exception:
-                # The platform never received these requests, so roll back the optimistic cache writes to keep
-                # a later retry from being deduplicated away.
-                for request in new_requests:
-                    request_id = unique_key_to_request_id(request.unique_key)
-                    self._requests_cache.pop(request_id, None)
-                    with contextlib.suppress(ValueError):
-                        self._head_requests.remove(request_id)
-                raise
-
+            batch_response = await self._api_client.batch_add_requests(requests=requests_dict, forefront=forefront)
             batch_response_dict = batch_response.model_dump(by_alias=True)
             api_response = AddRequestsResponse.model_validate(batch_response_dict)
 
+            # Commit only the requests the platform actually accepted to the local caches. Caching is done after
+            # `batch_add_requests` succeeds (not before) so that a failed call leaves no entry behind: caching
+            # first would poison the cache and a later retry of the same request would be silently deduplicated
+            # and lost. It also keeps a concurrent producer from observing an uncommitted in-flight entry and
+            # returning false success while this call is still in flight.
+            unprocessed_unique_keys = {request.unique_key for request in api_response.unprocessed_requests}
+            for request in new_requests:
+                if request.unique_key in unprocessed_unique_keys:
+                    continue
+                request_id = unique_key_to_request_id(request.unique_key)
+                self._requests_cache[request_id] = request
+                if forefront:
+                    self._head_requests.append(request_id)
+                else:
+                    self._head_requests.appendleft(request_id)
+
             # Add the locally known already present processed requests based on the local cache.
             api_response.processed_requests.extend(already_present_requests)
-
-            # Remove unprocessed requests from the cache
-            for unprocessed_request in api_response.unprocessed_requests:
-                request_id = unique_key_to_request_id(unprocessed_request.unique_key)
-                self._requests_cache.pop(request_id, None)
 
         else:
             api_response = AddRequestsResponse(

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -139,13 +139,6 @@ class ApifyRequestQueueSingleClient:
                 # Push the request to the platform. Probably not there, or we are not aware of it
                 new_requests.append(request)
 
-                # Update local caches
-                self._requests_cache[request_id] = request
-                if forefront:
-                    self._head_requests.append(request_id)
-                else:
-                    self._head_requests.appendleft(request_id)
-
         if new_requests:
             # Prepare requests for API by converting to dictionaries.
             requests_dict = [request.model_dump(by_alias=True) for request in new_requests]
@@ -158,10 +151,21 @@ class ApifyRequestQueueSingleClient:
             # Add the locally known already present processed requests based on the local cache.
             api_response.processed_requests.extend(already_present_requests)
 
-            # Remove unprocessed requests from the cache
-            for unprocessed_request in api_response.unprocessed_requests:
-                request_id = unique_key_to_request_id(unprocessed_request.unique_key)
-                self._requests_cache.pop(request_id, None)
+            # Commit only requests the platform actually accepted to the local caches. Caching before the call
+            # would deduplicate a later retry of a request that never reached the platform, silently losing it.
+            unprocessed_ids = {
+                unique_key_to_request_id(unprocessed_request.unique_key)
+                for unprocessed_request in api_response.unprocessed_requests
+            }
+            for request in new_requests:
+                request_id = unique_key_to_request_id(request.unique_key)
+                if request_id in unprocessed_ids:
+                    continue
+                self._requests_cache[request_id] = request
+                if forefront:
+                    self._head_requests.append(request_id)
+                else:
+                    self._head_requests.appendleft(request_id)
 
         else:
             api_response = AddRequestsResponse(

--- a/src/apify/storage_clients/_apify/_utils.py
+++ b/src/apify/storage_clients/_apify/_utils.py
@@ -73,7 +73,7 @@ def settle_pending_addition(
     *,
     committed: bool,
 ) -> None:
-    """Resolve the in-flight add marker for a request, unblocking any concurrent producers awaiting it.
+    """Resolve the in-flight add marker for a request, unblocking any concurrent call awaiting it.
 
     Args:
         requests_being_added: The client's map of in-flight `add_batch_of_requests` markers.

--- a/src/apify/storage_clients/_apify/_utils.py
+++ b/src/apify/storage_clients/_apify/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import re
 from base64 import b64encode
 from hashlib import sha256
@@ -11,7 +12,6 @@ from crawlee.storage_clients.models import ProcessedRequest, UnprocessedRequest
 from apify import Request
 
 if TYPE_CHECKING:
-    import asyncio
     from collections.abc import Iterable
 
     from apify_client._models import HeadRequest, LockedHeadRequest
@@ -95,7 +95,9 @@ async def resolve_awaited_in_flight(
     so the caller retries them rather than receiving false success.
     """
     for request, future in awaited_in_flight:
-        if await future:
+        # Shield the shared in-flight marker: cancelling this awaiting caller must not cancel the future, which
+        # is owned by the original producer and may have other callers waiting on it.
+        if await asyncio.shield(future):
             api_response.processed_requests.append(
                 ProcessedRequest(
                     id=unique_key_to_request_id(request.unique_key),

--- a/src/apify/storage_clients/_apify/_utils.py
+++ b/src/apify/storage_clients/_apify/_utils.py
@@ -6,12 +6,17 @@ from hashlib import sha256
 from typing import TYPE_CHECKING
 
 from crawlee._utils.crypto import compute_short_hash
+from crawlee.storage_clients.models import ProcessedRequest, UnprocessedRequest
 
 from apify import Request
 
 if TYPE_CHECKING:
+    import asyncio
+    from collections.abc import Iterable
+
     from apify_client._models import HeadRequest, LockedHeadRequest
     from apify_client._models import Request as ClientRequest
+    from crawlee.storage_clients.models import AddRequestsResponse
 
     from apify import Configuration
 
@@ -60,3 +65,46 @@ def to_crawlee_request(client_request: ClientRequest | HeadRequest | LockedHeadR
 
     # Validate and construct Crawlee Request from the serialized dict
     return Request.model_validate(request_dict)
+
+
+def settle_pending_addition(
+    requests_being_added: dict[str, asyncio.Future[bool]],
+    request_id: str,
+    *,
+    committed: bool,
+) -> None:
+    """Resolve the in-flight add marker for a request, unblocking any concurrent producers awaiting it.
+
+    Args:
+        requests_being_added: The client's map of in-flight `add_batch_of_requests` markers.
+        request_id: ID of the request whose in-flight add has settled.
+        committed: Whether the request was committed to the platform.
+    """
+    future = requests_being_added.pop(request_id, None)
+    if future is not None and not future.done():
+        future.set_result(committed)
+
+
+async def resolve_awaited_in_flight(
+    awaited_in_flight: Iterable[tuple[Request, asyncio.Future[bool]]],
+    api_response: AddRequestsResponse,
+) -> None:
+    """Await concurrent in-flight adds of these requests and fold the outcome into `api_response`.
+
+    Requests the concurrent add committed are reported as already present; the rest are reported unprocessed
+    so the caller retries them rather than receiving false success.
+    """
+    for request, future in awaited_in_flight:
+        if await future:
+            api_response.processed_requests.append(
+                ProcessedRequest(
+                    id=unique_key_to_request_id(request.unique_key),
+                    unique_key=request.unique_key,
+                    was_already_present=True,
+                    was_already_handled=request.was_already_handled,
+                )
+            )
+        else:
+            api_response.unprocessed_requests.append(
+                UnprocessedRequest(unique_key=request.unique_key, url=request.url, method=request.method)
+            )

--- a/tests/unit/storage_clients/test_apify_request_queue_client.py
+++ b/tests/unit/storage_clients/test_apify_request_queue_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -162,8 +163,8 @@ async def test_list_head_limit(in_progress_count: int, expected_limit: int) -> N
     api_client.list_head.assert_awaited_once_with(limit=expected_limit)
 
 
-# Failed `batch_add_requests` must not poison the local dedup cache (otherwise a user retry is
-# silently deduplicated and the request never reaches the platform).
+# A failed `batch_add_requests` must not poison the local dedup cache (otherwise a later add of the
+# same request, sequential or concurrent, is silently deduplicated and never reaches the platform).
 
 
 @pytest.mark.parametrize('access', ['single', 'shared'])
@@ -188,3 +189,54 @@ async def test_failed_batch_add_does_not_poison_dedup_cache(access: str) -> None
     api_client.batch_add_requests.assert_awaited_once()
     assert api_client.batch_add_requests.await_args is not None
     assert len(api_client.batch_add_requests.await_args.kwargs['requests']) == 1
+
+
+@pytest.mark.parametrize('access', ['single', 'shared'])
+async def test_concurrent_add_failure_does_not_falsely_dedupe(access: str) -> None:
+    """While one producer's `batch_add_requests` is in flight and fails, a concurrent producer of the same
+    request must still reach the platform instead of deduping against the uncommitted in-flight entry."""
+    client, api_client = _make_single_client() if access == 'single' else _make_shared_client()
+    # The single client lazily initializes its caches via `list_requests`; harmless for the shared client.
+    api_client.list_requests = AsyncMock(return_value=SimpleNamespace(items=[]))
+    request = Request.from_url('https://example.com/1')
+    request_id = unique_key_to_request_id(request.unique_key)
+
+    first_call_in_flight = asyncio.Event()
+    release_first_call = asyncio.Event()
+    call_count = 0
+
+    async def batch_add(*, requests: list, forefront: bool = False) -> BatchAddResult:  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First producer: block while its call is "in flight", then fail.
+            first_call_in_flight.set()
+            await release_first_call.wait()
+            raise RuntimeError('network down')
+        # Concurrent producer: the request reaches the platform and is accepted.
+        return _batch_result_all_processed([request])
+
+    api_client.batch_add_requests = AsyncMock(side_effect=batch_add)
+
+    # Start the first (failing) producer and wait until its API call is in flight.
+    first = asyncio.create_task(client.add_batch_of_requests([request]))
+    await first_call_in_flight.wait()
+
+    # Nothing is committed while the first call is still in flight, so a concurrent producer cannot
+    # observe a false "already present" entry.
+    assert request_id not in client._requests_cache
+
+    # The concurrent producer of the same request runs while the first call is still in flight.
+    second = asyncio.create_task(client.add_batch_of_requests([request]))
+
+    # Let the first producer fail.
+    release_first_call.set()
+    with pytest.raises(RuntimeError):
+        await first
+
+    # The concurrent producer must have actually sent the request to the platform and succeeded,
+    # rather than returning false success against an uncommitted (then discarded) in-flight entry.
+    response = await second
+    assert call_count == 2
+    assert [processed.unique_key for processed in response.processed_requests] == [request.unique_key]
+    assert request_id in client._requests_cache

--- a/tests/unit/storage_clients/test_apify_request_queue_client.py
+++ b/tests/unit/storage_clients/test_apify_request_queue_client.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from apify_client._models import AddedRequest, BatchAddResult, RequestQueueHead, RequestQueueStats
-from crawlee.storage_clients.models import RequestQueueMetadata
+from crawlee.storage_clients.models import AddRequestsResponse, RequestQueueMetadata
 
 from apify import Request
 from apify.storage_clients._apify._models import ApifyRequestQueueMetadata
@@ -163,8 +163,10 @@ async def test_list_head_limit(in_progress_count: int, expected_limit: int) -> N
     api_client.list_head.assert_awaited_once_with(limit=expected_limit)
 
 
-# A failed `batch_add_requests` must not poison the local dedup cache (otherwise a later add of the
-# same request, sequential or concurrent, is silently deduplicated and never reaches the platform).
+# Adding a request through `batch_add_requests` must never poison the local dedup cache or report false
+# success. A failed add leaves nothing cached, so a later add (sequential or concurrent) still reaches the
+# platform; a concurrent producer of the same request deduplicates against the in-flight add instead of
+# re-sending it, yet is only told the request is present once the platform actually accepts it.
 
 
 @pytest.mark.parametrize('access', ['single', 'shared'])
@@ -191,52 +193,99 @@ async def test_failed_batch_add_does_not_poison_dedup_cache(access: str) -> None
     assert len(api_client.batch_add_requests.await_args.kwargs['requests']) == 1
 
 
+async def _start_first_then_concurrent_producer(
+    client: ApifyRequestQueueSingleClient | ApifyRequestQueueSharedClient,
+    request: Request,
+    *,
+    in_flight: asyncio.Event,
+) -> tuple[asyncio.Task[AddRequestsResponse], asyncio.Task[AddRequestsResponse]]:
+    """Start one producer, wait until its `batch_add_requests` is in flight, then start a concurrent producer
+    of the same request and let it park on the in-flight add. Returns the (first, second) tasks."""
+    if isinstance(client, ApifyRequestQueueSingleClient):
+        # Skip the lazy `list_requests` init so the concurrent producer's only suspension point is the
+        # in-flight future, which makes the scheduling below deterministic.
+        client._initialized_caches = True
+
+    first = asyncio.create_task(client.add_batch_of_requests([request]))
+    await in_flight.wait()
+    second = asyncio.create_task(client.add_batch_of_requests([request]))
+    await asyncio.sleep(0)  # let the concurrent producer classify and park on the in-flight future
+    return first, second
+
+
 @pytest.mark.parametrize('access', ['single', 'shared'])
 async def test_concurrent_add_failure_does_not_falsely_dedupe(access: str) -> None:
-    """While one producer's `batch_add_requests` is in flight and fails, a concurrent producer of the same
-    request must still reach the platform instead of deduping against the uncommitted in-flight entry."""
+    """While one producer's `batch_add_requests` is in flight and then fails, a concurrent producer of the same
+    request must not report false success: the request is returned unprocessed (so the caller retries it)."""
     client, api_client = _make_single_client() if access == 'single' else _make_shared_client()
-    # The single client lazily initializes its caches via `list_requests`; harmless for the shared client.
-    api_client.list_requests = AsyncMock(return_value=SimpleNamespace(items=[]))
     request = Request.from_url('https://example.com/1')
     request_id = unique_key_to_request_id(request.unique_key)
 
-    first_call_in_flight = asyncio.Event()
-    release_first_call = asyncio.Event()
+    in_flight = asyncio.Event()
+    release = asyncio.Event()
     call_count = 0
 
     async def batch_add(*, requests: list, forefront: bool = False) -> BatchAddResult:  # noqa: ARG001
         nonlocal call_count
         call_count += 1
-        if call_count == 1:
-            # First producer: block while its call is "in flight", then fail.
-            first_call_in_flight.set()
-            await release_first_call.wait()
-            raise RuntimeError('network down')
-        # Concurrent producer: the request reaches the platform and is accepted.
+        in_flight.set()
+        await release.wait()
+        raise RuntimeError('network down')
+
+    api_client.batch_add_requests = AsyncMock(side_effect=batch_add)
+
+    first, second = await _start_first_then_concurrent_producer(client, request, in_flight=in_flight)
+
+    # Nothing is committed while the first call is still in flight, so the concurrent producer cannot observe a
+    # false "already present" entry.
+    assert request_id not in client._requests_cache
+
+    # Let the first producer fail.
+    release.set()
+    with pytest.raises(RuntimeError):
+        await first
+
+    # The concurrent producer deduplicated against the in-flight add (no second API call), but because that add
+    # failed it must be told the request is unprocessed rather than receiving false success.
+    response = await second
+    assert call_count == 1
+    assert [unprocessed.unique_key for unprocessed in response.unprocessed_requests] == [request.unique_key]
+    assert all(processed.unique_key != request.unique_key for processed in response.processed_requests)
+    assert request_id not in client._requests_cache
+
+
+@pytest.mark.parametrize('access', ['single', 'shared'])
+async def test_concurrent_add_deduplicates_against_in_flight(access: str) -> None:
+    """A concurrent producer of an in-flight request deduplicates against it: only one `batch_add_requests` call
+    is made, and once it succeeds the concurrent producer is told the request is already present."""
+    client, api_client = _make_single_client() if access == 'single' else _make_shared_client()
+    request = Request.from_url('https://example.com/1')
+    request_id = unique_key_to_request_id(request.unique_key)
+
+    in_flight = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def batch_add(*, requests: list, forefront: bool = False) -> BatchAddResult:  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        in_flight.set()
+        await release.wait()
         return _batch_result_all_processed([request])
 
     api_client.batch_add_requests = AsyncMock(side_effect=batch_add)
 
-    # Start the first (failing) producer and wait until its API call is in flight.
-    first = asyncio.create_task(client.add_batch_of_requests([request]))
-    await first_call_in_flight.wait()
+    first, second = await _start_first_then_concurrent_producer(client, request, in_flight=in_flight)
 
-    # Nothing is committed while the first call is still in flight, so a concurrent producer cannot
-    # observe a false "already present" entry.
-    assert request_id not in client._requests_cache
+    # Let the first producer succeed.
+    release.set()
+    first_response = await first
+    second_response = await second
 
-    # The concurrent producer of the same request runs while the first call is still in flight.
-    second = asyncio.create_task(client.add_batch_of_requests([request]))
-
-    # Let the first producer fail.
-    release_first_call.set()
-    with pytest.raises(RuntimeError):
-        await first
-
-    # The concurrent producer must have actually sent the request to the platform and succeeded,
-    # rather than returning false success against an uncommitted (then discarded) in-flight entry.
-    response = await second
-    assert call_count == 2
-    assert [processed.unique_key for processed in response.processed_requests] == [request.unique_key]
+    assert call_count == 1
     assert request_id in client._requests_cache
+    # The first producer added the request, the concurrent one deduplicated against the in-flight add.
+    assert [processed.unique_key for processed in first_response.processed_requests] == [request.unique_key]
+    assert [processed.unique_key for processed in second_response.processed_requests] == [request.unique_key]
+    assert second_response.processed_requests[0].was_already_present is True
+    assert second_response.unprocessed_requests == []

--- a/tests/unit/storage_clients/test_apify_request_queue_client.py
+++ b/tests/unit/storage_clients/test_apify_request_queue_client.py
@@ -1,24 +1,27 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
 import pytest
 
-from apify_client._models import RequestQueueHead
+from apify_client._models import AddedRequest, BatchAddResult, RequestQueueHead
 from crawlee.storage_clients.models import RequestQueueMetadata
 
+from apify import Request
+from apify.storage_clients._apify._request_queue_shared_client import ApifyRequestQueueSharedClient
 from apify.storage_clients._apify._request_queue_single_client import ApifyRequestQueueSingleClient
 from apify.storage_clients._apify._utils import unique_key_to_request_id
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
-def _make_single_client(
-    api_client: AsyncMock | None = None,
-) -> tuple[ApifyRequestQueueSingleClient, AsyncMock]:
-    if api_client is None:
-        api_client = AsyncMock()
+
+def _make_metadata() -> RequestQueueMetadata:
     now = datetime.now(tz=UTC)
-    metadata = RequestQueueMetadata(
+    return RequestQueueMetadata(
         id='test-rq-id',
         name='test-rq',
         accessed_at=now,
@@ -29,7 +32,45 @@ def _make_single_client(
         pending_request_count=0,
         total_request_count=0,
     )
-    client = ApifyRequestQueueSingleClient(api_client=api_client, metadata=metadata, cache_size=100)
+
+
+def _batch_result_all_processed(requests: Sequence[Request]) -> BatchAddResult:
+    """Build a `batch_add_requests` response marking every request as newly processed."""
+    return BatchAddResult.model_construct(
+        processed_requests=[
+            AddedRequest.model_construct(
+                request_id=unique_key_to_request_id(request.unique_key),
+                unique_key=request.unique_key,
+                was_already_present=False,
+                was_already_handled=False,
+            )
+            for request in requests
+        ],
+        unprocessed_requests=[],
+    )
+
+
+def _make_single_client(
+    api_client: AsyncMock | None = None,
+) -> tuple[ApifyRequestQueueSingleClient, AsyncMock]:
+    if api_client is None:
+        api_client = AsyncMock()
+    client = ApifyRequestQueueSingleClient(api_client=api_client, metadata=_make_metadata(), cache_size=100)
+    return client, api_client
+
+
+def _make_shared_client(
+    api_client: AsyncMock | None = None,
+) -> tuple[ApifyRequestQueueSharedClient, AsyncMock]:
+    if api_client is None:
+        api_client = AsyncMock()
+    metadata = _make_metadata()
+    client = ApifyRequestQueueSharedClient(
+        api_client=api_client,
+        metadata=metadata,
+        cache_size=100,
+        metadata_getter=AsyncMock(return_value=metadata),
+    )
     return client, api_client
 
 
@@ -92,3 +133,31 @@ async def test_list_head_limit(in_progress_count: int, expected_limit: int) -> N
     await client._list_head()
 
     api_client.list_head.assert_awaited_once_with(limit=expected_limit)
+
+
+# Failed `batch_add_requests` must not poison the local dedup cache (otherwise a user retry is
+# silently deduplicated and the request never reaches the platform).
+
+
+@pytest.mark.parametrize('access', ['single', 'shared'])
+async def test_failed_batch_add_does_not_poison_dedup_cache(access: str) -> None:
+    """A failed `batch_add_requests` leaves no cached entry, so a retry still reaches the platform."""
+    client, api_client = _make_single_client() if access == 'single' else _make_shared_client()
+    # The single client lazily initializes its caches via `list_requests`; harmless for the shared client.
+    api_client.list_requests = AsyncMock(return_value=SimpleNamespace(items=[]))
+    request = Request.from_url('https://example.com/1')
+    request_id = unique_key_to_request_id(request.unique_key)
+
+    # First attempt: the platform call fails.
+    api_client.batch_add_requests = AsyncMock(side_effect=RuntimeError('network down'))
+    with pytest.raises(RuntimeError):
+        await client.add_batch_of_requests([request])
+    assert request_id not in client._requests_cache
+
+    # Retry: the platform call succeeds. The request must be sent again, not deduped away.
+    api_client.batch_add_requests = AsyncMock(return_value=_batch_result_all_processed([request]))
+    await client.add_batch_of_requests([request])
+
+    api_client.batch_add_requests.assert_awaited_once()
+    assert api_client.batch_add_requests.await_args is not None
+    assert len(api_client.batch_add_requests.await_args.kwargs['requests']) == 1

--- a/tests/unit/storage_clients/test_apify_request_queue_client.py
+++ b/tests/unit/storage_clients/test_apify_request_queue_client.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from apify_client._models import AddedRequest, BatchAddResult, RequestQueueHead, RequestQueueStats
+from apify_client._models import AddedRequest, BatchAddResult, RequestDraft, RequestQueueHead, RequestQueueStats
 from crawlee.storage_clients.models import AddRequestsResponse, RequestQueueMetadata
 
 from apify import Request
@@ -36,8 +36,12 @@ def _make_metadata() -> RequestQueueMetadata:
     )
 
 
-def _batch_result_all_processed(requests: Sequence[Request]) -> BatchAddResult:
-    """Build a `batch_add_requests` response marking every request as newly processed."""
+def _batch_result(
+    *,
+    processed: Sequence[Request] = (),
+    unprocessed: Sequence[Request] = (),
+) -> BatchAddResult:
+    """Build a `batch_add_requests` response with explicit processed / unprocessed splits."""
     return BatchAddResult.model_construct(
         processed_requests=[
             AddedRequest.model_construct(
@@ -46,10 +50,22 @@ def _batch_result_all_processed(requests: Sequence[Request]) -> BatchAddResult:
                 was_already_present=False,
                 was_already_handled=False,
             )
-            for request in requests
+            for request in processed
         ],
-        unprocessed_requests=[],
+        unprocessed_requests=[
+            RequestDraft.model_construct(
+                unique_key=request.unique_key,
+                url=request.url,
+                method=request.method,
+            )
+            for request in unprocessed
+        ],
     )
+
+
+def _batch_result_all_processed(requests: Sequence[Request]) -> BatchAddResult:
+    """Build a `batch_add_requests` response marking every request as newly processed."""
+    return _batch_result(processed=requests)
 
 
 def _make_single_client(
@@ -289,3 +305,36 @@ async def test_concurrent_add_deduplicates_against_in_flight(access: str) -> Non
     assert [processed.unique_key for processed in second_response.processed_requests] == [request.unique_key]
     assert second_response.processed_requests[0].was_already_present is True
     assert second_response.unprocessed_requests == []
+
+
+@pytest.mark.parametrize('access', ['single', 'shared'])
+async def test_partial_unprocessed_commits_only_accepted_requests(access: str) -> None:
+    """When the platform accepts only part of a batch, only the accepted requests are cached. The rejected one
+    leaves no entry behind, so a later retry re-sends it while the accepted one is deduped locally."""
+    client, api_client = _make_single_client() if access == 'single' else _make_shared_client()
+    api_client.list_requests = AsyncMock(return_value=SimpleNamespace(items=[]))
+    accepted = Request.from_url('https://example.com/accepted')
+    rejected = Request.from_url('https://example.com/rejected')
+    accepted_id = unique_key_to_request_id(accepted.unique_key)
+    rejected_id = unique_key_to_request_id(rejected.unique_key)
+
+    api_client.batch_add_requests = AsyncMock(return_value=_batch_result(processed=[accepted], unprocessed=[rejected]))
+    response = await client.add_batch_of_requests([accepted, rejected])
+
+    # Only the accepted request is committed to the local cache; the rejected one is not.
+    assert accepted_id in client._requests_cache
+    assert rejected_id not in client._requests_cache
+    # The response mirrors the platform split, and no in-flight marker is left behind.
+    assert [processed.unique_key for processed in response.processed_requests] == [accepted.unique_key]
+    assert [unprocessed.unique_key for unprocessed in response.unprocessed_requests] == [rejected.unique_key]
+    assert client._requests_being_added == {}
+
+    # Retry both: the rejected request must reach the platform again (it was not poisoned), while the accepted one
+    # is deduped locally and never re-sent.
+    api_client.batch_add_requests = AsyncMock(return_value=_batch_result(processed=[rejected]))
+    await client.add_batch_of_requests([accepted, rejected])
+
+    api_client.batch_add_requests.assert_awaited_once()
+    assert api_client.batch_add_requests.await_args is not None
+    resent = api_client.batch_add_requests.await_args.kwargs['requests']
+    assert [request['uniqueKey'] for request in resent] == [rejected.unique_key]


### PR DESCRIPTION
Both Apify request queue clients (`ApifyRequestQueueSingleClient`, `ApifyRequestQueueSharedClient`) cached new requests locally (the single client also updates `_head_requests`) before calling `batch_add_requests`. That caused two bugs:

- A failed call left the cache entry behind, so a later retry of the same request was deduplicated locally and never re-sent. The request was silently lost.
- A concurrent producer could match the in-flight cache entry and return `was_already_present` before the first call finished. If that call then failed, the producer had already reported success for a request that never reached the platform.

Now the cache and head are committed only after `batch_add_requests` succeeds, and only for requests the platform accepted (`unprocessed_requests` are skipped). A failed call commits nothing.

To keep deduplicating concurrent producers (so overlapping batches do not multiply platform writes), each in-flight add is tracked by a per-request future. A concurrent producer of the same request awaits it instead of re-sending. It is told the request is present only if the original add committed it. If the original add failed, the producer reports the request unprocessed so Crawlee retries it, rather than receiving false success.

Within-batch deduplication is unaffected, since Crawlee already collapses a batch by `unique_key` (via `_transform_requests`) before it reaches these clients.

Tests (parametrized over both clients, plus integration):

- A failed `batch_add_requests` leaves no cached entry, and the retry reaches the platform.
- A concurrent producer of an in-flight request deduplicates against it (a single API call) and is told the request is present only once it is accepted.
- When the in-flight add fails, the concurrent producer reports the request unprocessed instead of false success.
- `test_request_queue_parallel_deduplication` confirms overlapping concurrent producers write each request to the platform exactly once.
