### PR TITLE
fix: prevent duplicate platform websocket when nesting ApifyEventManager

### DIFF
--- a/src/apify/events/_apify_event_manager.py
+++ b/src/apify/events/_apify_event_manager.py
@@ -95,6 +95,13 @@ class ApifyEventManager(EventManager):
     @override
     async def __aenter__(self) -> Self:
         await super().__aenter__()
+
+        # The parent ref-counts nested contexts (e.g. a crawler entering the same event manager). Only the
+        # outermost enter (0 -> 1) may start the platform websocket machinery; a nested enter must reuse the
+        # existing connection rather than open a second one.
+        if self._active_ref_count > 1:
+            return self
+
         self._connected_to_platform_websocket = asyncio.Future()
 
         # Run tasks but don't await them
@@ -119,15 +126,19 @@ class ApifyEventManager(EventManager):
         exc_value: BaseException | None,
         exc_traceback: TracebackType | None,
     ) -> None:
-        # Cancel the task before closing the websocket so that the closed connection is not treated as a drop
-        # and followed by a reconnect attempt.
-        if self._process_platform_messages_task and not self._process_platform_messages_task.done():
-            self._process_platform_messages_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._process_platform_messages_task
+        # Mirror the parent's ref counting: only the outermost exit (1 -> 0) tears down the platform websocket
+        # machinery. A nested exit must leave the connection and its processing task intact for the still-active
+        # outer context.
+        if self._active_ref_count == 1:
+            # Cancel the task before closing the websocket so that the closed connection is not treated as a drop
+            # and followed by a reconnect attempt.
+            if self._process_platform_messages_task and not self._process_platform_messages_task.done():
+                self._process_platform_messages_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._process_platform_messages_task
 
-        if self._platform_events_websocket:
-            await self._platform_events_websocket.close()
+            if self._platform_events_websocket:
+                await self._platform_events_websocket.close()
 
         await super().__aexit__(exc_type, exc_value, exc_traceback)
 

--- a/src/apify/events/_apify_event_manager.py
+++ b/src/apify/events/_apify_event_manager.py
@@ -93,20 +93,14 @@ class ApifyEventManager(EventManager):
         """Future that resolves when the connection to the platform websocket is established."""
 
         self._context_depth = 0
-        """Nesting depth of active `async with` contexts, tracked independently of the parent's ref counting.
-
-        The platform websocket machinery is started on the outermost enter (0 -> 1) and torn down on the
-        outermost exit (1 -> 0); nested enters/exits reuse the single existing connection.
-        """
+        """Nesting depth of active contexts; the outermost enter/exit (0 <-> 1) starts/tears down the websocket."""
 
     @override
     async def __aenter__(self) -> Self:
         await super().__aenter__()
 
-        # Ref-count nested contexts (e.g. a crawler entering the same event manager) with our own counter,
-        # incremented right after a successful parent enter, rather than reading the parent's private ref-count
-        # internals (whose mutation timing we would otherwise depend on). Only the outermost enter (0 -> 1) starts
-        # the platform websocket machinery; a nested enter reuses the connection instead of opening a second one.
+        # Track nesting depth ourselves rather than reading the parent's private ref count. Only the outermost
+        # enter (0 -> 1) starts the websocket machinery; a nested enter reuses the existing connection.
         self._context_depth += 1
         if self._context_depth > 1:
             return self
@@ -135,9 +129,8 @@ class ApifyEventManager(EventManager):
         exc_value: BaseException | None,
         exc_traceback: TracebackType | None,
     ) -> None:
-        # Mirror the enter's own ref counting: only the outermost exit (1 -> 0) tears down the platform websocket
-        # machinery. A nested exit must leave the connection and its processing task intact for the still-active
-        # outer context.
+        # Only the outermost exit (1 -> 0) tears down the websocket machinery; a nested exit must leave the
+        # connection and its processing task intact for the still-active outer context.
         if self._context_depth == 1:
             # Cancel the task before closing the websocket so that the closed connection is not treated as a drop
             # and followed by a reconnect attempt.

--- a/src/apify/events/_apify_event_manager.py
+++ b/src/apify/events/_apify_event_manager.py
@@ -92,14 +92,23 @@ class ApifyEventManager(EventManager):
         self._connected_to_platform_websocket: asyncio.Future[bool] | None = None
         """Future that resolves when the connection to the platform websocket is established."""
 
+        self._context_depth = 0
+        """Nesting depth of active `async with` contexts, tracked independently of the parent's ref counting.
+
+        The platform websocket machinery is started on the outermost enter (0 -> 1) and torn down on the
+        outermost exit (1 -> 0); nested enters/exits reuse the single existing connection.
+        """
+
     @override
     async def __aenter__(self) -> Self:
         await super().__aenter__()
 
-        # The parent ref-counts nested contexts (e.g. a crawler entering the same event manager). Only the
-        # outermost enter (0 -> 1) may start the platform websocket machinery; a nested enter must reuse the
-        # existing connection rather than open a second one.
-        if self._active_ref_count > 1:
+        # Ref-count nested contexts (e.g. a crawler entering the same event manager) with our own counter,
+        # incremented right after a successful parent enter, rather than reading the parent's private ref-count
+        # internals (whose mutation timing we would otherwise depend on). Only the outermost enter (0 -> 1) starts
+        # the platform websocket machinery; a nested enter reuses the connection instead of opening a second one.
+        self._context_depth += 1
+        if self._context_depth > 1:
             return self
 
         self._connected_to_platform_websocket = asyncio.Future()
@@ -126,10 +135,10 @@ class ApifyEventManager(EventManager):
         exc_value: BaseException | None,
         exc_traceback: TracebackType | None,
     ) -> None:
-        # Mirror the parent's ref counting: only the outermost exit (1 -> 0) tears down the platform websocket
+        # Mirror the enter's own ref counting: only the outermost exit (1 -> 0) tears down the platform websocket
         # machinery. A nested exit must leave the connection and its processing task intact for the still-active
         # outer context.
-        if self._active_ref_count == 1:
+        if self._context_depth == 1:
             # Cancel the task before closing the websocket so that the closed connection is not treated as a drop
             # and followed by a reconnect attempt.
             if self._process_platform_messages_task and not self._process_platform_messages_task.done():
@@ -140,6 +149,7 @@ class ApifyEventManager(EventManager):
             if self._platform_events_websocket:
                 await self._platform_events_websocket.close()
 
+        self._context_depth -= 1
         await super().__aexit__(exc_type, exc_value, exc_traceback)
 
     def _process_connection_exception(self, exc: Exception) -> Exception | None:

--- a/tests/unit/events/test_apify_event_manager.py
+++ b/tests/unit/events/test_apify_event_manager.py
@@ -303,6 +303,12 @@ async def test_reentrant_context_reuses_single_platform_connection(monkeypatch: 
                 await asyncio.sleep(0.2)
                 assert len(event_calls) == 1
 
+        # The outermost exit tears down the single shared connection and its processing task; nothing is leaked.
+        assert outer_task is not None
+        assert outer_task.done()
+        await poll_until_condition(lambda: len(connected_ws_clients) == 0, poll_interval=0.05)
+        assert len(connected_ws_clients) == 0
+
 
 async def test_reentrant_exit_leaves_outer_context_functional(monkeypatch: pytest.MonkeyPatch) -> None:
     """Exiting a nested context leaves the outer connection alive and working; only the final exit tears it down."""

--- a/tests/unit/events/test_apify_event_manager.py
+++ b/tests/unit/events/test_apify_event_manager.py
@@ -277,6 +277,63 @@ async def test_lifecycle_on_platform(monkeypatch: pytest.MonkeyPatch) -> None:
         assert len(connected_ws_clients) == 1
 
 
+async def test_reentrant_context_reuses_single_platform_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A nested `async with` on the same event manager reuses the one platform connection, not a second."""
+    async with _platform_ws_server(monkeypatch) as (connected_ws_clients, client_connected):
+        event_manager = ApifyEventManager(Configuration.get_global_configuration())
+        async with event_manager:
+            await client_connected.wait()
+            assert len(connected_ws_clients) == 1
+            outer_task = event_manager._process_platform_messages_task
+
+            event_calls: list[Any] = []
+            event_manager.on(event=Event.SYSTEM_INFO, listener=event_calls.append)
+
+            async with event_manager:
+                # The nested enter must not replace the message-processing task nor open a second connection.
+                assert event_manager._process_platform_messages_task is outer_task
+                await asyncio.sleep(0.2)
+                assert len(connected_ws_clients) == 1
+
+                # A single platform event must be delivered exactly once, not once per connection.
+                websockets.broadcast(
+                    connected_ws_clients, json.dumps({'name': 'systemInfo', 'data': DUMMY_SYSTEM_INFO})
+                )
+                await poll_until_condition(lambda: len(event_calls) >= 1, poll_interval=0.05)
+                await asyncio.sleep(0.2)
+                assert len(event_calls) == 1
+
+
+async def test_reentrant_exit_leaves_outer_context_functional(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exiting a nested context leaves the outer connection alive and working; only the final exit tears it down."""
+    async with _platform_ws_server(monkeypatch) as (connected_ws_clients, client_connected):
+        event_manager = ApifyEventManager(Configuration.get_global_configuration())
+        async with event_manager:
+            await client_connected.wait()
+            outer_task = event_manager._process_platform_messages_task
+            assert outer_task is not None
+
+            async with event_manager:
+                pass
+
+            # The nested exit must not cancel the outer context's processing task.
+            assert event_manager.active is True
+            assert not outer_task.done()
+
+            # Events must still be delivered on the surviving connection.
+            event_calls: list[Any] = []
+            event_manager.on(event=Event.SYSTEM_INFO, listener=event_calls.append)
+            websockets.broadcast(connected_ws_clients, json.dumps({'name': 'systemInfo', 'data': DUMMY_SYSTEM_INFO}))
+            await poll_until_condition(lambda: len(event_calls) == 1, poll_interval=0.05)
+            assert len(event_calls) == 1
+
+        # The final exit tears everything down; no connection or task is leaked.
+        assert event_manager.active is False
+        assert outer_task.done()
+        await poll_until_condition(lambda: len(connected_ws_clients) == 0, poll_interval=0.05)
+        assert len(connected_ws_clients) == 0
+
+
 async def test_event_handling_on_platform(monkeypatch: pytest.MonkeyPatch) -> None:
     async with _platform_ws_server(monkeypatch) as (connected_ws_clients, client_connected):
 


### PR DESCRIPTION
`ApifyEventManager` overrode Crawlee's `EventManager` async context manager without respecting the parent's ref counting. Crawlee ref-counts nested `async with` blocks, and `BasicCrawler._run_crawler` always re-enters the same global event manager that `async with Actor:` already entered. Because the override started the platform websocket machinery on every enter and tore it down on every exit, the standard `async with Actor:` + `await crawler.run()` pattern opened a **second** websocket connection.

On the platform this meant every platform event (`MIGRATING`, `ABORTING`, `PERSIST_STATE`) was delivered twice during a crawl, and on the inner exit the fields pointed at the second connection, so the first leaked and could never be cancelled. Each sequential `crawler.run()` added another connection; the platform caps at 10 per run and then closes with `1008` (a non-retryable code), permanently disabling platform events - so migration/abort handling silently stops for the rest of the run.

The fix mirrors the parent's ref counting: the websocket machinery is started only on the outermost enter (`0 -> 1`) and torn down only on the outermost exit (`1 -> 0`). Nested enters/exits reuse the single existing connection.

Added two regression tests: a nested enter reuses the one connection and delivers each event exactly once; a nested exit leaves the outer context's connection working while the final exit tears everything down with no leaked task.

*✍️ Drafted by Claude Code*
