### PR TITLE
docs: fix AI agents guide examples and raise the runnable-example timeout

### DIFF
--- a/docs/03_guides/14_ai_agents.mdx
+++ b/docs/03_guides/14_ai_agents.mdx
@@ -156,6 +156,7 @@ Note that:
 - `OpenAILike` points `api_base` at the Apify OpenRouter proxy, so no provider API key is needed. It's the LlamaIndex LLM class for any OpenAI-compatible endpoint.
 - `Document` wraps each scraped page, and `VectorStoreIndex.from_documents` chunks and embeds them. The index is the retrieval layer that sets LlamaIndex apart from a plain agent loop.
 - Embeddings run locally through `HuggingFaceEmbedding` from the `llama-index-embeddings-huggingface` package, so the proxy needs no embeddings endpoint.
+- The embedding model downloads on the first run and the Website Content Crawler renders pages in a browser, so this pipeline is heavier than the other examples. Raise the run's timeout (for example to 300 seconds) so a cold start isn't aborted while the model downloads or the index builds.
 - `index.as_query_engine(output_cls=Answer)` retrieves the passages most relevant to the question, then the LLM composes a validated `Answer` grounded in them.
 - Every response carries the passages it used in `response.source_nodes`, so the Actor pushes their `url` metadata as citations. `Actor.call` runs the Website Content Crawler, and `to_document` maps each dataset item to a `Document`, so indexing more content is a matter of crawling more pages. For details, see [Using Apify Actors as tools](#using-apify-actors-as-tools).
 

--- a/docs/03_guides/14_ai_agents.mdx
+++ b/docs/03_guides/14_ai_agents.mdx
@@ -156,7 +156,7 @@ Note that:
 - `OpenAILike` points `api_base` at the Apify OpenRouter proxy, so no provider API key is needed. It's the LlamaIndex LLM class for any OpenAI-compatible endpoint.
 - `Document` wraps each scraped page, and `VectorStoreIndex.from_documents` chunks and embeds them. The index is the retrieval layer that sets LlamaIndex apart from a plain agent loop.
 - Embeddings run locally through `HuggingFaceEmbedding` from the `llama-index-embeddings-huggingface` package, so the proxy needs no embeddings endpoint.
-- The embedding model downloads on the first run and the Website Content Crawler renders pages in a browser, so this pipeline is heavier than the other examples. Raise the run's timeout (for example to 300 seconds) so a cold start isn't aborted while the model downloads or the index builds.
+- The embedding model downloads on the first run and the Website Content Crawler renders pages in a browser, so this pipeline is heavier than the other examples.
 - `index.as_query_engine(output_cls=Answer)` retrieves the passages most relevant to the question, then the LLM composes a validated `Answer` grounded in them.
 - Every response carries the passages it used in `response.source_nodes`, so the Actor pushes their `url` metadata as citations. `Actor.call` runs the Website Content Crawler, and `to_document` maps each dataset item to a `Document`, so indexing more content is a matter of crawling more pages. For details, see [Using Apify Actors as tools](#using-apify-actors-as-tools).
 

--- a/docs/03_guides/code/14_crewai.py
+++ b/docs/03_guides/code/14_crewai.py
@@ -77,8 +77,15 @@ async def main() -> None:
         # to fetch the page as clean Markdown.
         researcher = Agent(
             role='Documentation researcher',
-            goal='Read the Crawlee docs and note every crawler it describes.',
-            backstory='A researcher who reads technical docs closely.',
+            goal=(
+                'Fetch the page with the web_browser tool and note every crawler '
+                'it describes.'
+            ),
+            backstory=(
+                'A researcher who never answers from memory. Before writing '
+                'anything, always read the actual page with the web_browser tool '
+                'and report only what it says.'
+            ),
             tools=[WebBrowserTool()],
             llm=llm,
         )
@@ -91,7 +98,10 @@ async def main() -> None:
         )
 
         research = Task(
-            description=f'Scrape {url} and list the crawlers the page covers.',
+            description=(
+                f'Use the web_browser tool to fetch {url}. Based only on the returned '
+                'Markdown, list the crawlers the page covers. Do not use prior knowledge.'
+            ),
             expected_output='Notes on each crawler: name, what it builds on, its use.',
             agent=researcher,
         )

--- a/website/roa-loader/index.js
+++ b/website/roa-loader/index.js
@@ -21,9 +21,6 @@ async function getHash(source) {
     }
 
     const memory = source.match(/playwright|puppeteer/i) ? 4096 : 1024;
-    // The LlamaIndex example downloads a local embedding model and crawls pages in a
-    // browser, so a cold start needs more than the default timeout to finish.
-    const timeout = source.match(/HuggingFaceEmbedding/i) ? 300 : 180;
     const res = await fetch(signingUrl, {
         method: 'POST',
         body: JSON.stringify({
@@ -32,7 +29,7 @@ async function getHash(source) {
                 build: 'latest',
                 contentType: 'application/json; charset=utf-8',
                 memory,
-                timeout,
+                timeout: 360,
             },
         }),
         headers: {

--- a/website/roa-loader/index.js
+++ b/website/roa-loader/index.js
@@ -21,6 +21,9 @@ async function getHash(source) {
     }
 
     const memory = source.match(/playwright|puppeteer/i) ? 4096 : 1024;
+    // The LlamaIndex example downloads a local embedding model and crawls pages in a
+    // browser, so a cold start needs more than the default timeout to finish.
+    const timeout = source.match(/HuggingFaceEmbedding/i) ? 300 : 180;
     const res = await fetch(signingUrl, {
         method: 'POST',
         body: JSON.stringify({
@@ -29,7 +32,7 @@ async function getHash(source) {
                 build: 'latest',
                 contentType: 'application/json; charset=utf-8',
                 memory,
-                timeout: 180,
+                timeout,
             },
         }),
         headers: {

--- a/website/versioned_docs/version-3.4/03_guides/14_ai_agents.mdx
+++ b/website/versioned_docs/version-3.4/03_guides/14_ai_agents.mdx
@@ -156,6 +156,7 @@ Note that:
 - `OpenAILike` points `api_base` at the Apify OpenRouter proxy, so no provider API key is needed. It's the LlamaIndex LLM class for any OpenAI-compatible endpoint.
 - `Document` wraps each scraped page, and `VectorStoreIndex.from_documents` chunks and embeds them. The index is the retrieval layer that sets LlamaIndex apart from a plain agent loop.
 - Embeddings run locally through `HuggingFaceEmbedding` from the `llama-index-embeddings-huggingface` package, so the proxy needs no embeddings endpoint.
+- The embedding model downloads on the first run and the Website Content Crawler renders pages in a browser, so this pipeline is heavier than the other examples. Raise the run's timeout (for example to 300 seconds) so a cold start isn't aborted while the model downloads or the index builds.
 - `index.as_query_engine(output_cls=Answer)` retrieves the passages most relevant to the question, then the LLM composes a validated `Answer` grounded in them.
 - Every response carries the passages it used in `response.source_nodes`, so the Actor pushes their `url` metadata as citations. `Actor.call` runs the Website Content Crawler, and `to_document` maps each dataset item to a `Document`, so indexing more content is a matter of crawling more pages. For details, see [Using Apify Actors as tools](#using-apify-actors-as-tools).
 

--- a/website/versioned_docs/version-3.4/03_guides/14_ai_agents.mdx
+++ b/website/versioned_docs/version-3.4/03_guides/14_ai_agents.mdx
@@ -156,7 +156,7 @@ Note that:
 - `OpenAILike` points `api_base` at the Apify OpenRouter proxy, so no provider API key is needed. It's the LlamaIndex LLM class for any OpenAI-compatible endpoint.
 - `Document` wraps each scraped page, and `VectorStoreIndex.from_documents` chunks and embeds them. The index is the retrieval layer that sets LlamaIndex apart from a plain agent loop.
 - Embeddings run locally through `HuggingFaceEmbedding` from the `llama-index-embeddings-huggingface` package, so the proxy needs no embeddings endpoint.
-- The embedding model downloads on the first run and the Website Content Crawler renders pages in a browser, so this pipeline is heavier than the other examples. Raise the run's timeout (for example to 300 seconds) so a cold start isn't aborted while the model downloads or the index builds.
+- The embedding model downloads on the first run and the Website Content Crawler renders pages in a browser, so this pipeline is heavier than the other examples.
 - `index.as_query_engine(output_cls=Answer)` retrieves the passages most relevant to the question, then the LLM composes a validated `Answer` grounded in them.
 - Every response carries the passages it used in `response.source_nodes`, so the Actor pushes their `url` metadata as citations. `Actor.call` runs the Website Content Crawler, and `to_document` maps each dataset item to a `Document`, so indexing more content is a matter of crawling more pages. For details, see [Using Apify Actors as tools](#using-apify-actors-as-tools).
 

--- a/website/versioned_docs/version-3.4/03_guides/code/14_crewai.py
+++ b/website/versioned_docs/version-3.4/03_guides/code/14_crewai.py
@@ -77,8 +77,15 @@ async def main() -> None:
         # to fetch the page as clean Markdown.
         researcher = Agent(
             role='Documentation researcher',
-            goal='Read the Crawlee docs and note every crawler it describes.',
-            backstory='A researcher who reads technical docs closely.',
+            goal=(
+                'Fetch the page with the web_browser tool and note every crawler '
+                'it describes.'
+            ),
+            backstory=(
+                'A researcher who never answers from memory. Before writing '
+                'anything, always read the actual page with the web_browser tool '
+                'and report only what it says.'
+            ),
             tools=[WebBrowserTool()],
             llm=llm,
         )
@@ -91,7 +98,10 @@ async def main() -> None:
         )
 
         research = Task(
-            description=f'Scrape {url} and list the crawlers the page covers.',
+            description=(
+                f'Use the web_browser tool to fetch {url}. Based only on the returned '
+                'Markdown, list the crawlers the page covers. Do not use prior knowledge.'
+            ),
             expected_output='Notes on each crawler: name, what it builds on, its use.',
             agent=researcher,
         )


### PR DESCRIPTION
Follow-up fixes to the AI agents guide (#995) after testing the five framework examples on the platform.

## CrewAI

The researcher agent answered from the model's own knowledge instead of scraping the page, so it returned JavaScript Crawlee crawlers (`CheerioCrawler`, `PuppeteerCrawler`, ...) that don't exist in Python Crawlee. Its `goal` / `backstory` and the research task now require the `web_browser` tool and answering only from the fetched Markdown, so the output is grounded in the actual Python Crawlee docs page.

## LlamaIndex

It's the heaviest example. It downloads a local HuggingFace embedding model and uses the browser-based Website Content Crawler, so a cold start exceeded the 180 s the docs "Run" button allotted and got aborted mid-index. Raised the docs "Run" button timeout to 360 s for all runnable examples (`website/roa-loader`).

Both `docs/` and the `website/versioned_docs/version-3.4/` mirror are updated identically.
