### PR TITLE
fix: don't disable Actor exit_process just because scrapy is importable

### DIFF
--- a/docs/02_concepts/01_actor_lifecycle.mdx
+++ b/docs/02_concepts/01_actor_lifecycle.mdx
@@ -48,7 +48,7 @@ You can also create an <ApiLink to="class/Actor">`Actor`</ApiLink> instance dire
 
 - `configuration` — a custom <ApiLink to="class/Configuration">`Configuration`</ApiLink> instance to control storage paths, API URLs, and other settings.
 - `configure_logging` — whether to set up default logging configuration (default `True`). Set to `False` if you configure logging yourself.
-- `exit_process` — whether the Actor calls `sys.exit()` when the context manager exits. Defaults to `True`, except in IPython, Pytest, and Scrapy environments.
+- `exit_process` — whether the Actor calls `sys.exit()` when the context manager exits. Defaults to `True`, except in IPython and Scrapy environments.
 - `event_listeners_timeout` — maximum time to wait for Actor event listeners to complete before exiting.
 - `cleanup_timeout` — maximum time to wait for cleanup tasks to finish (default 30 seconds).
 

--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import warnings
-from contextlib import suppress
 from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
 from functools import cached_property
@@ -1441,10 +1441,11 @@ class _ActorType:
             self.log.debug('Running in IPython, setting default `exit_process` to False.')
             return False
 
-        # Check if running in Scrapy by attempting to import it.
-        with suppress(ImportError):
-            import scrapy  # noqa: F401 PLC0415
-
+        # Detect an actual Scrapy project via the `SCRAPY_SETTINGS_MODULE` environment variable (set by the
+        # Scrapy CLI and by `apify.scrapy.run_scrapy_actor`), not by whether `scrapy` merely happens to be
+        # importable. Otherwise any image where Scrapy is a transitive dependency would silently disable the
+        # `sys.exit()` on Actor exit, so a failed run could end with exit code 0 and be marked as succeeded.
+        if os.environ.get('SCRAPY_SETTINGS_MODULE'):
             self.log.debug('Running in Scrapy, setting default `exit_process` to False.')
             return False
 

--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -1440,10 +1440,9 @@ class _ActorType:
             self.log.debug('Running in IPython, setting default `exit_process` to False.')
             return False
 
-        # Delegate the Scrapy check to `apify.scrapy._detection`, but only if it is already imported. A
-        # non-Scrapy Actor never imports `apify.scrapy` (doing so pulls in Scrapy itself), so this keeps the
-        # common path from paying that cost, and from disabling `exit_process` just because Scrapy happens to
-        # be an importable transitive dependency.
+        # Consult `apify.scrapy._detection` only when it is already imported. A non-Scrapy Actor never
+        # imports `apify.scrapy` (which pulls in Scrapy itself), so this avoids that cost and the old bug of
+        # disabling `exit_process` just because Scrapy is an importable transitive dependency.
         scrapy_detection = sys.modules.get('apify.scrapy._detection')
         if scrapy_detection is not None and scrapy_detection.is_running_in_scrapy():
             self.log.debug('Running in Scrapy, setting default `exit_process` to False.')

--- a/src/apify/_actor.py
+++ b/src/apify/_actor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import sys
 import warnings
 from dataclasses import asdict
@@ -1441,11 +1440,12 @@ class _ActorType:
             self.log.debug('Running in IPython, setting default `exit_process` to False.')
             return False
 
-        # Detect an actual Scrapy project via the `SCRAPY_SETTINGS_MODULE` environment variable (set by the
-        # Scrapy CLI and by `apify.scrapy.run_scrapy_actor`), not by whether `scrapy` merely happens to be
-        # importable. Otherwise any image where Scrapy is a transitive dependency would silently disable the
-        # `sys.exit()` on Actor exit, so a failed run could end with exit code 0 and be marked as succeeded.
-        if os.environ.get('SCRAPY_SETTINGS_MODULE'):
+        # Delegate the Scrapy check to `apify.scrapy._detection`, but only if it is already imported. A
+        # non-Scrapy Actor never imports `apify.scrapy` (doing so pulls in Scrapy itself), so this keeps the
+        # common path from paying that cost, and from disabling `exit_process` just because Scrapy happens to
+        # be an importable transitive dependency.
+        scrapy_detection = sys.modules.get('apify.scrapy._detection')
+        if scrapy_detection is not None and scrapy_detection.is_running_in_scrapy():
             self.log.debug('Running in Scrapy, setting default `exit_process` to False.')
             return False
 

--- a/src/apify/scrapy/_actor_runner.py
+++ b/src/apify/scrapy/_actor_runner.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from ._detection import mark_running_in_scrapy
+
 if TYPE_CHECKING:
     from collections.abc import Coroutine
 
@@ -14,6 +16,10 @@ def run_scrapy_actor(coro: Coroutine) -> None:
     coroutine (typically the Actor's main) by converting it to a Deferred. This bridges the asyncio and Twisted
     event loops, enabling the Apify and Scrapy integration to work together.
     """
+    # Record that we are driving the process, so the Actor defaults `exit_process` to False (see
+    # `apify.scrapy._detection`). This runs before the coroutine, hence before the Actor initializes.
+    mark_running_in_scrapy()
+
     from scrapy.utils.reactor import install_reactor  # noqa: PLC0415
     from twisted.internet.error import ReactorAlreadyInstalledError  # noqa: PLC0415
 

--- a/src/apify/scrapy/_detection.py
+++ b/src/apify/scrapy/_detection.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+
+_running_in_scrapy = False
+"""Whether `run_scrapy_actor` is currently driving the process."""
+
+
+def mark_running_in_scrapy() -> None:
+    """Record that the current process is being driven by the Apify-Scrapy integration.
+
+    Called by `run_scrapy_actor` before the Actor's main coroutine runs, so `is_running_in_scrapy` already
+    reports the correct value by the time the Actor initializes.
+    """
+    global _running_in_scrapy  # noqa: PLW0603
+    _running_in_scrapy = True
+
+
+def is_running_in_scrapy() -> bool:
+    """Whether the Actor is running as part of a Scrapy project.
+
+    Returns `True` when `run_scrapy_actor` is driving the process, or when the `SCRAPY_SETTINGS_MODULE`
+    environment variable is set (by the Scrapy CLI or by the Actor's entry point). Detecting a real Scrapy
+    run this way, rather than by whether `scrapy` merely happens to be importable, keeps the `exit_process`
+    default correct for images where Scrapy is only a transitive dependency.
+    """
+    return _running_in_scrapy or bool(os.environ.get('SCRAPY_SETTINGS_MODULE'))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -56,6 +56,12 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
     """
 
     def _prepare_test_env() -> None:
+        # Production code deliberately does not detect the test environment (see issue #641), so force the
+        # `exit_process` default to False here. Otherwise a clean Actor context exit would call `sys.exit()`
+        # and abort the test. Tests that need a specific value pass `exit_process` explicitly. Patch before
+        # touching the `Actor` proxy below, since that materializes its `_ActorType` instance.
+        monkeypatch.setattr(apify._actor._ActorType, '_get_default_exit_process', lambda _self: False)
+
         if hasattr(apify._actor.Actor, '__wrapped__'):
             delattr(apify._actor.Actor, '__wrapped__')
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -56,10 +56,9 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
     """
 
     def _prepare_test_env() -> None:
-        # Production code deliberately does not detect the test environment (see issue #641), so force the
-        # `exit_process` default to False here. Otherwise a clean Actor context exit would call `sys.exit()`
-        # and abort the test. Tests that need a specific value pass `exit_process` explicitly. Patch before
-        # touching the `Actor` proxy below, since that materializes its `_ActorType` instance.
+        # Production code doesn't detect the test env (#641), so force the `exit_process` default to False.
+        # Otherwise a clean context exit calls `sys.exit()` and aborts the test. Patch before touching the
+        # `Actor` proxy below, which materializes its `_ActorType` instance.
         monkeypatch.setattr(apify._actor._ActorType, '_get_default_exit_process', lambda _self: False)
 
         if hasattr(apify._actor.Actor, '__wrapped__'):

--- a/tests/unit/actor/test_actor_lifecycle.py
+++ b/tests/unit/actor/test_actor_lifecycle.py
@@ -18,13 +18,12 @@ from crawlee.events._types import Event, EventPersistStateData
 
 from ..._utils import poll_until_condition
 from apify import Actor
+from apify._actor import _ActorType
 from apify._charging import ChargingManagerImplementation
 from apify._consts import EXIT_CODE_ERROR_USER_FUNCTION_THREW, ActorEnvVars, ApifyEnvVars
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable
-
-    from apify._actor import _ActorType
 
 
 @pytest.fixture(
@@ -197,6 +196,27 @@ async def test_unhandled_exception_sets_error_exit_code() -> None:
             raise RuntimeError('Test error')
 
     assert actor.exit_code == EXIT_CODE_ERROR_USER_FUNCTION_THREW
+
+
+# The autouse `_isolate_test_environment` fixture forces the `exit_process` default to False so a clean
+# context exit does not call `sys.exit()`. Capture the genuine detector at import time and call it
+# directly so these tests exercise the real logic rather than the test-environment override.
+_detect_default_exit_process = _ActorType._get_default_exit_process
+
+
+def test_default_exit_process_true_when_scrapy_importable_but_not_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression for B7: `scrapy` merely being importable must not disable `exit_process`."""
+    pytest.importorskip('scrapy')
+    monkeypatch.delenv('SCRAPY_SETTINGS_MODULE', raising=False)
+    actor = Actor(exit_process=False)
+    assert _detect_default_exit_process(actor) is True
+
+
+def test_default_exit_process_false_when_running_under_scrapy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Scrapy runner sets `SCRAPY_SETTINGS_MODULE`, which must disable `exit_process` by default."""
+    monkeypatch.setenv('SCRAPY_SETTINGS_MODULE', 'src.settings')
+    actor = Actor(exit_process=False)
+    assert _detect_default_exit_process(actor) is False
 
 
 async def test_actor_stops_periodic_events_after_exit(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/actor/test_actor_lifecycle.py
+++ b/tests/unit/actor/test_actor_lifecycle.py
@@ -205,7 +205,7 @@ _detect_default_exit_process = _ActorType._get_default_exit_process
 
 
 def test_default_exit_process_true_when_scrapy_importable_but_not_running(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Regression for B7: `scrapy` merely being importable must not disable `exit_process`."""
+    """`scrapy` merely being importable must not disable `exit_process`."""
     from apify.scrapy import _detection
 
     monkeypatch.setattr(_detection, '_running_in_scrapy', False)

--- a/tests/unit/actor/test_actor_lifecycle.py
+++ b/tests/unit/actor/test_actor_lifecycle.py
@@ -206,15 +206,19 @@ _detect_default_exit_process = _ActorType._get_default_exit_process
 
 def test_default_exit_process_true_when_scrapy_importable_but_not_running(monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression for B7: `scrapy` merely being importable must not disable `exit_process`."""
-    pytest.importorskip('scrapy')
+    from apify.scrapy import _detection
+
+    monkeypatch.setattr(_detection, '_running_in_scrapy', False)
     monkeypatch.delenv('SCRAPY_SETTINGS_MODULE', raising=False)
     actor = Actor(exit_process=False)
     assert _detect_default_exit_process(actor) is True
 
 
 def test_default_exit_process_false_when_running_under_scrapy(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The Scrapy runner sets `SCRAPY_SETTINGS_MODULE`, which must disable `exit_process` by default."""
-    monkeypatch.setenv('SCRAPY_SETTINGS_MODULE', 'src.settings')
+    """A real Scrapy run (the runner flag is set) disables `exit_process` by default."""
+    from apify.scrapy import _detection
+
+    monkeypatch.setattr(_detection, '_running_in_scrapy', True)
     actor = Actor(exit_process=False)
     assert _detect_default_exit_process(actor) is False
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -60,10 +60,9 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
     """
 
     def _prepare_test_env() -> None:
-        # Production code deliberately does not detect the test environment (see issue #641), so force the
-        # `exit_process` default to False here. Otherwise a clean Actor context exit would call `sys.exit()`
-        # and abort the test. Tests that need a specific value pass `exit_process` explicitly. Patch before
-        # touching the `Actor` proxy below, since that materializes its `_ActorType` instance.
+        # Production code doesn't detect the test env (#641), so force the `exit_process` default to False.
+        # Otherwise a clean context exit calls `sys.exit()` and aborts the test. Patch before touching the
+        # `Actor` proxy below, which materializes its `_ActorType` instance.
         monkeypatch.setattr(apify._actor._ActorType, '_get_default_exit_process', lambda _self: False)
 
         if hasattr(apify._actor.Actor, '__wrapped__'):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -60,6 +60,12 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
     """
 
     def _prepare_test_env() -> None:
+        # Production code deliberately does not detect the test environment (see issue #641), so force the
+        # `exit_process` default to False here. Otherwise a clean Actor context exit would call `sys.exit()`
+        # and abort the test. Tests that need a specific value pass `exit_process` explicitly. Patch before
+        # touching the `Actor` proxy below, since that materializes its `_ActorType` instance.
+        monkeypatch.setattr(apify._actor._ActorType, '_get_default_exit_process', lambda _self: False)
+
         if hasattr(apify._actor.Actor, '__wrapped__'):
             delattr(apify._actor.Actor, '__wrapped__')
 

--- a/tests/unit/scrapy/test_detection.py
+++ b/tests/unit/scrapy/test_detection.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from apify.scrapy import _detection
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_not_in_scrapy_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the runner flag or `SCRAPY_SETTINGS_MODULE`, the process is not treated as Scrapy."""
+    monkeypatch.setattr(_detection, '_running_in_scrapy', False)
+    monkeypatch.delenv('SCRAPY_SETTINGS_MODULE', raising=False)
+    assert _detection.is_running_in_scrapy() is False
+
+
+def test_detected_via_settings_module_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`SCRAPY_SETTINGS_MODULE` (set by the Scrapy CLI or entry point) marks a Scrapy run."""
+    monkeypatch.setattr(_detection, '_running_in_scrapy', False)
+    monkeypatch.setenv('SCRAPY_SETTINGS_MODULE', 'src.settings')
+    assert _detection.is_running_in_scrapy() is True
+
+
+def test_detected_via_runner_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`mark_running_in_scrapy` (called by `run_scrapy_actor`) marks a Scrapy run without any env var."""
+    monkeypatch.setattr(_detection, '_running_in_scrapy', False)
+    monkeypatch.delenv('SCRAPY_SETTINGS_MODULE', raising=False)
+    _detection.mark_running_in_scrapy()
+    assert _detection.is_running_in_scrapy() is True


### PR DESCRIPTION
`_get_default_exit_process` decided the `exit_process` default from whether `import scrapy` *succeeded*, not from whether the Actor is actually running under Scrapy. Any image where Scrapy arrives as a transitive dependency therefore silently disabled the `sys.exit()` on Actor exit. On the platform, an Actor that signals failure via `Actor.fail(exit_code=1)` without raising would keep running, end with exit code 0, and get marked SUCCEEDED.

Detection now lives in `apify.scrapy._detection` and treats the Actor as running under Scrapy when either of these holds:

- `run_scrapy_actor` is driving the process. It sets an explicit flag before the Actor's main coroutine runs, hence before the Actor initializes.
- The `SCRAPY_SETTINGS_MODULE` environment variable is set, by the Scrapy CLI or the Actor's entry point. This is the fallback and is already documented as a detection mechanism.

`_actor.py` consults this detector only through `sys.modules`, so a non-Scrapy Actor never imports `apify.scrapy`. Importing it pulls in Scrapy itself (~860 ms), and the old importability check would disable `exit_process` for exactly such images.

Test environments no longer get `exit_process=False` implicitly through the scrapy import. The unit `_isolate_test_environment` fixture now forces the default to `False` explicitly, since production code must not detect the test environment (see #641). As a side effect, the unit suite no longer needs the `scrapy` extra installed to avoid `SystemExit`.

**Behavioral change:** an Actor that runs Scrapy without using `run_scrapy_actor` and without setting `SCRAPY_SETTINGS_MODULE` now defaults `exit_process` to `True`. The documented Scrapy setup and the project template always do at least one of those, so legitimate Scrapy Actors are unaffected. I kept this as a plain `fix:` rather than a breaking change since the old behavior was itself the bug; promote the squash title to `fix!:` at merge if a major bump is preferred.
