### PR TITLE
fix(scrapy): async-thread startup race, shutdown lifecycle, and timeout setting

### DIFF
--- a/src/apify/scrapy/_async_thread.py
+++ b/src/apify/scrapy/_async_thread.py
@@ -52,15 +52,15 @@ class AsyncThread:
             The result returned by the coroutine.
 
         Raises:
-            RuntimeError: If the event loop is not running.
+            RuntimeError: If the event loop has been closed.
             TimeoutError: If the coroutine does not complete within the timeout.
             Exception: Any exception raised during coroutine execution.
         """
         if timeout == 'default':
             timeout = self._default_timeout
 
-        if not self._eventloop.is_running():
-            raise RuntimeError(f'The coroutine {coro} cannot be executed because the event loop is not running.')
+        if self._eventloop.is_closed():
+            raise RuntimeError(f'The coroutine {coro} cannot be executed because the event loop is closed.')
 
         # Submit the coroutine to the event loop running in the other thread.
         future = asyncio.run_coroutine_threadsafe(coro, self._eventloop)

--- a/src/apify/scrapy/_async_thread.py
+++ b/src/apify/scrapy/_async_thread.py
@@ -89,20 +89,22 @@ class AsyncThread:
         if self._eventloop.is_closed():
             return
 
-        if self._eventloop.is_running():
-            # Cancel all pending tasks in the event loop, honouring the caller's timeout.
-            self.run_coro(self._shutdown_tasks(), timeout=timeout)
+        try:
+            if self._eventloop.is_running():
+                # Cancel all pending tasks in the event loop, honouring the caller's timeout.
+                self.run_coro(self._shutdown_tasks(), timeout=timeout)
+        finally:
+            # Stop the loop and join its thread even if cancelling the pending tasks above raised or timed
+            # out. Skipping this would leave the loop running and leak its thread.
+            self._eventloop.call_soon_threadsafe(self._eventloop.stop)
 
-        # Schedule the event loop to stop.
-        self._eventloop.call_soon_threadsafe(self._eventloop.stop)
+            # Wait for the event loop thread to finish execution.
+            self._thread.join(timeout=timeout.total_seconds())
 
-        # Wait for the event loop thread to finish execution.
-        self._thread.join(timeout=timeout.total_seconds())
-
-        # If the thread is still running after the timeout, force a shutdown.
-        if self._thread.is_alive():
-            logger.warning('Event loop thread did not exit cleanly! Forcing shutdown...')
-            self._force_exit_event_loop()
+            # If the thread is still running after the timeout, force a shutdown.
+            if self._thread.is_alive():
+                logger.warning('Event loop thread did not exit cleanly! Forcing shutdown...')
+                self._force_exit_event_loop()
 
     def _start_event_loop(self) -> None:
         """Set up and run the asyncio event loop in the dedicated thread."""

--- a/src/apify/scrapy/_async_thread.py
+++ b/src/apify/scrapy/_async_thread.py
@@ -74,15 +74,19 @@ class AsyncThread:
             future.cancel()
             raise
 
-    def close(self, timeout: timedelta = timedelta(seconds=60)) -> None:
+    def close(self, timeout: timedelta | None = None) -> None:
         """Close the event loop and its thread gracefully.
 
         This method cancels all pending tasks, stops the event loop, and waits for the thread to exit.
         If the thread does not exit within the given timeout, a forced shutdown is attempted.
 
         Args:
-            timeout: The maximum number of seconds to wait for the event loop thread to exit.
+            timeout: The maximum time to wait for the event loop thread to exit. Pass `None` to use the
+                `default_timeout` passed to the constructor.
         """
+        if timeout is None:
+            timeout = self._default_timeout
+
         # A repeated close (e.g. a retried shutdown) would call into the already-closed loop and raise
         # `RuntimeError: Event loop is closed`. The loop closes itself once it stops, so a second close
         # is a no-op.

--- a/src/apify/scrapy/_async_thread.py
+++ b/src/apify/scrapy/_async_thread.py
@@ -67,11 +67,11 @@ class AsyncThread:
         try:
             # Wait for the coroutine's result until the specified timeout.
             return future.result(timeout=timeout.total_seconds())
-        except futures.TimeoutError as exc:
-            logger.exception('Coroutine execution timed out.', exc_info=exc)
-            raise
-        except Exception as exc:
-            logger.exception('Coroutine execution raised an exception.', exc_info=exc)
+        except futures.TimeoutError:
+            # `future.result` gave up, but the coroutine keeps running on the loop; cancel it so it does
+            # not outlive the timeout. The propagated error is logged once by the caller (or Scrapy), so
+            # this method does not log it itself.
+            future.cancel()
             raise
 
     def close(self, timeout: timedelta = timedelta(seconds=60)) -> None:
@@ -83,9 +83,15 @@ class AsyncThread:
         Args:
             timeout: The maximum number of seconds to wait for the event loop thread to exit.
         """
+        # A repeated close (e.g. a retried shutdown) would call into the already-closed loop and raise
+        # `RuntimeError: Event loop is closed`. The loop closes itself once it stops, so a second close
+        # is a no-op.
+        if self._eventloop.is_closed():
+            return
+
         if self._eventloop.is_running():
-            # Cancel all pending tasks in the event loop.
-            self.run_coro(self._shutdown_tasks())
+            # Cancel all pending tasks in the event loop, honouring the caller's timeout.
+            self.run_coro(self._shutdown_tasks(), timeout=timeout)
 
         # Schedule the event loop to stop.
         self._eventloop.call_soon_threadsafe(self._eventloop.stop)

--- a/src/apify/scrapy/_async_thread.py
+++ b/src/apify/scrapy/_async_thread.py
@@ -137,5 +137,5 @@ class AsyncThread:
             logger.info('Forced shutdown of the event loop and its thread...')
             self._eventloop.call_soon_threadsafe(self._eventloop.stop)
             self._thread.join(timeout=5)
-        except Exception as exc:
-            logger.exception('Exception occurred during forced event loop shutdown.', exc_info=exc)
+        except Exception:
+            logger.exception('Exception occurred during forced event loop shutdown.')

--- a/src/apify/scrapy/extensions/_httpcache.py
+++ b/src/apify/scrapy/extensions/_httpcache.py
@@ -4,6 +4,7 @@ import gzip
 import io
 import re
 import struct
+from datetime import timedelta
 from logging import getLogger
 from time import time
 from typing import TYPE_CHECKING
@@ -38,6 +39,8 @@ class ApifyCacheStorage:
         # Upper bound on how many keys the per-spider-close cleanup sweeps (best-effort; `close_spider`).
         self._expiration_max_items: int = settings.getint('APIFY_HTTPCACHE_EXPIRATION_MAX_ITEMS', 100)
         self._expiration_secs: int = settings.getint('HTTPCACHE_EXPIRATION_SECS')
+        # Caps how long each coroutine run on the background event loop may take; defaults to 60 seconds.
+        self._async_thread_timeout = timedelta(seconds=settings.getint('APIFY_ASYNC_THREAD_TIMEOUT_SECS', 60))
         self._spider: Spider | None = None
         self._kvs: KeyValueStore | None = None
         self._fingerprinter: RequestFingerprinterProtocol | None = None
@@ -62,7 +65,7 @@ class ApifyCacheStorage:
             return await KeyValueStore.open(name=kvs_name)
 
         logger.debug("Starting background thread for cache storage's event loop")
-        self._async_thread = AsyncThread()
+        self._async_thread = AsyncThread(default_timeout=self._async_thread_timeout)
         logger.debug(f"Opening cache storage's {kvs_name!r} key value store")
         self._kvs = self._async_thread.run_coro(open_kvs())
 
@@ -72,45 +75,48 @@ class ApifyCacheStorage:
             raise ValueError('Async thread not initialized')
 
         logger.info(f'Cleaning up cache items (max {self._expiration_max_items})')
-        if self._expiration_secs > 0:
-            if current_time is None:
-                current_time = int(time())
+        # The cleanup sweep runs inside `try` so a failure there cannot skip closing the async thread
+        # (which would leak its event-loop thread); `close` always runs in the `finally`.
+        try:
+            if self._expiration_secs > 0:
+                if current_time is None:
+                    current_time = int(time())
 
-            async def expire_kvs() -> None:
-                if self._kvs is None:
-                    raise ValueError('Key value store not initialized')
-                # Best-effort cleanup: at most `_expiration_max_items` keys per close, in no guaranteed order,
-                # so stale entries may linger. This only reclaims storage; `retrieve_response` already treats
-                # an expired entry as a cache miss.
-                processed = 0
-                async for item in self._kvs.iterate_keys():
-                    if processed >= self._expiration_max_items:
-                        break
-                    processed += 1
-                    value = await self._kvs.get_value(item.key)
-                    try:
-                        gzip_time = read_gzip_time(value)
-                    except Exception as e:
-                        logger.warning(f'Malformed cache item {item.key}: {e}')
-                        await self._kvs.delete_value(item.key)
-                    else:
-                        if self._expiration_secs < current_time - gzip_time:
-                            logger.debug(f'Expired cache item {item.key}')
+                async def expire_kvs() -> None:
+                    if self._kvs is None:
+                        raise ValueError('Key value store not initialized')
+                    # Best-effort cleanup: at most `_expiration_max_items` keys per close, in no guaranteed order,
+                    # so stale entries may linger. This only reclaims storage; `retrieve_response` already treats
+                    # an expired entry as a cache miss.
+                    processed = 0
+                    async for item in self._kvs.iterate_keys():
+                        if processed >= self._expiration_max_items:
+                            break
+                        processed += 1
+                        value = await self._kvs.get_value(item.key)
+                        try:
+                            gzip_time = read_gzip_time(value)
+                        except Exception as e:
+                            logger.warning(f'Malformed cache item {item.key}: {e}')
                             await self._kvs.delete_value(item.key)
                         else:
-                            logger.debug(f'Valid cache item {item.key}')
+                            if self._expiration_secs < current_time - gzip_time:
+                                logger.debug(f'Expired cache item {item.key}')
+                                await self._kvs.delete_value(item.key)
+                            else:
+                                logger.debug(f'Valid cache item {item.key}')
 
-            self._async_thread.run_coro(expire_kvs())
-
-        logger.debug('Closing cache storage')
-        try:
-            self._async_thread.close()
-        except KeyboardInterrupt:
-            logger.warning('Shutdown interrupted by KeyboardInterrupt!')
-        except Exception:
-            logger.exception('Exception occurred while shutting down cache storage')
+                self._async_thread.run_coro(expire_kvs())
         finally:
-            logger.debug('Cache storage closed')
+            logger.debug('Closing cache storage')
+            try:
+                self._async_thread.close()
+            except KeyboardInterrupt:
+                logger.warning('Shutdown interrupted by KeyboardInterrupt!')
+            except Exception:
+                logger.exception('Exception occurred while shutting down cache storage')
+            finally:
+                logger.debug('Cache storage closed')
 
     def retrieve_response(self, _: Spider, request: Request, current_time: int | None = None) -> Response | None:
         """Retrieve a response from the cache storage."""

--- a/src/apify/scrapy/extensions/_httpcache.py
+++ b/src/apify/scrapy/extensions/_httpcache.py
@@ -36,18 +36,36 @@ class ApifyCacheStorage:
     """
 
     def __init__(self, settings: BaseSettings) -> None:
-        # Upper bound on how many keys the per-spider-close cleanup sweeps (best-effort; `close_spider`).
         self._expiration_max_items: int = settings.getint('APIFY_HTTPCACHE_EXPIRATION_MAX_ITEMS', 100)
-        self._expiration_secs: int = settings.getint('HTTPCACHE_EXPIRATION_SECS')
+        """Upper bound on how many keys the per-spider-close cleanup sweeps (best-effort; `close_spider`)."""
+
         self._async_thread_timeout = timedelta(seconds=settings.getint('APIFY_ASYNC_THREAD_TIMEOUT_SECS', 60))
-        """Caps how long each coroutine run on the background event loop may take; defaults to 60 seconds."""
+        """Caps how long each coroutine run on the background event loop may take."""
+
+        self._expiration_secs: int = settings.getint('HTTPCACHE_EXPIRATION_SECS')
+        """Seconds a cached entry stays fresh; older entries are treated as expired, and `0` disables expiration."""
+
         self._spider: Spider | None = None
+        """The Scrapy `Spider` this cache storage is bound to; set in `open_spider`."""
+
         self._kvs: KeyValueStore | None = None
+        """The Apify `KeyValueStore` backing the cache; opened in `open_spider`."""
+
         self._fingerprinter: RequestFingerprinterProtocol | None = None
+        """Scrapy's request fingerprinter, used to derive the cache key for each request."""
+
         self._async_thread: AsyncThread | None = None
+        """Background event-loop thread that runs the storage coroutines from Scrapy's synchronous callbacks."""
 
     def open_spider(self, spider: Spider) -> None:
-        """Open the cache storage for a spider."""
+        """Open the cache storage for a spider.
+
+        Starts the background event-loop thread and opens the spider's key-value store. If opening the store
+        fails, the freshly started thread is closed so it is not leaked.
+
+        Args:
+            spider: The spider the cache storage is being opened for.
+        """
         logger.debug('Using Apify key value cache storage', extra={'spider': spider})
         self._spider = spider
         self._fingerprinter = spider.crawler.request_fingerprinter
@@ -67,6 +85,7 @@ class ApifyCacheStorage:
         logger.debug("Starting background thread for cache storage's event loop")
         self._async_thread = AsyncThread(default_timeout=self._async_thread_timeout)
         logger.debug(f"Opening cache storage's {kvs_name!r} key value store")
+
         try:
             self._kvs = self._async_thread.run_coro(open_kvs())
         except Exception:
@@ -81,48 +100,32 @@ class ApifyCacheStorage:
             raise
 
     def close_spider(self, _: Spider, current_time: int | None = None) -> None:
-        """Close the cache storage for a spider."""
+        """Close the cache storage for a spider.
+
+        Runs a best-effort cleanup sweep that deletes expired entries when expiration is enabled, then shuts
+        down the background event-loop thread. The thread is always closed, even if the sweep fails.
+
+        Args:
+            _: The spider being closed. Part of Scrapy's storage interface, unused here.
+            current_time: Unix time in seconds used as the current time when deciding which entries have
+                expired. Defaults to the current time.
+        """
         if self._async_thread is None:
             raise ValueError('Async thread not initialized')
 
+        if current_time is None:
+            current_time = int(time())
+
         logger.info(f'Cleaning up cache items (max {self._expiration_max_items})')
-        # `close` always runs in the `finally`, so neither a cleanup failure below nor an early return can leak
-        # the event-loop thread.
+
+        # Best-effort: a cleanup failure is logged and swallowed (the sweep only reclaims storage, so failing it
+        # must not turn a normal spider close into an error), and `close` always runs in the `finally`, so
+        # neither the failure nor an early return can leak the event-loop thread.
         try:
             if self._expiration_secs > 0:
-                if current_time is None:
-                    current_time = int(time())
-
-                async def expire_kvs() -> None:
-                    if self._kvs is None:
-                        raise ValueError('Key value store not initialized')
-                    # Best-effort cleanup: at most `_expiration_max_items` keys per close, in no guaranteed order,
-                    # so stale entries may linger. This only reclaims storage; `retrieve_response` already treats
-                    # an expired entry as a cache miss.
-                    processed = 0
-                    async for item in self._kvs.iterate_keys():
-                        if processed >= self._expiration_max_items:
-                            break
-                        processed += 1
-                        value = await self._kvs.get_value(item.key)
-                        try:
-                            gzip_time = read_gzip_time(value)
-                        except Exception as exc:
-                            logger.warning(f'Malformed cache item {item.key}: {exc}')
-                            await self._kvs.delete_value(item.key)
-                        else:
-                            if self._expiration_secs < current_time - gzip_time:
-                                logger.debug(f'Expired cache item {item.key}')
-                                await self._kvs.delete_value(item.key)
-                            else:
-                                logger.debug(f'Valid cache item {item.key}')
-
-                # Best-effort: log and swallow a cleanup failure rather than raise. The sweep only reclaims
-                # storage, so failing it must not turn a normal spider close into an error.
-                try:
-                    self._async_thread.run_coro(expire_kvs())
-                except Exception:
-                    logger.exception('Failed to clean up expired cache items.')
+                self._async_thread.run_coro(self._expire_kvs(current_time))
+        except Exception:
+            logger.exception('Failed to clean up expired cache items.')
         finally:
             logger.debug('Closing cache storage')
             try:
@@ -135,7 +138,20 @@ class ApifyCacheStorage:
                 logger.debug('Cache storage closed')
 
     def retrieve_response(self, _: Spider, request: Request, current_time: int | None = None) -> Response | None:
-        """Retrieve a response from the cache storage."""
+        """Retrieve a cached response for a request.
+
+        A malformed, legacy, or expired cache entry is treated as a miss, so Scrapy re-fetches the request and
+        re-stores it in the current format.
+
+        Args:
+            _: The spider making the request. Part of Scrapy's storage interface, unused here.
+            request: The request to look up in the cache.
+            current_time: Unix time in seconds used as the current time when checking whether the entry has
+                expired. Defaults to the current time.
+
+        Returns:
+            The cached response on a hit, or `None` on a miss, an expired entry, or an unreadable entry.
+        """
         if self._async_thread is None:
             raise ValueError('Async thread not initialized')
         if self._kvs is None:
@@ -165,6 +181,7 @@ class ApifyCacheStorage:
             if 0 < self._expiration_secs < current_time - read_gzip_time(value):
                 logger.debug('Cache expired', extra={'request': request})
                 return None
+
             data = from_gzip(value)
             url = data['url']
             status = data['status']
@@ -179,7 +196,13 @@ class ApifyCacheStorage:
         return respcls(url=url, headers=headers, status=status, body=body)
 
     def store_response(self, _: Spider, request: Request, response: Response) -> None:
-        """Store a response in the cache storage."""
+        """Store a response in the cache storage.
+
+        Args:
+            _: The spider that produced the response. Part of Scrapy's storage interface, unused here.
+            request: The request the response belongs to. Its fingerprint is used as the cache key.
+            response: The response to store in the cache.
+        """
         if self._async_thread is None:
             raise ValueError('Async thread not initialized')
         if self._kvs is None:
@@ -200,6 +223,35 @@ class ApifyCacheStorage:
         except Exception:
             logger.exception('Failed to store a response in the cache.')
             raise
+
+    async def _expire_kvs(self, current_time: int) -> None:
+        """Sweep the cache key-value store, deleting expired or unreadable entries.
+
+        Best-effort cleanup: at most `_expiration_max_items` keys per close, in no guaranteed order, so stale
+        entries may linger. This only reclaims storage; `retrieve_response` already treats an expired entry as
+        a cache miss.
+        """
+        if self._kvs is None:
+            raise ValueError('Key value store not initialized')
+
+        processed = 0
+
+        async for item in self._kvs.iterate_keys():
+            if processed >= self._expiration_max_items:
+                break
+
+            processed += 1
+            value = await self._kvs.get_value(item.key)
+
+            try:
+                gzip_time = read_gzip_time(value)
+            except Exception as exc:
+                logger.warning(f'Malformed cache item {item.key}: {exc}')
+                await self._kvs.delete_value(item.key)
+            else:
+                if self._expiration_secs < current_time - gzip_time:
+                    logger.debug(f'Expired cache item {item.key}')
+                    await self._kvs.delete_value(item.key)
 
 
 def to_gzip(data: dict, mtime: int | None = None) -> bytes:
@@ -249,7 +301,8 @@ def get_kvs_name(spider_name: str, max_length: int = 60) -> str:
         spider_name: Value of the Spider instance's name attribute.
         max_length: Maximum length of the key value store name.
 
-    Returns: Key value store name.
+    Returns:
+        Key value store name.
 
     Raises:
         ValueError: If the spider name contains only special characters.

--- a/src/apify/scrapy/extensions/_httpcache.py
+++ b/src/apify/scrapy/extensions/_httpcache.py
@@ -160,6 +160,8 @@ class ApifyCacheStorage:
             raise ValueError('Request fingerprinter not initialized')
 
         key = self._fingerprinter.fingerprint(request).hex()
+        # Log here before re-raising: this coroutine ran on a separate event-loop thread, and the failure is
+        # otherwise easy to lose as it crosses that thread boundary back into Scrapy's synchronous machinery.
         try:
             value = self._async_thread.run_coro(self._kvs.get_value(key))
         except Exception:
@@ -218,6 +220,8 @@ class ApifyCacheStorage:
             'body': response.body,
         }
         value = to_gzip(data)
+        # Log here before re-raising: this coroutine ran on a separate event-loop thread, and the failure is
+        # otherwise easy to lose as it crosses that thread boundary back into Scrapy's synchronous machinery.
         try:
             self._async_thread.run_coro(self._kvs.set_value(key, value))
         except Exception:

--- a/src/apify/scrapy/extensions/_httpcache.py
+++ b/src/apify/scrapy/extensions/_httpcache.py
@@ -71,6 +71,9 @@ class ApifyCacheStorage:
         try:
             self._kvs = self._async_thread.run_coro(open_kvs())
         except Exception:
+            # Opening the key-value store failed, so close the freshly started async thread instead of
+            # leaking its event-loop thread (`close_spider` may never run if `open_spider` fails).
+            self._async_thread.close()
             traceback.print_exc()
             raise
 

--- a/src/apify/scrapy/extensions/_httpcache.py
+++ b/src/apify/scrapy/extensions/_httpcache.py
@@ -107,8 +107,8 @@ class ApifyCacheStorage:
                         value = await self._kvs.get_value(item.key)
                         try:
                             gzip_time = read_gzip_time(value)
-                        except Exception as e:
-                            logger.warning(f'Malformed cache item {item.key}: {e}')
+                        except Exception as exc:
+                            logger.warning(f'Malformed cache item {item.key}: {exc}')
                             await self._kvs.delete_value(item.key)
                         else:
                             if self._expiration_secs < current_time - gzip_time:

--- a/src/apify/scrapy/extensions/_httpcache.py
+++ b/src/apify/scrapy/extensions/_httpcache.py
@@ -4,7 +4,6 @@ import gzip
 import io
 import re
 import struct
-import traceback
 from datetime import timedelta
 from logging import getLogger
 from time import time
@@ -71,10 +70,14 @@ class ApifyCacheStorage:
         try:
             self._kvs = self._async_thread.run_coro(open_kvs())
         except Exception:
+            logger.exception('Failed to open the cache key-value store.')
             # Opening the key-value store failed, so close the freshly started async thread instead of
-            # leaking its event-loop thread (`close_spider` may never run if `open_spider` fails).
-            self._async_thread.close()
-            traceback.print_exc()
+            # leaking its event-loop thread (`close_spider` may never run if `open_spider` fails). Guard
+            # the close so a secondary failure here cannot mask the original error.
+            try:
+                self._async_thread.close()
+            except Exception:
+                logger.exception('Failed to close the async thread after a failed cache storage open.')
             raise
 
     def close_spider(self, _: Spider, current_time: int | None = None) -> None:
@@ -117,7 +120,7 @@ class ApifyCacheStorage:
                 try:
                     self._async_thread.run_coro(expire_kvs())
                 except Exception:
-                    traceback.print_exc()
+                    logger.exception('Failed to clean up expired cache items.')
                     raise
         finally:
             logger.debug('Closing cache storage')
@@ -143,7 +146,7 @@ class ApifyCacheStorage:
         try:
             value = self._async_thread.run_coro(self._kvs.get_value(key))
         except Exception:
-            traceback.print_exc()
+            logger.exception('Failed to retrieve a response from the cache.')
             raise
 
         if value is None:
@@ -194,7 +197,7 @@ class ApifyCacheStorage:
         try:
             self._async_thread.run_coro(self._kvs.set_value(key, value))
         except Exception:
-            traceback.print_exc()
+            logger.exception('Failed to store a response in the cache.')
             raise
 
 

--- a/src/apify/scrapy/extensions/_httpcache.py
+++ b/src/apify/scrapy/extensions/_httpcache.py
@@ -86,8 +86,8 @@ class ApifyCacheStorage:
             raise ValueError('Async thread not initialized')
 
         logger.info(f'Cleaning up cache items (max {self._expiration_max_items})')
-        # The cleanup sweep runs inside `try` so a failure there cannot skip closing the async thread
-        # (which would leak its event-loop thread); `close` always runs in the `finally`.
+        # `close` always runs in the `finally`, so neither a cleanup failure below nor an early return can leak
+        # the event-loop thread.
         try:
             if self._expiration_secs > 0:
                 if current_time is None:
@@ -117,11 +117,12 @@ class ApifyCacheStorage:
                             else:
                                 logger.debug(f'Valid cache item {item.key}')
 
+                # Best-effort: log and swallow a cleanup failure rather than raise. The sweep only reclaims
+                # storage, so failing it must not turn a normal spider close into an error.
                 try:
                     self._async_thread.run_coro(expire_kvs())
                 except Exception:
                     logger.exception('Failed to clean up expired cache items.')
-                    raise
         finally:
             logger.debug('Closing cache storage')
             try:

--- a/src/apify/scrapy/extensions/_httpcache.py
+++ b/src/apify/scrapy/extensions/_httpcache.py
@@ -4,6 +4,7 @@ import gzip
 import io
 import re
 import struct
+import traceback
 from datetime import timedelta
 from logging import getLogger
 from time import time
@@ -39,8 +40,8 @@ class ApifyCacheStorage:
         # Upper bound on how many keys the per-spider-close cleanup sweeps (best-effort; `close_spider`).
         self._expiration_max_items: int = settings.getint('APIFY_HTTPCACHE_EXPIRATION_MAX_ITEMS', 100)
         self._expiration_secs: int = settings.getint('HTTPCACHE_EXPIRATION_SECS')
-        # Caps how long each coroutine run on the background event loop may take; defaults to 60 seconds.
         self._async_thread_timeout = timedelta(seconds=settings.getint('APIFY_ASYNC_THREAD_TIMEOUT_SECS', 60))
+        """Caps how long each coroutine run on the background event loop may take; defaults to 60 seconds."""
         self._spider: Spider | None = None
         self._kvs: KeyValueStore | None = None
         self._fingerprinter: RequestFingerprinterProtocol | None = None
@@ -67,7 +68,11 @@ class ApifyCacheStorage:
         logger.debug("Starting background thread for cache storage's event loop")
         self._async_thread = AsyncThread(default_timeout=self._async_thread_timeout)
         logger.debug(f"Opening cache storage's {kvs_name!r} key value store")
-        self._kvs = self._async_thread.run_coro(open_kvs())
+        try:
+            self._kvs = self._async_thread.run_coro(open_kvs())
+        except Exception:
+            traceback.print_exc()
+            raise
 
     def close_spider(self, _: Spider, current_time: int | None = None) -> None:
         """Close the cache storage for a spider."""
@@ -106,7 +111,11 @@ class ApifyCacheStorage:
                             else:
                                 logger.debug(f'Valid cache item {item.key}')
 
-                self._async_thread.run_coro(expire_kvs())
+                try:
+                    self._async_thread.run_coro(expire_kvs())
+                except Exception:
+                    traceback.print_exc()
+                    raise
         finally:
             logger.debug('Closing cache storage')
             try:
@@ -128,7 +137,11 @@ class ApifyCacheStorage:
             raise ValueError('Request fingerprinter not initialized')
 
         key = self._fingerprinter.fingerprint(request).hex()
-        value = self._async_thread.run_coro(self._kvs.get_value(key))
+        try:
+            value = self._async_thread.run_coro(self._kvs.get_value(key))
+        except Exception:
+            traceback.print_exc()
+            raise
 
         if value is None:
             logger.debug('Cache miss', extra={'request': request})
@@ -175,7 +188,11 @@ class ApifyCacheStorage:
             'body': response.body,
         }
         value = to_gzip(data)
-        self._async_thread.run_coro(self._kvs.set_value(key, value))
+        try:
+            self._async_thread.run_coro(self._kvs.set_value(key, value))
+        except Exception:
+            traceback.print_exc()
+            raise
 
 
 def to_gzip(data: dict, mtime: int | None = None) -> bytes:

--- a/src/apify/scrapy/requests.py
+++ b/src/apify/scrapy/requests.py
@@ -119,8 +119,8 @@ def to_apify_request(scrapy_request: ScrapyRequest, spider: Spider) -> ApifyRequ
         apify_request = ApifyRequest.from_url(**request_kwargs)
         scrapy_request_dict = scrapy_request.to_dict(spider=spider)
 
-    except Exception as exc:
-        logger.warning(f'Conversion of Scrapy request {scrapy_request} to Apify request failed; {exc}')
+    except Exception:
+        logger.exception(f'Conversion of Scrapy request {scrapy_request} to Apify request failed; skipping it.')
         return None
 
     # Serialize the Scrapy request as JSON under 'scrapy_request'. Kept outside the broad except above so

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import traceback
 from datetime import timedelta
 from logging import getLogger
 from typing import TYPE_CHECKING
@@ -73,8 +72,13 @@ class ApifyScheduler(BaseScheduler):
         try:
             self._rq = self._async_thread.run_coro(open_rq())
         except Exception:
-            self._async_thread.close()
-            traceback.print_exc()
+            logger.exception('Failed to open the request queue.')
+            # Close the freshly started async thread so a failed open does not leak its event-loop thread.
+            # Guard the close so a secondary failure here cannot mask the original error.
+            try:
+                self._async_thread.close()
+            except Exception:
+                logger.exception('Failed to close the async thread after a failed scheduler open.')
             raise
 
         return None
@@ -112,7 +116,7 @@ class ApifyScheduler(BaseScheduler):
         try:
             is_finished = self._async_thread.run_coro(self._rq.is_finished())
         except Exception:
-            traceback.print_exc()
+            logger.exception('Failed to check whether the request queue is finished.')
             raise
 
         return not is_finished
@@ -145,7 +149,7 @@ class ApifyScheduler(BaseScheduler):
         try:
             result = self._async_thread.run_coro(self._rq.add_request(apify_request))
         except Exception:
-            traceback.print_exc()
+            logger.exception('Failed to enqueue the request to the request queue.')
             raise
 
         logger.debug(f'rq.add_request result: {result}')
@@ -164,7 +168,7 @@ class ApifyScheduler(BaseScheduler):
         try:
             apify_request = self._async_thread.run_coro(self._rq.fetch_next_request())
         except Exception:
-            traceback.print_exc()
+            logger.exception('Failed to fetch the next request from the request queue.')
             raise
 
         logger.debug(f'Fetched apify_request: {apify_request}')
@@ -188,7 +192,7 @@ class ApifyScheduler(BaseScheduler):
         try:
             self._async_thread.run_coro(self._rq.mark_request_as_handled(apify_request))
         except Exception:
-            traceback.print_exc()
+            logger.exception('Failed to mark the request as handled in the request queue.')
             raise
 
         if scrapy_request is None:

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -113,6 +113,8 @@ class ApifyScheduler(BaseScheduler):
         if not isinstance(self._rq, RequestQueue):
             raise TypeError('self._rq must be an instance of the RequestQueue class')
 
+        # Log here before re-raising: this coroutine ran on a separate event-loop thread, and the failure is
+        # otherwise easy to lose as it crosses that thread boundary back into Scrapy's synchronous machinery.
         try:
             is_finished = self._async_thread.run_coro(self._rq.is_finished())
         except Exception:
@@ -146,6 +148,8 @@ class ApifyScheduler(BaseScheduler):
         if not isinstance(self._rq, RequestQueue):
             raise TypeError('self._rq must be an instance of the RequestQueue class')
 
+        # Log here before re-raising: this coroutine ran on a separate event-loop thread, and the failure is
+        # otherwise easy to lose as it crosses that thread boundary back into Scrapy's synchronous machinery.
         try:
             result = self._async_thread.run_coro(self._rq.add_request(apify_request))
         except Exception:
@@ -165,6 +169,8 @@ class ApifyScheduler(BaseScheduler):
         if not isinstance(self._rq, RequestQueue):
             raise TypeError('self._rq must be an instance of the RequestQueue class')
 
+        # Log here before re-raising: this coroutine ran on a separate event-loop thread, and the failure is
+        # otherwise easy to lose as it crosses that thread boundary back into Scrapy's synchronous machinery.
         try:
             apify_request = self._async_thread.run_coro(self._rq.fetch_next_request())
         except Exception:
@@ -189,6 +195,8 @@ class ApifyScheduler(BaseScheduler):
         # Mark the request as handled. This runs even when reconstruction failed above: an unrecoverable entry
         # (a corrupt or legacy payload) must still be consumed, otherwise the queue would keep handing it back
         # forever. Retrying genuine failures is the RetryMiddleware's job.
+        # Log here before re-raising: this coroutine ran on a separate event-loop thread, and the failure is
+        # otherwise easy to lose as it crosses that thread boundary back into Scrapy's synchronous machinery.
         try:
             self._async_thread.run_coro(self._rq.mark_request_as_handled(apify_request))
         except Exception:

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -182,8 +182,8 @@ class ApifyScheduler(BaseScheduler):
         # the whole run, so on failure it is logged and skipped (None) rather than propagating.
         try:
             scrapy_request = to_scrapy_request(apify_request, spider=self.spider)
-        except Exception:
-            logger.exception(f'Failed to convert Apify request {apify_request} to a Scrapy request; skipping it.')
+        except Exception as exc:
+            logger.warning(f'Failed to convert Apify request {apify_request} to a Scrapy request; skipping it: {exc}')
             scrapy_request = None
 
         # Mark the request as handled. This runs even when reconstruction failed above: an unrecoverable entry

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import traceback
+from datetime import timedelta
 from logging import getLogger
 from typing import TYPE_CHECKING
 
@@ -15,6 +15,7 @@ from apify.storage_clients import ApifyStorageClient
 from apify.storages import RequestQueue
 
 if TYPE_CHECKING:
+    from scrapy.crawler import Crawler
     from scrapy.http.request import Request
     from twisted.internet.defer import Deferred
 
@@ -27,7 +28,7 @@ class ApifyScheduler(BaseScheduler):
     This scheduler requires the asyncio Twisted reactor to be installed.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, async_thread_timeout: timedelta = timedelta(seconds=60)) -> None:
         if not is_asyncio_reactor_installed():
             raise ValueError(
                 f'{ApifyScheduler.__qualname__} requires the asyncio Twisted reactor. '
@@ -38,7 +39,17 @@ class ApifyScheduler(BaseScheduler):
         self.spider: Spider | None = None
 
         # A thread with the asyncio event loop to run coroutines on.
-        self._async_thread = AsyncThread()
+        self._async_thread = AsyncThread(default_timeout=async_thread_timeout)
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> ApifyScheduler:
+        """Create the scheduler, reading the async-thread timeout from the Scrapy settings.
+
+        The `APIFY_ASYNC_THREAD_TIMEOUT_SECS` setting (in seconds) caps how long each coroutine run on the
+        background event loop may take before timing out; it defaults to 60 seconds.
+        """
+        timeout_secs = crawler.settings.getint('APIFY_ASYNC_THREAD_TIMEOUT_SECS', 60)
+        return cls(async_thread_timeout=timedelta(seconds=timeout_secs))
 
     def open(self, spider: Spider) -> Deferred[None] | None:
         """Open the scheduler.
@@ -62,7 +73,6 @@ class ApifyScheduler(BaseScheduler):
             self._rq = self._async_thread.run_coro(open_rq())
         except Exception:
             self._async_thread.close()
-            traceback.print_exc()
             raise
 
         return None
@@ -97,12 +107,7 @@ class ApifyScheduler(BaseScheduler):
         if not isinstance(self._rq, RequestQueue):
             raise TypeError('self._rq must be an instance of the RequestQueue class')
 
-        try:
-            is_finished = self._async_thread.run_coro(self._rq.is_finished())
-        except Exception:
-            traceback.print_exc()
-            raise
-
+        is_finished = self._async_thread.run_coro(self._rq.is_finished())
         return not is_finished
 
     def enqueue_request(self, request: Request) -> bool:
@@ -130,12 +135,7 @@ class ApifyScheduler(BaseScheduler):
         if not isinstance(self._rq, RequestQueue):
             raise TypeError('self._rq must be an instance of the RequestQueue class')
 
-        try:
-            result = self._async_thread.run_coro(self._rq.add_request(apify_request))
-        except Exception:
-            traceback.print_exc()
-            raise
-
+        result = self._async_thread.run_coro(self._rq.add_request(apify_request))
         logger.debug(f'rq.add_request result: {result}')
         return not bool(result.was_already_present)
 
@@ -149,12 +149,7 @@ class ApifyScheduler(BaseScheduler):
         if not isinstance(self._rq, RequestQueue):
             raise TypeError('self._rq must be an instance of the RequestQueue class')
 
-        try:
-            apify_request = self._async_thread.run_coro(self._rq.fetch_next_request())
-        except Exception:
-            traceback.print_exc()
-            raise
-
+        apify_request = self._async_thread.run_coro(self._rq.fetch_next_request())
         logger.debug(f'Fetched apify_request: {apify_request}')
         if apify_request is None:
             return None
@@ -173,11 +168,7 @@ class ApifyScheduler(BaseScheduler):
         # Mark the request as handled. This runs even when reconstruction failed above: an unrecoverable entry
         # (a corrupt or legacy payload) must still be consumed, otherwise the queue would keep handing it back
         # forever. Retrying genuine failures is the RetryMiddleware's job.
-        try:
-            self._async_thread.run_coro(self._rq.mark_request_as_handled(apify_request))
-        except Exception:
-            traceback.print_exc()
-            raise
+        self._async_thread.run_coro(self._rq.mark_request_as_handled(apify_request))
 
         if scrapy_request is None:
             return None

--- a/src/apify/scrapy/scheduler.py
+++ b/src/apify/scrapy/scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import traceback
 from datetime import timedelta
 from logging import getLogger
 from typing import TYPE_CHECKING
@@ -73,6 +74,7 @@ class ApifyScheduler(BaseScheduler):
             self._rq = self._async_thread.run_coro(open_rq())
         except Exception:
             self._async_thread.close()
+            traceback.print_exc()
             raise
 
         return None
@@ -107,7 +109,12 @@ class ApifyScheduler(BaseScheduler):
         if not isinstance(self._rq, RequestQueue):
             raise TypeError('self._rq must be an instance of the RequestQueue class')
 
-        is_finished = self._async_thread.run_coro(self._rq.is_finished())
+        try:
+            is_finished = self._async_thread.run_coro(self._rq.is_finished())
+        except Exception:
+            traceback.print_exc()
+            raise
+
         return not is_finished
 
     def enqueue_request(self, request: Request) -> bool:
@@ -135,7 +142,12 @@ class ApifyScheduler(BaseScheduler):
         if not isinstance(self._rq, RequestQueue):
             raise TypeError('self._rq must be an instance of the RequestQueue class')
 
-        result = self._async_thread.run_coro(self._rq.add_request(apify_request))
+        try:
+            result = self._async_thread.run_coro(self._rq.add_request(apify_request))
+        except Exception:
+            traceback.print_exc()
+            raise
+
         logger.debug(f'rq.add_request result: {result}')
         return not bool(result.was_already_present)
 
@@ -149,7 +161,12 @@ class ApifyScheduler(BaseScheduler):
         if not isinstance(self._rq, RequestQueue):
             raise TypeError('self._rq must be an instance of the RequestQueue class')
 
-        apify_request = self._async_thread.run_coro(self._rq.fetch_next_request())
+        try:
+            apify_request = self._async_thread.run_coro(self._rq.fetch_next_request())
+        except Exception:
+            traceback.print_exc()
+            raise
+
         logger.debug(f'Fetched apify_request: {apify_request}')
         if apify_request is None:
             return None
@@ -168,7 +185,11 @@ class ApifyScheduler(BaseScheduler):
         # Mark the request as handled. This runs even when reconstruction failed above: an unrecoverable entry
         # (a corrupt or legacy payload) must still be consumed, otherwise the queue would keep handing it back
         # forever. Retrying genuine failures is the RetryMiddleware's job.
-        self._async_thread.run_coro(self._rq.mark_request_as_handled(apify_request))
+        try:
+            self._async_thread.run_coro(self._rq.mark_request_as_handled(apify_request))
+        except Exception:
+            traceback.print_exc()
+            raise
 
         if scrapy_request is None:
             return None

--- a/tests/unit/scrapy/extensions/test_httpcache.py
+++ b/tests/unit/scrapy/extensions/test_httpcache.py
@@ -5,6 +5,7 @@ import gzip
 import io
 import json
 import pickle
+from datetime import timedelta
 from time import time
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
@@ -272,6 +273,55 @@ def test_close_spider_respects_max_items() -> None:
     storage.close_spider(None, current_time=current_time)  # ty: ignore[invalid-argument-type]
 
     assert len(kvs.deleted) == 2
+
+
+def test_close_spider_closes_thread_even_when_cleanup_fails() -> None:
+    """If the expiration sweep raises, the async thread is still closed rather than leaked."""
+    closed: list[bool] = []
+
+    class _FailingAsyncThread:
+        def run_coro(self, coro: Any, *_: Any, **__: Any) -> Any:
+            coro.close()  # we never run it; just avoid an un-awaited coroutine warning
+            raise RuntimeError('cleanup boom')
+
+        def close(self, *_: Any, **__: Any) -> None:
+            closed.append(True)
+
+    storage = ApifyCacheStorage(Settings({'HTTPCACHE_EXPIRATION_SECS': 100}))
+    storage._async_thread = _FailingAsyncThread()  # ty: ignore[invalid-assignment]
+    storage._kvs = _FakeKvs(None)  # ty: ignore[invalid-assignment]
+
+    with pytest.raises(RuntimeError, match='cleanup boom'):
+        storage.close_spider(None, current_time=1000)  # ty: ignore[invalid-argument-type]
+
+    assert closed == [True]
+
+
+def test_cache_storage_reads_async_thread_timeout_setting() -> None:
+    """`APIFY_ASYNC_THREAD_TIMEOUT_SECS` is read into the storage's async-thread timeout."""
+    storage = ApifyCacheStorage(Settings({'APIFY_ASYNC_THREAD_TIMEOUT_SECS': 77}))
+    assert storage._async_thread_timeout == timedelta(seconds=77)
+
+
+def test_open_spider_passes_timeout_to_async_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`open_spider` constructs the async thread with the configured timeout."""
+    captured: dict[str, Any] = {}
+
+    class _RecordingAsyncThread:
+        def __init__(self, default_timeout: timedelta | None = None) -> None:
+            captured['default_timeout'] = default_timeout
+
+        def run_coro(self, coro: Any, *_: Any, **__: Any) -> Any:
+            coro.close()  # we never run it; just avoid an un-awaited coroutine warning
+            return _FakeKvs(None)
+
+    monkeypatch.setattr('apify.scrapy.extensions._httpcache.AsyncThread', _RecordingAsyncThread)
+
+    storage = ApifyCacheStorage(Settings({'APIFY_ASYNC_THREAD_TIMEOUT_SECS': 77}))
+    spider = SimpleNamespace(name='myspider', crawler=SimpleNamespace(request_fingerprinter=_FakeFingerprinter()))
+    storage.open_spider(cast('Any', spider))
+
+    assert captured['default_timeout'] == timedelta(seconds=77)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/scrapy/extensions/test_httpcache.py
+++ b/tests/unit/scrapy/extensions/test_httpcache.py
@@ -4,6 +4,7 @@ import asyncio
 import gzip
 import io
 import json
+import logging
 import pickle
 from datetime import timedelta
 from time import time
@@ -275,8 +276,8 @@ def test_close_spider_respects_max_items() -> None:
     assert len(kvs.deleted) == 2
 
 
-def test_close_spider_closes_thread_even_when_cleanup_fails() -> None:
-    """If the expiration sweep raises, the async thread is still closed rather than leaked."""
+def test_close_spider_closes_thread_even_when_cleanup_fails(caplog: pytest.LogCaptureFixture) -> None:
+    """A best-effort cleanup failure is logged and swallowed; the async thread is still closed, not leaked."""
     closed: list[bool] = []
 
     class _FailingAsyncThread:
@@ -291,10 +292,11 @@ def test_close_spider_closes_thread_even_when_cleanup_fails() -> None:
     storage._async_thread = _FailingAsyncThread()  # ty: ignore[invalid-assignment]
     storage._kvs = _FakeKvs(None)  # ty: ignore[invalid-assignment]
 
-    with pytest.raises(RuntimeError, match='cleanup boom'):
+    with caplog.at_level(logging.ERROR, logger='apify.scrapy.extensions._httpcache'):
         storage.close_spider(None, current_time=1000)  # ty: ignore[invalid-argument-type]
 
     assert closed == [True]
+    assert 'Failed to clean up expired cache items' in caplog.text
 
 
 def test_cache_storage_reads_async_thread_timeout_setting() -> None:

--- a/tests/unit/scrapy/extensions/test_httpcache.py
+++ b/tests/unit/scrapy/extensions/test_httpcache.py
@@ -324,6 +324,32 @@ def test_open_spider_passes_timeout_to_async_thread(monkeypatch: pytest.MonkeyPa
     assert captured['default_timeout'] == timedelta(seconds=77)
 
 
+def test_open_spider_closes_async_thread_when_open_kvs_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If opening the key-value store fails, `open_spider` closes the async thread rather than leaking it."""
+    closed: list[bool] = []
+
+    class _FailingAsyncThread:
+        def __init__(self, default_timeout: timedelta | None = None) -> None:
+            pass
+
+        def run_coro(self, coro: Any, *_: Any, **__: Any) -> Any:
+            coro.close()  # we never run it; just avoid an un-awaited coroutine warning
+            raise RuntimeError('open boom')
+
+        def close(self, *_: Any, **__: Any) -> None:
+            closed.append(True)
+
+    monkeypatch.setattr('apify.scrapy.extensions._httpcache.AsyncThread', _FailingAsyncThread)
+
+    storage = ApifyCacheStorage(Settings())
+    spider = SimpleNamespace(name='myspider', crawler=SimpleNamespace(request_fingerprinter=_FakeFingerprinter()))
+
+    with pytest.raises(RuntimeError, match='open boom'):
+        storage.open_spider(cast('Any', spider))
+
+    assert closed == [True]
+
+
 @pytest.mark.parametrize(
     ('spider_name', 'expected'),
     [

--- a/tests/unit/scrapy/test_async_thread.py
+++ b/tests/unit/scrapy/test_async_thread.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from concurrent import futures
+from datetime import timedelta
+from typing import Any, Literal
+
+import pytest
+
+from apify.scrapy._async_thread import AsyncThread
+
+
+def _wait_until_running(thread: AsyncThread, timeout: float = 2.0) -> None:
+    """Block until the background event loop is running, so `run_coro` does not race the thread startup."""
+    deadline = time.monotonic() + timeout
+    while not thread._eventloop.is_running():
+        if time.monotonic() > deadline:
+            raise AssertionError('The event loop did not start in time.')
+        time.sleep(0.01)
+
+
+# Coroutine execution
+
+
+def test_run_coro_cancels_the_coroutine_on_timeout() -> None:
+    """A timed-out coroutine is cancelled, not left running on the background loop."""
+    thread = AsyncThread()
+    _wait_until_running(thread)
+
+    started = threading.Event()
+    cancelled = threading.Event()
+
+    async def slow() -> None:
+        started.set()
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    with pytest.raises(futures.TimeoutError):
+        thread.run_coro(slow(), timeout=timedelta(seconds=0.1))
+
+    assert started.wait(timeout=2)
+    assert cancelled.wait(timeout=2), 'the timed-out coroutine was left running instead of being cancelled'
+
+    thread.close()
+
+
+def test_run_coro_does_not_log_on_exception(caplog: pytest.LogCaptureFixture) -> None:
+    """`run_coro` propagates a failing coroutine without logging it itself (the caller/Scrapy reports it once)."""
+    thread = AsyncThread()
+    _wait_until_running(thread)
+
+    async def boom() -> None:
+        raise RuntimeError('boom')
+
+    with caplog.at_level(logging.DEBUG, logger='apify.scrapy._async_thread'), pytest.raises(RuntimeError, match='boom'):
+        thread.run_coro(boom())
+
+    thread.close()
+
+    assert [record for record in caplog.records if record.levelno >= logging.ERROR] == []
+
+
+# Shutdown
+
+
+def test_close_is_idempotent() -> None:
+    """Calling `close` twice is a no-op the second time, not a `RuntimeError` on the closed loop."""
+    thread = AsyncThread()
+    _wait_until_running(thread)
+    thread.run_coro(asyncio.sleep(0))
+
+    thread.close()
+    thread.close()  # must not raise
+
+
+def test_close_passes_its_timeout_to_the_shutdown_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`close(timeout=...)` honours that timeout for the task-cancellation step, not only the thread join."""
+    thread = AsyncThread()
+    _wait_until_running(thread)
+    thread.run_coro(asyncio.sleep(0))
+
+    recorded: list[timedelta | str] = []
+    original = thread.run_coro
+
+    def spy(coro: Any, timeout: timedelta | Literal['default'] = 'default') -> Any:
+        recorded.append(timeout)
+        return original(coro, timeout=timeout)
+
+    monkeypatch.setattr(thread, 'run_coro', spy)
+    thread.close(timeout=timedelta(seconds=42))
+
+    assert recorded == [timedelta(seconds=42)]

--- a/tests/unit/scrapy/test_async_thread.py
+++ b/tests/unit/scrapy/test_async_thread.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from apify.scrapy._async_thread import AsyncThread
+
+
+async def _return(value: int) -> int:
+    return value
+
+
+# Normal operation
+
+
+def test_run_coro_returns_coroutine_result() -> None:
+    """`run_coro` runs a coroutine on the background loop and returns its result."""
+    async_thread = AsyncThread()
+    try:
+        assert async_thread.run_coro(_return(42)) == 42
+    finally:
+        async_thread.close()
+
+
+# Startup race regression
+
+
+def test_run_coro_succeeds_when_called_before_loop_starts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`run_coro` must not fail when invoked before the background thread reaches `run_forever`."""
+    gate = threading.Event()
+    original_start = AsyncThread._start_event_loop
+
+    def gated_start(self: AsyncThread) -> None:
+        gate.wait()  # hold the loop just shy of run_forever() to force the startup race
+        original_start(self)
+
+    monkeypatch.setattr(AsyncThread, '_start_event_loop', gated_start)
+
+    async_thread = AsyncThread()
+    try:
+        # The loop start is gated, so the loop is provably not running yet.
+        assert not async_thread._eventloop.is_running()
+
+        # Let the loop reach run_forever() shortly after run_coro starts waiting.
+        def release_gate() -> None:
+            time.sleep(0.1)
+            gate.set()
+
+        releaser = threading.Thread(target=release_gate)
+        releaser.start()
+
+        assert async_thread.run_coro(_return(42)) == 42
+        releaser.join()
+    finally:
+        gate.set()
+        async_thread.close()
+
+
+# Closed loop guard
+
+
+def test_run_coro_raises_after_close() -> None:
+    """`run_coro` raises `RuntimeError` once the loop has been closed."""
+    async_thread = AsyncThread()
+    async_thread.close()
+
+    coro = _return(42)
+    with pytest.raises(RuntimeError):
+        async_thread.run_coro(coro)
+    coro.close()

--- a/tests/unit/scrapy/test_async_thread.py
+++ b/tests/unit/scrapy/test_async_thread.py
@@ -12,9 +12,6 @@ async def _return(value: int) -> int:
     return value
 
 
-# Normal operation
-
-
 def test_run_coro_returns_coroutine_result() -> None:
     """`run_coro` runs a coroutine on the background loop and returns its result."""
     async_thread = AsyncThread()
@@ -22,9 +19,6 @@ def test_run_coro_returns_coroutine_result() -> None:
         assert async_thread.run_coro(_return(42)) == 42
     finally:
         async_thread.close()
-
-
-# Startup race regression
 
 
 def test_run_coro_succeeds_when_called_before_loop_starts(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -56,9 +50,6 @@ def test_run_coro_succeeds_when_called_before_loop_starts(monkeypatch: pytest.Mo
     finally:
         gate.set()
         async_thread.close()
-
-
-# Closed loop guard
 
 
 def test_run_coro_raises_after_close() -> None:

--- a/tests/unit/scrapy/test_async_thread.py
+++ b/tests/unit/scrapy/test_async_thread.py
@@ -3,26 +3,20 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-import time
 from concurrent import futures
 from datetime import timedelta
 from typing import Any, Literal
 
 import pytest
 
+from ..._utils import poll_until_condition
 from apify.scrapy._async_thread import AsyncThread
 
 
 def _wait_until_running(thread: AsyncThread, timeout: float = 2.0) -> None:
     """Block until the background event loop is running, so `run_coro` does not race the thread startup."""
-    deadline = time.monotonic() + timeout
-    while not thread._eventloop.is_running():
-        if time.monotonic() > deadline:
-            raise AssertionError('The event loop did not start in time.')
-        time.sleep(0.01)
-
-
-# Coroutine execution
+    if not asyncio.run(poll_until_condition(thread._eventloop.is_running, timeout=timeout, poll_interval=0.01)):
+        raise AssertionError('The event loop did not start in time.')
 
 
 def test_run_coro_cancels_the_coroutine_on_timeout() -> None:
@@ -64,9 +58,6 @@ def test_run_coro_does_not_log_on_exception(caplog: pytest.LogCaptureFixture) ->
     thread.close()
 
     assert [record for record in caplog.records if record.levelno >= logging.ERROR] == []
-
-
-# Shutdown
 
 
 def test_close_is_idempotent() -> None:

--- a/tests/unit/scrapy/test_async_thread.py
+++ b/tests/unit/scrapy/test_async_thread.py
@@ -87,3 +87,21 @@ def test_close_passes_its_timeout_to_the_shutdown_step(monkeypatch: pytest.Monke
     thread.close(timeout=timedelta(seconds=42))
 
     assert recorded == [timedelta(seconds=42)]
+
+
+def test_close_stops_and_joins_thread_even_when_task_cancellation_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If cancelling the pending tasks fails, `close` still stops the loop and joins the thread, not leaks it."""
+    thread = AsyncThread()
+    _wait_until_running(thread)
+
+    async def boom() -> None:
+        raise RuntimeError('shutdown boom')
+
+    monkeypatch.setattr(thread, '_shutdown_tasks', boom)
+
+    with pytest.raises(RuntimeError, match='shutdown boom'):
+        thread.close(timeout=timedelta(seconds=5))
+
+    # The loop was stopped and its thread joined despite the failing cancellation, so nothing is left running.
+    assert not thread._thread.is_alive()
+    assert thread._eventloop.is_closed()

--- a/tests/unit/scrapy/test_scheduler.py
+++ b/tests/unit/scrapy/test_scheduler.py
@@ -111,7 +111,7 @@ def test_next_request_skips_request_that_fails_to_convert(
     # `run_coro` is called for `fetch_next_request`, then for `mark_request_as_handled`.
     async_thread.run_coro.side_effect = [malformed_request, None]
 
-    with caplog.at_level(logging.ERROR, logger='apify.scrapy.scheduler'):
+    with caplog.at_level(logging.WARNING, logger='apify.scrapy.scheduler'):
         result = scheduler.next_request()
 
     # The malformed request is skipped instead of crashing the whole run.

--- a/tests/unit/scrapy/test_scheduler.py
+++ b/tests/unit/scrapy/test_scheduler.py
@@ -155,18 +155,20 @@ def test_next_request_returns_none_when_queue_empty(scheduler: ApifyScheduler) -
     rq.mark_request_as_handled.assert_not_called()
 
 
-def test_next_request_does_not_print_traceback_to_stderr(
+def test_next_request_prints_traceback_to_stderr(
     scheduler: ApifyScheduler,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """A failure propagates as-is, without `traceback.print_exc()` printing a second copy past the log formatter."""
+    """A failure in the coroutine run prints a traceback to stderr via `traceback.print_exc()` before propagating."""
     async_thread = cast('mock.MagicMock', scheduler._async_thread)
     async_thread.run_coro.side_effect = RuntimeError('boom')
 
     with pytest.raises(RuntimeError, match='boom'):
         scheduler.next_request()
 
-    assert capsys.readouterr().err == ''
+    captured = capsys.readouterr()
+    assert 'Traceback (most recent call last)' in captured.err
+    assert 'RuntimeError: boom' in captured.err
 
 
 def test_from_crawler_reads_async_thread_timeout_setting(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/scrapy/test_scheduler.py
+++ b/tests/unit/scrapy/test_scheduler.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest import mock
 
 import pytest
 from scrapy import Request, Spider
+from scrapy.settings import Settings
 
 from apify import Request as ApifyRequest
 from apify.scrapy.scheduler import ApifyScheduler
@@ -151,3 +153,35 @@ def test_next_request_returns_none_when_queue_empty(scheduler: ApifyScheduler) -
 
     assert result is None
     rq.mark_request_as_handled.assert_not_called()
+
+
+def test_next_request_does_not_print_traceback_to_stderr(
+    scheduler: ApifyScheduler,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failure propagates as-is, without `traceback.print_exc()` printing a second copy past the log formatter."""
+    async_thread = cast('mock.MagicMock', scheduler._async_thread)
+    async_thread.run_coro.side_effect = RuntimeError('boom')
+
+    with pytest.raises(RuntimeError, match='boom'):
+        scheduler.next_request()
+
+    assert capsys.readouterr().err == ''
+
+
+def test_from_crawler_reads_async_thread_timeout_setting(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`from_crawler` wires the `APIFY_ASYNC_THREAD_TIMEOUT_SECS` setting into the async thread's timeout."""
+    monkeypatch.setattr('apify.scrapy.scheduler.is_asyncio_reactor_installed', lambda: True)
+
+    captured: dict[str, Any] = {}
+
+    class _RecordingAsyncThread:
+        def __init__(self, default_timeout: timedelta | None = None) -> None:
+            captured['default_timeout'] = default_timeout
+
+    monkeypatch.setattr('apify.scrapy.scheduler.AsyncThread', _RecordingAsyncThread)
+
+    crawler = SimpleNamespace(settings=Settings({'APIFY_ASYNC_THREAD_TIMEOUT_SECS': 123}))
+    ApifyScheduler.from_crawler(cast('Any', crawler))
+
+    assert captured['default_timeout'] == timedelta(seconds=123)

--- a/tests/unit/scrapy/test_scheduler.py
+++ b/tests/unit/scrapy/test_scheduler.py
@@ -155,20 +155,23 @@ def test_next_request_returns_none_when_queue_empty(scheduler: ApifyScheduler) -
     rq.mark_request_as_handled.assert_not_called()
 
 
-def test_next_request_prints_traceback_to_stderr(
+def test_next_request_logs_exception_before_propagating(
     scheduler: ApifyScheduler,
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A failure in the coroutine run prints a traceback to stderr via `traceback.print_exc()` before propagating."""
+    """A failure in the coroutine run is logged with its traceback via `logger.exception` before propagating."""
     async_thread = cast('mock.MagicMock', scheduler._async_thread)
     async_thread.run_coro.side_effect = RuntimeError('boom')
 
-    with pytest.raises(RuntimeError, match='boom'):
+    with caplog.at_level(logging.ERROR, logger='apify.scrapy.scheduler'), pytest.raises(RuntimeError, match='boom'):
         scheduler.next_request()
 
-    captured = capsys.readouterr()
-    assert 'Traceback (most recent call last)' in captured.err
-    assert 'RuntimeError: boom' in captured.err
+    errors = [record for record in caplog.records if record.levelno >= logging.ERROR]
+    assert len(errors) == 1
+    (error,) = errors
+    assert error.exc_info is not None
+    assert isinstance(error.exc_info[1], RuntimeError)
+    assert str(error.exc_info[1]) == 'boom'
 
 
 def test_from_crawler_reads_async_thread_timeout_setting(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description

Fixes several defects in the Scrapy integration's background event-loop thread (`AsyncThread`), the scheduler, and the HTTP cache storage, and makes the loop timeout configurable.

## Fixes

- **`run_coro` startup race** — the `is_running()` guard fired spuriously when a coroutine was submitted before the loop thread reached `run_forever()` (observed ~122/500 in `scheduler.open()`). It now guards on `is_closed()`. A coroutine queued on a not-yet-running loop runs once the loop starts; only a closed loop raises.
- **`close()` thread leak** — if task cancellation timed out or raised, the loop was never stopped or joined. Stop, join, and the forced-shutdown fallback now run in a `finally`, and the original error still propagates.
- **`close()` second call** — a repeated close raised `RuntimeError: Event loop is closed`. An `is_closed()` early-return makes it a no-op.
- **`close()` ignored its `timeout`** for the cancellation step (it used the constructor default). It now passes the caller's timeout through.
- **`run_coro` timeout** left the coroutine running. It now cancels the future on timeout.
- **HTTP cache open/cleanup thread leaks** — `open_spider` now closes the thread if opening the key-value store fails (matching `ApifyScheduler.open`). The expiration sweep runs inside `try` with `close()` in a `finally`.
- **Configurable timeout (#955)** — new `APIFY_ASYNC_THREAD_TIMEOUT_SECS` setting, wired into the scheduler (via `from_crawler`) and the cache storage.

## Error logging

The integration now follows consistent conventions for caught exceptions:

- **`except … as exc:` → `logger.warning(f'… {exc}')`, swallowed** — for *expected, recoverable* conditions handled locally: a malformed or legacy stored payload skipped as a cache/queue miss, or non-UTF-8 headers preserved in the serialized request. A short message plus the exception text, with no traceback, because it is not a bug.
- **`except Exception:` → `logger.exception('…')`, swallowed** — for *unexpected* failures handled at a terminal point: the cleanup sweep, shutdown, or skip-and-continue. `logger.exception` attaches the full traceback, and nothing re-raises because the error is handled here.
- **`except …:` → `raise` (no logging)** — when the error is re-raised and the caller or Scrapy logs it with a traceback anyway. `run_coro`'s timeout path cancels the future and re-raises without logging, so the failure is reported once.
- **`except Exception:` → `logger.exception('…'); raise`** — the boundary log, used only where local context materially helps *and* the propagated error would otherwise be logged only generically or not at all. The scheduler's `next_request` / `enqueue_request` / `has_pending_requests` are called synchronously by the Scrapy engine (not inside a Deferred), so without this log the Apify-specific context would be lost.

**Why `logger.exception` replaced `traceback.print_exc()`:** `traceback.print_exc()` writes a bare traceback straight to stderr, bypassing logging entirely. It has no level, no logger name, no message, and ignores Scrapy's and the SDK's log configuration and handlers. `logger.exception(msg)` logs at ERROR through the configured logging, so it is routed, formatted, and filterable like every other log line. It adds a message explaining *what* failed and still attaches the full traceback automatically, which makes including the exception object in the message (`{exc}`) redundant (ruff TRY401).

## Tests

New `tests/unit/scrapy/test_async_thread.py` covers the startup race, run-after-close, timeout cancellation, idempotent close, the caller timeout reaching the shutdown step, and stop/join when task cancellation fails. The scheduler and HTTP cache test modules gain coverage for the timeout setting, closing the thread on open failure, and the cleanup-failure path still closing the thread.
