### PR TITLE
test: deflake request queue fetch-and-handle integration tests

### DIFF
--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -57,10 +57,12 @@ async def test_add_and_fetch_requests(
         Actor.log.info('Fetching next request...')
         queue_operation_info = await rq.mark_request_as_handled(next_request)
         assert queue_operation_info is not None, f'queue_operation_info={queue_operation_info}'
-        assert queue_operation_info.was_already_handled is False, (
-            f'queue_operation_info.was_already_handled={queue_operation_info.was_already_handled}'
-        )
-        handled_request_count += 1
+        # The request queue has at-least-once delivery: a request can occasionally be fetched again before the
+        # platform propagates its handled state, so the same request may be marked as handled more than once
+        # (`was_already_handled` reports the state before this update). Count only the first time each request is
+        # handled. See https://github.com/apify/apify-sdk-python/issues/808.
+        if not queue_operation_info.was_already_handled:
+            handled_request_count += 1
 
     assert handled_request_count == desired_request_count, (
         f'handled_request_count={handled_request_count}',
@@ -92,10 +94,12 @@ async def test_add_requests_in_batches(
             Actor.log.info(f'Processing request {handled_request_count + 1}...')
         queue_operation_info = await rq.mark_request_as_handled(next_request)
         assert queue_operation_info is not None, f'queue_operation_info={queue_operation_info}'
-        assert queue_operation_info.was_already_handled is False, (
-            f'queue_operation_info.was_already_handled={queue_operation_info.was_already_handled}'
-        )
-        handled_request_count += 1
+        # The request queue has at-least-once delivery: a request can occasionally be fetched again before the
+        # platform propagates its handled state, so the same request may be marked as handled more than once
+        # (`was_already_handled` reports the state before this update). Count only the first time each request is
+        # handled. See https://github.com/apify/apify-sdk-python/issues/808.
+        if not queue_operation_info.was_already_handled:
+            handled_request_count += 1
 
     assert handled_request_count == desired_request_count, (
         f'handled_request_count={handled_request_count}',
@@ -130,10 +134,12 @@ async def test_add_non_unique_requests_in_batch(
             Actor.log.info(f'Processing request {handled_request_count + 1}: {next_request.url}')
         queue_operation_info = await rq.mark_request_as_handled(next_request)
         assert queue_operation_info is not None, f'queue_operation_info={queue_operation_info}'
-        assert queue_operation_info.was_already_handled is False, (
-            f'queue_operation_info.was_already_handled={queue_operation_info.was_already_handled}'
-        )
-        handled_request_count += 1
+        # The request queue has at-least-once delivery: a request can occasionally be fetched again before the
+        # platform propagates its handled state, so the same request may be marked as handled more than once
+        # (`was_already_handled` reports the state before this update). Count only the first time each request is
+        # handled. See https://github.com/apify/apify-sdk-python/issues/808.
+        if not queue_operation_info.was_already_handled:
+            handled_request_count += 1
 
     expected_count = int(desired_request_count * 3 / 4)
     assert handled_request_count == expected_count, (


### PR DESCRIPTION
`test_add_and_fetch_requests[single]` (and its siblings `test_add_requests_in_batches` and `test_add_non_unique_requests_in_batch`) intermittently failed in CI on `queue_operation_info.was_already_handled is False`.

The Apify request queue has at-least-once delivery. A request can occasionally be fetched again before the platform propagates its handled state, so `mark_request_as_handled` reports `was_already_handled=True` (the state before the update) on the duplicate. The single-mode client already does best-effort local dedup and documents this as a low-probability race and API propagation delay, so the queue contract is at-least-once, not exactly-once.

These tests asserted exactly-once delivery on every mark. They now count only first-time handles (`if not was_already_handled`), which keeps the `handled_request_count == desired_request_count` invariant while tolerating the occasional duplicate. See #808.