### PR TITLE
chore(deps): bump vulnerable website deps to resolve security alerts

### DIFF
--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -5287,9 +5287,6 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
-  joi@17.13.3:
-    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
-
   joi@17.13.4:
     resolution: {integrity: sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==}
 
@@ -10691,7 +10688,7 @@ snapshots:
       '@docusaurus/utils': 3.10.1(@swc/core@1.15.40)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.40)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.5
-      joi: 17.13.3
+      joi: 17.13.4
       js-yaml: 4.2.0
       lodash: 4.18.1
       tslib: 2.8.1
@@ -14864,14 +14861,6 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@1.21.7: {}
-
-  joi@17.13.3:
-    dependencies:
-      '@hapi/hoek': 9.3.0
-      '@hapi/topo': 5.1.0
-      '@sideway/address': 4.1.5
-      '@sideway/formula': 3.0.1
-      '@sideway/pinpoint': 2.0.0
 
   joi@17.13.4:
     dependencies:


### PR DESCRIPTION
Resolves Dependabot security alerts in the docs website (pnpm project). Lockfile-only bump via `pnpm update joi js-yaml -r` — no `overrides` or hand-edited versions.

### Fixed
- **joi**: 17.13.3 → 17.13.4 (consumers repointed; duplicate 17.13.3 resolution removed)
- **js-yaml**: ≥ 4.2.0 already resolved in the lockfile (no change needed for the v4 line)

### Not addressed here
- **js-yaml 3.14.2** remains via `gray-matter@4.0.3`, which pins `js-yaml@^3.x` and cannot be moved to v4 without a `gray-matter` upgrade. Out of scope for a lockfile-only bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)