### PR TITLE
build: replace hatchling with the uv_build backend and bump uv to 0.12

### DIFF
--- a/.rules.md
+++ b/.rules.md
@@ -4,7 +4,7 @@ This file provides guidance to programming agents when working with code in this
 
 ## Project Overview
 
-The Apify SDK for Python (`apify` package on PyPI) is the official library for creating [Apify Actors](https://docs.apify.com/platform/actors) in Python. It provides Actor lifecycle management, storage access (datasets, key-value stores, request queues), event handling, proxy configuration, and pay-per-event charging. It builds on top of the [Crawlee](https://crawlee.dev/python) web scraping framework and the [Apify API Client](https://docs.apify.com/api/client/python). Supports Python 3.11–3.14. Build system: hatchling.
+The Apify SDK for Python (`apify` package on PyPI) is the official library for creating [Apify Actors](https://docs.apify.com/platform/actors) in Python. It provides Actor lifecycle management, storage access (datasets, key-value stores, request queues), event handling, proxy configuration, and pay-per-event charging. It builds on top of the [Crawlee](https://crawlee.dev/python) web scraping framework and the [Apify API Client](https://docs.apify.com/api/client/python). Supports Python 3.11–3.14. Build system: uv_build.
 
 ## Common Commands
 

--- a/docs/03_guides/code/uv_project/Dockerfile
+++ b/docs/03_guides/code/uv_project/Dockerfile
@@ -4,8 +4,8 @@
 # You can also use any other image from Docker Hub.
 FROM apify/actor-python:3.14
 
-# Add the uv binary from its official distroless image (pinned to the 0.11.x line).
-COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /uvx /bin/
+# Add the uv binary from its official distroless image (pinned to the 0.12.x line).
+COPY --from=ghcr.io/astral-sh/uv:0.12 /uv /uvx /bin/
 
 # Configure uv for container builds:
 #  - compile installed packages to bytecode, so the Actor starts faster,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.12.0,<0.13.0"]
+requires = ["uv_build"]
 build-backend = "uv_build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,20 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.12.0,<0.13.0"]
+build-backend = "uv_build"
 
 [project]
 name = "apify"
 version = "4.0.0"
 description = "Apify SDK for Python"
 authors = [{ name = "Apify Technologies s.r.o.", email = "support@apify.com" }]
-license = { file = "LICENSE" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -88,21 +88,9 @@ dev = [
     "werkzeug<4.0.0", # Werkzeug is used by httpserver
 ]
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/apify"]
-
-[tool.hatch.build.targets.sdist]
-only-include = [
-    "src/apify",
-    "CHANGELOG.md",
-    "CONTRIBUTING.md",
-    "LICENSE",
-    "README.md",
-    "pyproject.toml",
-]
-
-[tool.hatch.metadata]
-allow-direct-references = true
+# The module, pyproject.toml, README, and LICENSE are included in the sdist by default.
+[tool.uv.build-backend]
+source-include = ["CHANGELOG.md", "CONTRIBUTING.md"]
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,8 @@ dev = [
     "werkzeug<4.0.0", # Werkzeug is used by httpserver
 ]
 
-# The module, pyproject.toml, README, and LICENSE are included in the sdist by default.
 [tool.uv.build-backend]
+# The module, pyproject.toml, README, and LICENSE are included in the sdist by default.
 source-include = ["CHANGELOG.md", "CONTRIBUTING.md"]
 
 [tool.ruff]

--- a/website/versioned_docs/version-4.0/03_guides/code/uv_project/Dockerfile
+++ b/website/versioned_docs/version-4.0/03_guides/code/uv_project/Dockerfile
@@ -4,8 +4,8 @@
 # You can also use any other image from Docker Hub.
 FROM apify/actor-python:3.14
 
-# Add the uv binary from its official distroless image (pinned to the 0.11.x line).
-COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /uvx /bin/
+# Add the uv binary from its official distroless image (pinned to the 0.12.x line).
+COPY --from=ghcr.io/astral-sh/uv:0.12 /uv /uvx /bin/
 
 # Configure uv for container builds:
 #  - compile installed packages to bytecode, so the Actor starts faster,


### PR DESCRIPTION
Switches the build backend from `hatchling` to `uv_build`, replacing the `[tool.hatch.build.targets.*]` config with `[tool.uv.build-backend]`. Only `CHANGELOG.md` and `CONTRIBUTING.md` need an explicit `source-include` - the module, `pyproject.toml`, README, and LICENSE are in the sdist by default. The `[tool.hatch.metadata] allow-direct-references` setting is dropped, no dependency uses a direct reference.

License metadata moves to PEP 639: `license = "Apache-2.0"` plus `license-files = ["LICENSE"]`. That part is required, not cosmetic: `uv_build` ships `LICENSE` inside the wheel only when it is declared via `license-files`, and uv rejects `license-files` combined with the legacy `license = { file = ... }` table.

The `License :: OSI Approved :: Apache Software License` classifier is dropped because [PEP 639 deprecates license classifiers](https://peps.python.org/pep-0639/#deprecate-license-classifiers) in favor of `License-Expression`, which now carries the same information ("Using license classifier in the `Classifier` Core Metadata field is deprecated and replaced by the more precise `License-Expression` field"). See also the [core metadata spec](https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression). uv warns about the classifier on every build.

The uv guide's Dockerfile now pulls `ghcr.io/astral-sh/uv:0.12` (in `docs/` and in the `version-4.0` docs snapshot; the `version-3.4` snapshot is left on 0.11).

Verified by building sdist + wheel before and after: the wheel contents are identical, and the metadata differs only in `License-Expression: Apache-2.0` replacing the inlined license text. The sdist drops `.gitignore` and gains `pyproject.toml.orig` (uv 0.12 writes a TOML 1.0-compatible `pyproject.toml` into the sdist and keeps the original alongside it). `uv.lock` is unchanged.

*✍️ Drafted by Claude Code*