### PR TITLE
chore(ci): Update renovate schedules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
     "lockFileMaintenance": {
         "enabled": true,
         "automerge": true,
-        "automergeType": "branch"
+        "automergeType": "pr",
+        "schedule": ["* 0-5 * * 1"]
     },
     "packageRules": [
         {
@@ -23,10 +24,14 @@
         {
             "matchPackageNames": ["@apify/*", "@crawlee/*", "apify", "apify-client", "apify-shared", "apify-fingerprint-datapoints", "crawlee", "got-scraping"],
             "minimumReleaseAge": "0 days"
+        },
+        {
+          "matchUpdateTypes": ["lockFileMaintenance"],
+          "minimumReleaseAgeBehaviour": "timestamp-optional"
         }
     ],
     "minimumReleaseAge": "1 day",
     "internalChecksFilter": "strict",
-    "schedule": ["before 7am every weekday"],
+    "schedule": ["* 0-5 * * 2-5"],
     "ignoreDeps": ["apify", "docusaurus-plugin-typedoc-api"]
 }


### PR DESCRIPTION
- Replace deprecated `breejslater` syntax with `cron` syntax
https://docs.renovatebot.com/key-concepts/scheduling/#deprecated-breejslater-syntax
- Use these triggers, limit the window to avoid spam:
  - Every **Tuesday - Friday** between **0:00 and 6:00** to update **dependencies**
  - Every **Monday** between **0:00 and 6:00** to update **lockfiles** 
- Do not run both jobs on the same day.