### PR TITLE
docs: Enable Ruff formatting of Python code blocks in Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,12 @@ async def main() -> None:
             soup = BeautifulSoup(response.content, 'html.parser')
 
             # Push the extracted data to the default dataset.
-            await Actor.push_data({
-                'url': request.url,
-                'title': soup.title.string if soup.title else None,
-            })
+            await Actor.push_data(
+                {
+                    'url': request.url,
+                    'title': soup.title.string if soup.title else None,
+                }
+            )
 
             # Mark the request as handled so it is not processed again.
             await request_queue.mark_request_as_handled(request)
@@ -183,10 +185,12 @@ async def main() -> None:
         @crawler.router.default_handler
         async def handler(context: PlaywrightCrawlingContext) -> None:
             Actor.log.info(f'Scraping {context.request.url} ...')
-            await context.push_data({
-                'url': context.request.url,
-                'title': await context.page.title(),
-            })
+            await context.push_data(
+                {
+                    'url': context.request.url,
+                    'title': await context.page.title(),
+                }
+            )
             # Follow links found on the page.
             await context.enqueue_links()
 

--- a/docs/04_upgrading/upgrading_to_v3.md
+++ b/docs/04_upgrading/upgrading_to_v3.md
@@ -96,6 +96,7 @@ from crawlee.configuration import Configuration
 from crawlee.events import LocalEventManager
 from apify import Actor
 
+
 async def main():
 
     async with Actor():
@@ -125,15 +126,19 @@ Apify SDK v3.0 also reworks how storage clients are configured, giving you expli
 
 ```python
 from crawlee import service_locator
-from apify.storage_clients import ApifyStorageClient, SmartApifyStorageClient, MemoryStorageClient
+from apify.storage_clients import (
+    ApifyStorageClient,
+    SmartApifyStorageClient,
+    MemoryStorageClient,
+)
 from apify import Actor
 
 
 async def main():
     service_locator.set_storage_client(
         SmartApifyStorageClient(
-            cloud_storage_client=ApifyStorageClient(request_queue_access="single"),
-            local_storage_client=MemoryStorageClient()
+            cloud_storage_client=ApifyStorageClient(request_queue_access='single'),
+            local_storage_client=MemoryStorageClient(),
         )
     )
     async with Actor:
@@ -158,7 +163,7 @@ async def main():
     # Full client that supports multiple consumers of the Apify Request Queue
     service_locator.set_storage_client(
         SmartApifyStorageClient(
-            cloud_storage_client=ApifyStorageClient(request_queue_access="shared"),
+            cloud_storage_client=ApifyStorageClient(request_queue_access='shared'),
         )
     )
     async with Actor:

--- a/docs/04_upgrading/upgrading_to_v4.md
+++ b/docs/04_upgrading/upgrading_to_v4.md
@@ -227,11 +227,15 @@ Secondary parameters on several client methods can no longer be passed positiona
 
 ```python
 # Before (v3)
-await client.key_value_store('my-store').set_record('my-key', {'data': 1}, 'application/json')
+await client.key_value_store('my-store').set_record(
+    'my-key', {'data': 1}, 'application/json'
+)
 await client.run('my-run').charge('my-event', 5)
 
 # After (v4)
-await client.key_value_store('my-store').set_record('my-key', {'data': 1}, content_type='application/json')
+await client.key_value_store('my-store').set_record(
+    'my-key', {'data': 1}, content_type='application/json'
+)
 await client.run('my-run').charge('my-event', count=5)
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,10 +107,7 @@ allow-direct-references = true
 [tool.ruff]
 line-length = 120
 include = [
-    "src/**/*.py",
-    "tests/**/*.py",
-    "docs/**/*.py",
-    "website/**/*.py",
+    "**/*.py",
     # Ruff formats Python code blocks embedded in Markdown files.
     "**/*.md",
     "**/*.mdx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,10 +106,20 @@ allow-direct-references = true
 
 [tool.ruff]
 line-length = 120
-include = ["src/**/*.py", "tests/**/*.py", "docs/**/*.py", "website/**/*.py"]
+include = [
+    "src/**/*.py",
+    "tests/**/*.py",
+    "docs/**/*.py",
+    "website/**/*.py",
+    # Ruff formats Python code blocks embedded in Markdown files.
+    "**/*.md",
+    "**/*.mdx",
+]
 exclude = [
     "website/versioned_docs/**",
 ]
+# MDX is Markdown; without this mapping Ruff would try to parse `.mdx` files as Python.
+extension = { mdx = "markdown" }
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
### What & why

Ruff 0.16 formats Python code blocks embedded in Markdown files, and does so by default. In this repo the feature was inert because `[tool.ruff] include` was an allowlist of `*.py` globs, so no Markdown file ever reached the formatter. Adding `**/*.md` and `**/*.mdx` turns it on, which means docs snippets are now held to the same formatting standard as the rest of the codebase instead of drifting by hand.

MDX needs the explicit `extension = { mdx = "markdown" }` mapping - without it Ruff would try to parse `.mdx` as Python and fail. Most of the Python snippets in `docs/` live in `.mdx`, so the mapping is what makes this useful here.

No changes to the `lint` / `format` Poe tasks are needed. `lint` already runs `ruff format --check` and `format` already runs `ruff format`, so both pick Markdown up automatically. Note that `ruff check` (lint rules) does not support Markdown yet, so only formatting is enforced there.

### Notes

- Code blocks under `docs/` are formatted to 90 columns, not 120, because of the existing `docs/pyproject.toml` override that keeps doc snippets free of a horizontal scrollbar. That is why a few lines in the upgrading guides got wrapped.
- The `README.md` examples were reformatted to the exploded call style. This matches what Ruff already produces for the `.py` examples under `docs/`.
- The second commit collapses the `include` allowlist to a single `**/*.py` glob. This is a pure simplification: no tracked `.py` file lives outside the previously listed directories, and Ruff processes exactly the same 304 files before and after.

*✍️ Drafted by Claude Code*
