### PR TITLE
feat: Compress requests using brotli algo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+brotli = ["apify-client[brotli]"]
 scrapy = ["scrapy>=2.14.0"]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+brotli = [
+    { name = "apify-client" },
+]
 scrapy = [
     { name = "scrapy" },
 ]
@@ -83,6 +86,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "apify-client", specifier = ">=3.0.0,<4.0.0" },
+    { name = "apify-client", extras = ["brotli"], marker = "extra == 'brotli'" },
     { name = "cachetools", specifier = ">=5.5.0" },
     { name = "crawlee", specifier = ">=1.8.0,<2.0.0" },
     { name = "cryptography", specifier = ">=42.0.0" },
@@ -95,7 +99,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=14.0" },
     { name = "yarl", specifier = ">=1.18.0" },
 ]
-provides-extras = ["scrapy"]
+provides-extras = ["brotli", "scrapy"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
- Update apify-client dependency to use `brotli` extra.
- Introduced in https://github.com/apify/apify-client-python/pull/927.

### Related PRs
- https://github.com/apify/apify-core/pull/28971
- https://github.com/apify/apify-docs/pull/2750
- https://github.com/apify/apify-client-js/pull/962
- https://github.com/apify/apify-client-python/pull/927
- https://github.com/apify/apify-sdk-python/pull/1031

TODO/blocked:
```
What to do once PR #927 merges and apify-client releases:
1. Check which version introduced the extra (likely 3.1.0 or 3.0.5)
2. Optionally bump the floor in pyproject.toml: apify-client[brotli]>=3.1.0 in the extra dep, or tighten the main apify-client>=3.0.0 to that version
3. Run uv sync --all-extras — the warning will disappear and brotli's transitive deps will be locked
4. Commit both files
```