### PR TITLE
fix: prevent request queue softlock by adding `is_finished` and correcting `is_empty`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,9 +243,6 @@ apify-client = false
 apify_fingerprint_datapoints = false
 crawlee = false
 
-[tool.uv.sources]
-crawlee = { git = "https://github.com/Mantisus/crawlee-python", branch = "queue-client-is-finished" }
-
 # Run tasks with: uv run poe <task>
 [tool.poe.tasks]
 clean = "rm -rf .coverage .pytest_cache .ruff_cache .ty_cache build dist htmlcov"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,6 +243,9 @@ apify-client = false
 apify_fingerprint_datapoints = false
 crawlee = false
 
+[tool.uv.sources]
+crawlee = { git = "https://github.com/Mantisus/crawlee-python", branch = "queue-client-is-finished" }
+
 # Run tasks with: uv run poe <task>
 [tool.poe.tasks]
 clean = "rm -rf .coverage .pytest_cache .ruff_cache .ty_cache build dist htmlcov"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 ]
 dependencies = [
     "apify-client>=3.0.0,<4.0.0",
-    "crawlee>=1.0.4,<2.0.0",
+    "crawlee>=1.8.0,<2.0.0",
     "cachetools>=5.5.0",
     "cryptography>=42.0.0",
     "impit>=0.8.0",

--- a/src/apify/storage_clients/_apify/_request_queue_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_client.py
@@ -199,5 +199,6 @@ class ApifyRequestQueueClient(RequestQueueClient):
     async def is_empty(self) -> bool:
         return await self._implementation.is_empty()
 
+    @override
     async def is_finished(self) -> bool:
         return await self._implementation.is_finished()

--- a/src/apify/storage_clients/_apify/_request_queue_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_client.py
@@ -198,3 +198,7 @@ class ApifyRequestQueueClient(RequestQueueClient):
     @override
     async def is_empty(self) -> bool:
         return await self._implementation.is_empty()
+
+    @override
+    async def is_finished(self) -> bool:
+        return await self._implementation.is_finished()

--- a/src/apify/storage_clients/_apify/_request_queue_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_client.py
@@ -199,6 +199,5 @@ class ApifyRequestQueueClient(RequestQueueClient):
     async def is_empty(self) -> bool:
         return await self._implementation.is_empty()
 
-    @override
     async def is_finished(self) -> bool:
         return await self._implementation.is_finished()

--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -292,15 +292,17 @@ class ApifyRequestQueueSharedClient:
         # Check _list_head.
         # Without the lock the `is_empty` is prone to falsely report True with some low probability race condition.
         async with self._fetch_lock:
-            head = await self._list_head(limit=1)
-            return len(head.items) == 0
+            return await self._is_empty()
 
     async def is_finished(self) -> bool:
         """Specific implementation of this method for the RQ shared access mode."""
-        if not await self.is_empty():
-            return False
+        async with self._fetch_lock:
+            return await self._is_empty() and not self._queue_has_locked_requests
 
-        return not self._queue_has_locked_requests
+    async def _is_empty(self) -> bool:
+        """Check whether anything is available to fetch. Lock-free core of `is_empty`, caller must hold the lock."""
+        head = await self._list_head(limit=1)
+        return len(head.items) == 0
 
     async def _get_metadata_estimate(self) -> RequestQueueMetadata:
         """Try to get cached metadata first. If multiple clients, fuse with global metadata.

--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -293,7 +293,14 @@ class ApifyRequestQueueSharedClient:
         # Without the lock the `is_empty` is prone to falsely report True with some low probability race condition.
         async with self._fetch_lock:
             head = await self._list_head(limit=1)
-            return len(head.items) == 0 and not self._queue_has_locked_requests
+            return len(head.items) == 0
+
+    async def is_finished(self) -> bool:
+        """Specific implementation of this method for the RQ shared access mode."""
+        if not await self.is_empty():
+            return False
+
+        return not self._queue_has_locked_requests
 
     async def _get_metadata_estimate(self) -> RequestQueueMetadata:
         """Try to get cached metadata first. If multiple clients, fuse with global metadata.

--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 from cachetools import LRUCache
 
+from crawlee.storage_clients._base import RequestQueueClient
 from crawlee.storage_clients.models import AddRequestsResponse, ProcessedRequest, RequestQueueMetadata
 
 from ._models import ApifyRequestQueueMetadata, CachedRequest, RequestQueueHead
@@ -21,6 +22,9 @@ if TYPE_CHECKING:
     from apify import Request
 
 logger = getLogger(__name__)
+
+
+_CRAWLEE_SUPPORTS_IS_FINISHED = hasattr(RequestQueueClient, 'is_finished')
 
 
 class ApifyRequestQueueSharedClient:
@@ -289,6 +293,9 @@ class ApifyRequestQueueSharedClient:
 
     async def is_empty(self) -> bool:
         """Specific implementation of this method for the RQ shared access mode."""
+        if not _CRAWLEE_SUPPORTS_IS_FINISHED:
+            return await self._old_is_empty()
+
         # Check _list_head.
         # Without the lock the `is_empty` is prone to falsely report True with some low probability race condition.
         async with self._fetch_lock:
@@ -296,6 +303,9 @@ class ApifyRequestQueueSharedClient:
 
     async def is_finished(self) -> bool:
         """Specific implementation of this method for the RQ shared access mode."""
+        if not _CRAWLEE_SUPPORTS_IS_FINISHED:
+            return await self._old_is_empty()
+
         async with self._fetch_lock:
             # Order of operations is important here, because affects on `_queue_has_locked_requests`.
             return await self._is_empty() and not self._queue_has_locked_requests
@@ -304,6 +314,12 @@ class ApifyRequestQueueSharedClient:
         """Check whether anything is available to fetch. Lock-free core of `is_empty`, caller must hold the lock."""
         head = await self._list_head(limit=1)
         return len(head.items) == 0
+
+    async def _old_is_empty(self) -> bool:
+        """Temporary workaround for compatibility with Crawlee versions earlier than 1.8.0."""
+        async with self._fetch_lock:
+            head = await self._list_head(limit=1)
+            return len(head.items) == 0 and not self._queue_has_locked_requests
 
     async def _get_metadata_estimate(self) -> RequestQueueMetadata:
         """Try to get cached metadata first. If multiple clients, fuse with global metadata.

--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Final
 
 from cachetools import LRUCache
 
-from crawlee.storage_clients._base import RequestQueueClient
 from crawlee.storage_clients.models import AddRequestsResponse, ProcessedRequest, RequestQueueMetadata
 
 from ._models import ApifyRequestQueueMetadata, CachedRequest, RequestQueueHead
@@ -22,9 +21,6 @@ if TYPE_CHECKING:
     from apify import Request
 
 logger = getLogger(__name__)
-
-
-_CRAWLEE_SUPPORTS_IS_FINISHED = hasattr(RequestQueueClient, 'is_finished')
 
 
 class ApifyRequestQueueSharedClient:
@@ -293,9 +289,6 @@ class ApifyRequestQueueSharedClient:
 
     async def is_empty(self) -> bool:
         """Specific implementation of this method for the RQ shared access mode."""
-        if not _CRAWLEE_SUPPORTS_IS_FINISHED:
-            return await self._old_is_empty()
-
         # Check _list_head.
         # Without the lock the `is_empty` is prone to falsely report True with some low probability race condition.
         async with self._fetch_lock:
@@ -303,9 +296,6 @@ class ApifyRequestQueueSharedClient:
 
     async def is_finished(self) -> bool:
         """Specific implementation of this method for the RQ shared access mode."""
-        if not _CRAWLEE_SUPPORTS_IS_FINISHED:
-            return await self._old_is_empty()
-
         async with self._fetch_lock:
             # Order of operations is important here, because affects on `_queue_has_locked_requests`.
             return await self._is_empty() and not self._queue_has_locked_requests
@@ -314,12 +304,6 @@ class ApifyRequestQueueSharedClient:
         """Check whether anything is available to fetch. Lock-free core of `is_empty`, caller must hold the lock."""
         head = await self._list_head(limit=1)
         return len(head.items) == 0
-
-    async def _old_is_empty(self) -> bool:
-        """Temporary workaround for compatibility with Crawlee versions earlier than 1.8.0."""
-        async with self._fetch_lock:
-            head = await self._list_head(limit=1)
-            return len(head.items) == 0 and not self._queue_has_locked_requests
 
     async def _get_metadata_estimate(self) -> RequestQueueMetadata:
         """Try to get cached metadata first. If multiple clients, fuse with global metadata.

--- a/src/apify/storage_clients/_apify/_request_queue_shared_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_shared_client.py
@@ -297,6 +297,7 @@ class ApifyRequestQueueSharedClient:
     async def is_finished(self) -> bool:
         """Specific implementation of this method for the RQ shared access mode."""
         async with self._fetch_lock:
+            # Order of operations is important here, because affects on `_queue_has_locked_requests`.
             return await self._is_empty() and not self._queue_has_locked_requests
 
     async def _is_empty(self) -> bool:

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -277,7 +277,6 @@ class ApifyRequestQueueSingleClient:
 
     async def is_empty(self) -> bool:
         """Specific implementation of this method for the RQ single access mode."""
-        # Without the lock the `is_empty` is prone to falsely report True with some low probability race condition.
         await self._ensure_head_is_non_empty()
         return not self._head_requests
 

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Final
 
 from cachetools import LRUCache
 
-from crawlee.storage_clients._base import RequestQueueClient
 from crawlee.storage_clients.models import AddRequestsResponse, ProcessedRequest, RequestQueueMetadata
 
 from ._utils import to_crawlee_request, unique_key_to_request_id
@@ -20,9 +19,6 @@ if TYPE_CHECKING:
     from apify import Request
 
 logger = getLogger(__name__)
-
-
-_CRAWLEE_SUPPORTS_IS_FINISHED = hasattr(RequestQueueClient, 'is_finished')
 
 
 class ApifyRequestQueueSingleClient:
@@ -281,23 +277,12 @@ class ApifyRequestQueueSingleClient:
 
     async def is_empty(self) -> bool:
         """Specific implementation of this method for the RQ single access mode."""
-        if not _CRAWLEE_SUPPORTS_IS_FINISHED:
-            return await self._old_is_empty()
-
         await self._ensure_head_is_non_empty()
         return not self._head_requests
 
     async def is_finished(self) -> bool:
         """Specific implementation of this method for the RQ single access mode."""
-        if not _CRAWLEE_SUPPORTS_IS_FINISHED:
-            return await self._old_is_empty()
-
         return await self.is_empty() and not self._requests_in_progress
-
-    async def _old_is_empty(self) -> bool:
-        """Temporary workaround for compatibility with Crawlee versions earlier than 1.8.0."""
-        await self._ensure_head_is_non_empty()
-        return not self._head_requests and not self._requests_in_progress
 
     async def _ensure_head_is_non_empty(self) -> None:
         """Ensure that the queue head has requests if they are available in the queue."""

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Final
 
 from cachetools import LRUCache
 
+from crawlee.storage_clients._base import RequestQueueClient
 from crawlee.storage_clients.models import AddRequestsResponse, ProcessedRequest, RequestQueueMetadata
 
 from ._utils import to_crawlee_request, unique_key_to_request_id
@@ -19,6 +20,9 @@ if TYPE_CHECKING:
     from apify import Request
 
 logger = getLogger(__name__)
+
+
+_CRAWLEE_SUPPORTS_IS_FINISHED = hasattr(RequestQueueClient, 'is_finished')
 
 
 class ApifyRequestQueueSingleClient:
@@ -277,12 +281,23 @@ class ApifyRequestQueueSingleClient:
 
     async def is_empty(self) -> bool:
         """Specific implementation of this method for the RQ single access mode."""
+        if not _CRAWLEE_SUPPORTS_IS_FINISHED:
+            return await self._old_is_empty()
+
         await self._ensure_head_is_non_empty()
         return not self._head_requests
 
     async def is_finished(self) -> bool:
         """Specific implementation of this method for the RQ single access mode."""
+        if not _CRAWLEE_SUPPORTS_IS_FINISHED:
+            return await self._old_is_empty()
+
         return await self.is_empty() and not self._requests_in_progress
+
+    async def _old_is_empty(self) -> bool:
+        """Temporary workaround for compatibility with Crawlee versions earlier than 1.8.0."""
+        await self._ensure_head_is_non_empty()
+        return not self._head_requests and not self._requests_in_progress
 
     async def _ensure_head_is_non_empty(self) -> None:
         """Ensure that the queue head has requests if they are available in the queue."""

--- a/src/apify/storage_clients/_apify/_request_queue_single_client.py
+++ b/src/apify/storage_clients/_apify/_request_queue_single_client.py
@@ -279,7 +279,11 @@ class ApifyRequestQueueSingleClient:
         """Specific implementation of this method for the RQ single access mode."""
         # Without the lock the `is_empty` is prone to falsely report True with some low probability race condition.
         await self._ensure_head_is_non_empty()
-        return not self._head_requests and not self._requests_in_progress
+        return not self._head_requests
+
+    async def is_finished(self) -> bool:
+        """Specific implementation of this method for the RQ single access mode."""
+        return await self.is_empty() and not self._requests_in_progress
 
     async def _ensure_head_is_non_empty(self) -> None:
         """Ensure that the queue head has requests if they are available in the queue."""

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -11,7 +11,6 @@ import pytest
 from apify_client._models import BatchAddResult, RequestDraft
 from crawlee import service_locator
 from crawlee.crawlers import BasicCrawler
-from crawlee.storage_clients._base import RequestQueueClient
 
 from .._utils import generate_unique_resource_name, poll_until_condition
 from apify import Actor, Request
@@ -1249,20 +1248,12 @@ async def test_request_queue_is_finished_and_is_empty(
     )
     assert fetched is not None
 
-    if hasattr(RequestQueueClient, 'is_finished'):
-        assert await poll_until_condition(request_queue_apify.is_empty, timeout=rq_poll_timeout, backoff_factor=2), (
-            'RequestQueue should be empty because queue does not contain any requests for fetching.'
-        )
-        assert not await request_queue_apify.is_finished(), (
-            'RequestQueue should not be finished unless the request is marked as handled.'
-        )
-    else:
-        assert not await poll_until_condition(
-            request_queue_apify.is_empty, timeout=rq_poll_timeout, backoff_factor=2
-        ), 'RequestQueue should not be empty because queue contains a request in progress.'
-        assert not await request_queue_apify.is_finished(), (
-            'RequestQueue should not be finished unless the request is marked as handled.'
-        )
+    assert await poll_until_condition(request_queue_apify.is_empty, timeout=rq_poll_timeout, backoff_factor=2), (
+        'RequestQueue should be empty because queue does not contain any requests for fetching.'
+    )
+    assert not await request_queue_apify.is_finished(), (
+        'RequestQueue should not be finished unless the request is marked as handled.'
+    )
 
     await request_queue_apify.mark_request_as_handled(fetched)
     assert await poll_until_condition(request_queue_apify.is_empty, timeout=rq_poll_timeout, backoff_factor=2)

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -651,6 +651,44 @@ async def test_empty_rq_behavior(request_queue_apify: RequestQueue, rq_poll_time
     assert metadata.pending_request_count == 0, f'metadata.pending_request_count={metadata.pending_request_count}'
 
 
+async def test_is_empty_and_is_finished(request_queue_apify: RequestQueue, rq_poll_timeout: int) -> None:
+    """Test `is_empty` and `is_finished` across the queue lifecycle."""
+
+    rq = request_queue_apify
+    Actor.log.info('Request queue opened')
+
+    # Initially the queue is empty and finished.
+    is_empty = await poll_until_condition(rq.is_empty, timeout=rq_poll_timeout, backoff_factor=2)
+    is_finished = await poll_until_condition(rq.is_finished, timeout=rq_poll_timeout, backoff_factor=2)
+    assert is_empty is True, f'is_empty={is_empty}'
+    assert is_finished is True, f'is_finished={is_finished}'
+
+    # After adding a request it is neither empty nor finished.
+    await rq.add_request('https://example.com')
+    is_empty = await poll_until_condition(rq.is_empty, condition=lambda e: e is False, timeout=rq_poll_timeout)
+    is_finished = await poll_until_condition(rq.is_finished, condition=lambda f: f is False, timeout=rq_poll_timeout)
+    assert is_empty is False, f'is_empty={is_empty}'
+    assert is_finished is False, f'is_finished={is_finished}'
+
+    # Fetch the request without handling it.
+    request = await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2)
+    assert request is not None, f'request={request}'
+
+    # The queue is empty, because there is no request available for fetching.
+    is_empty = await poll_until_condition(rq.is_empty, timeout=rq_poll_timeout, backoff_factor=2)
+    assert is_empty is True, f'is_empty={is_empty}'
+    # The queue is not finished, because there is a request being processed.
+    is_finished = await poll_until_condition(rq.is_finished, condition=lambda f: f is False, timeout=rq_poll_timeout)
+    assert is_finished is False, f'is_finished={is_finished}'
+
+    # After marking the request as handled the queue is empty and finished again.
+    await rq.mark_request_as_handled(request)
+    is_empty = await poll_until_condition(rq.is_empty, timeout=rq_poll_timeout, backoff_factor=2)
+    is_finished = await poll_until_condition(rq.is_finished, timeout=rq_poll_timeout, backoff_factor=2)
+    assert is_empty is True, f'is_empty={is_empty}'
+    assert is_finished is True, f'is_finished={is_finished}'
+
+
 async def test_large_batch_operations(
     request_queue_apify: RequestQueue,
     rq_poll_timeout: int,

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -11,6 +11,7 @@ import pytest
 from apify_client._models import BatchAddResult, RequestDraft
 from crawlee import service_locator
 from crawlee.crawlers import BasicCrawler
+from crawlee.storage_clients._base import RequestQueueClient
 
 from .._utils import generate_unique_resource_name, poll_until_condition
 from apify import Actor, Request
@@ -1247,12 +1248,21 @@ async def test_request_queue_is_finished_and_is_empty(
         request_queue_apify.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2
     )
     assert fetched is not None
-    assert await poll_until_condition(request_queue_apify.is_empty, timeout=rq_poll_timeout, backoff_factor=2), (
-        'RequestQueue should be empty because queue does not contain any requests for fetching.'
-    )
-    assert not await request_queue_apify.is_finished(), (
-        'RequestQueue should not be finished unless the request is marked as handled.'
-    )
+
+    if hasattr(RequestQueueClient, 'is_finished'):
+        assert await poll_until_condition(request_queue_apify.is_empty, timeout=rq_poll_timeout, backoff_factor=2), (
+            'RequestQueue should be empty because queue does not contain any requests for fetching.'
+        )
+        assert not await request_queue_apify.is_finished(), (
+            'RequestQueue should not be finished unless the request is marked as handled.'
+        )
+    else:
+        assert not await poll_until_condition(
+            request_queue_apify.is_empty, timeout=rq_poll_timeout, backoff_factor=2
+        ), 'RequestQueue should not be empty because queue contains a request in progress.'
+        assert not await request_queue_apify.is_finished(), (
+            'RequestQueue should not be finished unless the request is marked as handled.'
+        )
 
     await request_queue_apify.mark_request_as_handled(fetched)
     assert await poll_until_condition(request_queue_apify.is_empty, timeout=rq_poll_timeout, backoff_factor=2)

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -651,44 +651,6 @@ async def test_empty_rq_behavior(request_queue_apify: RequestQueue, rq_poll_time
     assert metadata.pending_request_count == 0, f'metadata.pending_request_count={metadata.pending_request_count}'
 
 
-async def test_is_empty_and_is_finished(request_queue_apify: RequestQueue, rq_poll_timeout: int) -> None:
-    """Test `is_empty` and `is_finished` across the queue lifecycle."""
-
-    rq = request_queue_apify
-    Actor.log.info('Request queue opened')
-
-    # Initially the queue is empty and finished.
-    is_empty = await poll_until_condition(rq.is_empty, timeout=rq_poll_timeout, backoff_factor=2)
-    is_finished = await poll_until_condition(rq.is_finished, timeout=rq_poll_timeout, backoff_factor=2)
-    assert is_empty is True, f'is_empty={is_empty}'
-    assert is_finished is True, f'is_finished={is_finished}'
-
-    # After adding a request it is neither empty nor finished.
-    await rq.add_request('https://example.com')
-    is_empty = await poll_until_condition(rq.is_empty, condition=lambda e: e is False, timeout=rq_poll_timeout)
-    is_finished = await poll_until_condition(rq.is_finished, condition=lambda f: f is False, timeout=rq_poll_timeout)
-    assert is_empty is False, f'is_empty={is_empty}'
-    assert is_finished is False, f'is_finished={is_finished}'
-
-    # Fetch the request without handling it.
-    request = await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2)
-    assert request is not None, f'request={request}'
-
-    # The queue is empty, because there is no request available for fetching.
-    is_empty = await poll_until_condition(rq.is_empty, timeout=rq_poll_timeout, backoff_factor=2)
-    assert is_empty is True, f'is_empty={is_empty}'
-    # The queue is not finished, because there is a request being processed.
-    is_finished = await poll_until_condition(rq.is_finished, condition=lambda f: f is False, timeout=rq_poll_timeout)
-    assert is_finished is False, f'is_finished={is_finished}'
-
-    # After marking the request as handled the queue is empty and finished again.
-    await rq.mark_request_as_handled(request)
-    is_empty = await poll_until_condition(rq.is_empty, timeout=rq_poll_timeout, backoff_factor=2)
-    is_finished = await poll_until_condition(rq.is_finished, timeout=rq_poll_timeout, backoff_factor=2)
-    assert is_empty is True, f'is_empty={is_empty}'
-    assert is_finished is True, f'is_finished={is_finished}'
-
-
 async def test_large_batch_operations(
     request_queue_apify: RequestQueue,
     rq_poll_timeout: int,
@@ -1265,10 +1227,18 @@ async def test_force_cloud(
     assert str(request_queue_request.url) == 'http://example.com'
 
 
-async def test_request_queue_is_finished(
+async def test_request_queue_is_finished_and_is_empty(
     request_queue_apify: RequestQueue,
     rq_poll_timeout: int,
 ) -> None:
+    """Test that `is_empty` and `is_finished` behave correctly with Apify request queue."""
+
+    assert await poll_until_condition(request_queue_apify.is_empty, timeout=rq_poll_timeout, backoff_factor=2), (
+        'RequestQueue should be empty initially.'
+    )
+    assert await poll_until_condition(request_queue_apify.is_finished, timeout=rq_poll_timeout, backoff_factor=2), (
+        'RequestQueue should be finished initially.'
+    )
 
     await request_queue_apify.add_request(Request.from_url('http://example.com'))
     assert not await request_queue_apify.is_finished()
@@ -1277,11 +1247,15 @@ async def test_request_queue_is_finished(
         request_queue_apify.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2
     )
     assert fetched is not None
+    assert await poll_until_condition(request_queue_apify.is_empty, timeout=rq_poll_timeout, backoff_factor=2), (
+        'RequestQueue should be empty because queue does not contain any requests for fetching.'
+    )
     assert not await request_queue_apify.is_finished(), (
         'RequestQueue should not be finished unless the request is marked as handled.'
     )
 
     await request_queue_apify.mark_request_as_handled(fetched)
+    assert await poll_until_condition(request_queue_apify.is_empty, timeout=rq_poll_timeout, backoff_factor=2)
     assert await poll_until_condition(request_queue_apify.is_finished, timeout=rq_poll_timeout, backoff_factor=2)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ dev = [
 requires-dist = [
     { name = "apify-client", specifier = ">=3.0.0,<4.0.0" },
     { name = "cachetools", specifier = ">=5.5.0" },
-    { name = "crawlee", specifier = ">=1.0.4,<2.0.0" },
+    { name = "crawlee", specifier = ">=1.8.0,<2.0.0" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "impit", specifier = ">=0.8.0" },
     { name = "lazy-object-proxy", specifier = ">=1.11.0" },
@@ -536,7 +536,7 @@ toml = [
 
 [[package]]
 name = "crawlee"
-version = "1.7.2"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout" },
@@ -553,9 +553,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/19/b2ca54efbdad4770a3889aa788bd9a738a754b8b8889a3f7413cc40f25c3/crawlee-1.7.2.tar.gz", hash = "sha256:362f3f9e43d7c28c8c0133f8787ad2ff77d159ff205b9a72f2013ece882298ac", size = 287966, upload-time = "2026-06-04T08:14:59.459Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/13/0e9622bc4ab7d205e1b4c54ada21869f1027f7616ba81e0fc559eebdb262/crawlee-1.8.0.tar.gz", hash = "sha256:168d52d538b294a7f8560dcf76f19bedaed716b030e81bd3d8a06091374ee4c1", size = 312606, upload-time = "2026-07-02T13:44:21.403Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/cd/00961c23ce321ba16343ae53cc08e23f088ff7c1ea5365f64cae3c71d349/crawlee-1.7.2-py3-none-any.whl", hash = "sha256:dd22b2c1fa6b39312222ec0e732344b22eb26aa53d33758ec9a1a8ad16725d4d", size = 370707, upload-time = "2026-06-04T08:14:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c3/69ec6e902d3a321658cc19acdca08bc45a62f2c00f622812b886f266c915/crawlee-1.8.0-py3-none-any.whl", hash = "sha256:f2f82d2df23aa2918672d66f4dd993ca0e807430f078fdbf4dbdeca1272534f3", size = 402044, upload-time = "2026-07-02T13:44:19.424Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ dev = [
 requires-dist = [
     { name = "apify-client", specifier = ">=3.0.0,<4.0.0" },
     { name = "cachetools", specifier = ">=5.5.0" },
-    { name = "crawlee", specifier = ">=1.0.4,<2.0.0" },
+    { name = "crawlee", git = "https://github.com/Mantisus/crawlee-python?branch=queue-client-is-finished" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "impit", specifier = ">=0.8.0" },
     { name = "lazy-object-proxy", specifier = ">=1.11.0" },
@@ -101,7 +101,7 @@ provides-extras = ["scrapy"]
 dev = [
     { name = "black", specifier = ">=24.3.0" },
     { name = "build", specifier = "<2.0.0" },
-    { name = "crawlee", extras = ["parsel"] },
+    { name = "crawlee", extras = ["parsel"], git = "https://github.com/Mantisus/crawlee-python?branch=queue-client-is-finished" },
     { name = "dycw-pytest-only", specifier = "<3.0.0" },
     { name = "griffe" },
     { name = "poethepoet", specifier = "<1.0.0" },
@@ -536,8 +536,8 @@ toml = [
 
 [[package]]
 name = "crawlee"
-version = "1.7.2"
-source = { registry = "https://pypi.org/simple" }
+version = "1.7.3"
+source = { git = "https://github.com/Mantisus/crawlee-python?branch=queue-client-is-finished#6433c378b58ffa8d233d3c232b05425bb6ade1a5" }
 dependencies = [
     { name = "async-timeout" },
     { name = "cachetools" },
@@ -552,10 +552,6 @@ dependencies = [
     { name = "tldextract" },
     { name = "typing-extensions" },
     { name = "yarl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/80/19/b2ca54efbdad4770a3889aa788bd9a738a754b8b8889a3f7413cc40f25c3/crawlee-1.7.2.tar.gz", hash = "sha256:362f3f9e43d7c28c8c0133f8787ad2ff77d159ff205b9a72f2013ece882298ac", size = 287966, upload-time = "2026-06-04T08:14:59.459Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/cd/00961c23ce321ba16343ae53cc08e23f088ff7c1ea5365f64cae3c71d349/crawlee-1.7.2-py3-none-any.whl", hash = "sha256:dd22b2c1fa6b39312222ec0e732344b22eb26aa53d33758ec9a1a8ad16725d4d", size = 370707, upload-time = "2026-06-04T08:14:57.574Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ dev = [
 requires-dist = [
     { name = "apify-client", specifier = ">=3.0.0,<4.0.0" },
     { name = "cachetools", specifier = ">=5.5.0" },
-    { name = "crawlee", git = "https://github.com/Mantisus/crawlee-python?branch=queue-client-is-finished" },
+    { name = "crawlee", specifier = ">=1.0.4,<2.0.0" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "impit", specifier = ">=0.8.0" },
     { name = "lazy-object-proxy", specifier = ">=1.11.0" },
@@ -101,7 +101,7 @@ provides-extras = ["scrapy"]
 dev = [
     { name = "black", specifier = ">=24.3.0" },
     { name = "build", specifier = "<2.0.0" },
-    { name = "crawlee", extras = ["parsel"], git = "https://github.com/Mantisus/crawlee-python?branch=queue-client-is-finished" },
+    { name = "crawlee", extras = ["parsel"] },
     { name = "dycw-pytest-only", specifier = "<3.0.0" },
     { name = "griffe" },
     { name = "poethepoet", specifier = "<1.0.0" },
@@ -536,8 +536,8 @@ toml = [
 
 [[package]]
 name = "crawlee"
-version = "1.7.3"
-source = { git = "https://github.com/Mantisus/crawlee-python?branch=queue-client-is-finished#6433c378b58ffa8d233d3c232b05425bb6ade1a5" }
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout" },
     { name = "cachetools" },
@@ -552,6 +552,10 @@ dependencies = [
     { name = "tldextract" },
     { name = "typing-extensions" },
     { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/19/b2ca54efbdad4770a3889aa788bd9a738a754b8b8889a3f7413cc40f25c3/crawlee-1.7.2.tar.gz", hash = "sha256:362f3f9e43d7c28c8c0133f8787ad2ff77d159ff205b9a72f2013ece882298ac", size = 287966, upload-time = "2026-06-04T08:14:59.459Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/cd/00961c23ce321ba16343ae53cc08e23f088ff7c1ea5365f64cae3c71d349/crawlee-1.7.2-py3-none-any.whl", hash = "sha256:dd22b2c1fa6b39312222ec0e732344b22eb26aa53d33758ec9a1a8ad16725d4d", size = 370707, upload-time = "2026-06-04T08:14:57.574Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Description

Add `is_finished` and align `is_empty` semantics in `ApifyRequestQueueClient`

Closes: #987
Follow-up: https://github.com/apify/crawlee-python/pull/1982