### PR TITLE
fix(scrapy): Drop deprecated spider arg from Scrapy proxy middleware methods

### DIFF
--- a/src/apify/scrapy/middlewares/apify_proxy.py
+++ b/src/apify/scrapy/middlewares/apify_proxy.py
@@ -10,7 +10,7 @@ from apify import Actor, ProxyConfiguration
 from apify.scrapy.utils import get_basic_auth_header
 
 if TYPE_CHECKING:
-    from scrapy import Request, Spider
+    from scrapy import Request
     from scrapy.crawler import Crawler
 
 
@@ -63,17 +63,16 @@ class ApifyHttpProxyMiddleware:
 
         return cls(proxy_settings)
 
-    async def process_request(self, request: Request, spider: Spider) -> None:
+    async def process_request(self, request: Request) -> None:
         """Process a Scrapy request by assigning a new proxy.
 
         Args:
             request: Scrapy Request object.
-            spider: Scrapy Spider object.
 
         Raises:
             ValueError: If username and password are not provided in the proxy URL.
         """
-        Actor.log.debug(f'ApifyHttpProxyMiddleware.process_request: request={request}, spider={spider}')
+        Actor.log.debug(f'ApifyHttpProxyMiddleware.process_request: request={request}')
         url = await self._get_new_proxy_url()
 
         if not (url.username and url.password):
@@ -89,14 +88,12 @@ class ApifyHttpProxyMiddleware:
         self,
         request: Request,
         exception: Exception,
-        spider: Spider,
     ) -> None:
         """Process an exception that occurs during request processing.
 
         Args:
             request: Scrapy Request object.
             exception: Exception object.
-            spider: Scrapy Spider object.
 
         Returns:
             Returning None, meaning Scrapy will continue processing this exception, executing any other
@@ -104,7 +101,7 @@ class ApifyHttpProxyMiddleware:
             exception handling kicks in.
         """
         Actor.log.debug(
-            f'ApifyHttpProxyMiddleware.process_exception: request={request}, exception={exception}, spider={spider}',
+            f'ApifyHttpProxyMiddleware.process_exception: request={request}, exception={exception}',
         )
 
         if isinstance(exception, TunnelError):

--- a/tests/unit/scrapy/middlewares/test_apify_proxy.py
+++ b/tests/unit/scrapy/middlewares/test_apify_proxy.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import warnings
 from urllib.parse import ParseResult, urlparse
 
 import pytest
 from scrapy import Request, Spider
 from scrapy.core.downloader.handlers.http11 import TunnelError
+from scrapy.core.downloader.middleware import DownloaderMiddlewareManager
 from scrapy.crawler import Crawler
-from scrapy.exceptions import NotConfigured
+from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
 
 from apify import ProxyConfiguration
 from apify.scrapy.middlewares import ApifyHttpProxyMiddleware
@@ -29,12 +31,6 @@ def crawler(monkeypatch: pytest.MonkeyPatch) -> Crawler:
     crawler = Crawler(DummySpider)
     monkeypatch.setattr(crawler, 'settings', {})
     return crawler
-
-
-@pytest.fixture
-def spider() -> DummySpider:
-    """Fixture to create a "dummy" Scrapy spider."""
-    return DummySpider()
 
 
 @pytest.fixture
@@ -119,7 +115,6 @@ async def test_retrieves_new_proxy_url(
 async def test_process_request_with_proxy(
     monkeypatch: pytest.MonkeyPatch,
     middleware: ApifyHttpProxyMiddleware,
-    spider: DummySpider,
     dummy_request: Request,
     proxy_url: str,
     expected_exception: type[Exception] | None,
@@ -131,12 +126,12 @@ async def test_process_request_with_proxy(
     monkeypatch.setattr(middleware, '_get_new_proxy_url', mock_get_new_proxy_url)
 
     if expected_exception is None:
-        await middleware.process_request(dummy_request, spider)
+        await middleware.process_request(dummy_request)
         assert dummy_request.meta['proxy'] == proxy_url
         assert dummy_request.headers[b'Proxy-Authorization'] == expected_request_header
     else:
         with pytest.raises(expected_exception):
-            await middleware.process_request(dummy_request, spider)
+            await middleware.process_request(dummy_request)
 
 
 @pytest.mark.parametrize(
@@ -146,9 +141,25 @@ async def test_process_request_with_proxy(
 )
 def test_handles_exceptions(
     middleware: ApifyHttpProxyMiddleware,
-    spider: DummySpider,
     dummy_request: Request,
     exception: Exception,
 ) -> None:
-    returned_value = middleware.process_exception(dummy_request, exception, spider)
+    returned_value = middleware.process_exception(dummy_request, exception)
     assert returned_value is None
+
+
+def test_methods_do_not_require_deprecated_spider_arg(
+    crawler: Crawler,
+    middleware: ApifyHttpProxyMiddleware,
+) -> None:
+    """Registering the middleware must not emit Scrapy's `spider` argument deprecation warning (scrapy>=2.14)."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        DownloaderMiddlewareManager(middleware, crawler=crawler)
+
+    spider_arg_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, ScrapyDeprecationWarning) and 'requires a spider argument' in str(w.message)
+    ]
+    assert spider_arg_warnings == []

--- a/tests/unit/scrapy/middlewares/test_apify_proxy.py
+++ b/tests/unit/scrapy/middlewares/test_apify_proxy.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import warnings
 from urllib.parse import ParseResult, urlparse
 
 import pytest
 from scrapy import Request, Spider
 from scrapy.core.downloader.handlers.http11 import TunnelError
-from scrapy.core.downloader.middleware import DownloaderMiddlewareManager
 from scrapy.crawler import Crawler
-from scrapy.exceptions import NotConfigured, ScrapyDeprecationWarning
+from scrapy.exceptions import NotConfigured
 
 from apify import ProxyConfiguration
 from apify.scrapy.middlewares import ApifyHttpProxyMiddleware
@@ -146,20 +144,3 @@ def test_handles_exceptions(
 ) -> None:
     returned_value = middleware.process_exception(dummy_request, exception)
     assert returned_value is None
-
-
-def test_methods_do_not_require_deprecated_spider_arg(
-    crawler: Crawler,
-    middleware: ApifyHttpProxyMiddleware,
-) -> None:
-    """Registering the middleware must not emit Scrapy's `spider` argument deprecation warning (scrapy>=2.14)."""
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter('always')
-        DownloaderMiddlewareManager(middleware, crawler=crawler)
-
-    spider_arg_warnings = [
-        w
-        for w in caught
-        if issubclass(w.category, ScrapyDeprecationWarning) and 'requires a spider argument' in str(w.message)
-    ]
-    assert spider_arg_warnings == []


### PR DESCRIPTION
Scrapy ≥2.14 deprecated the `spider` parameter on downloader-middleware methods and emits a `ScrapyDeprecationWarning` on every run for any method that still requires it. `ApifyHttpProxyMiddleware.process_request` and `process_exception` only used `spider` for debug logging, so this drops the parameter (and its docstring/log references), mirroring the already-migrated `ActorDatasetPushPipeline`.

A regression test registers the middleware via `DownloaderMiddlewareManager` and asserts no "requires a spider argument" warning is emitted.