### PR TITLE
fix: close the platform events websocket iterator on shutdown

### DIFF
--- a/src/apify/events/_apify_event_manager.py
+++ b/src/apify/events/_apify_event_manager.py
@@ -151,9 +151,8 @@ class ApifyEventManager(EventManager):
             # Used as an async iterator, `connect` reconnects with exponential backoff on failed connection attempts.
             connector = websockets.asyncio.client.connect(ws_url, process_exception=self._process_connection_exception)
 
-            # Close the iterator explicitly: neither `break` nor cancellation does it, and leaving it to the garbage
-            # collector lands its cleanup in `asyncio.run` teardown, too late to be awaited, which breaks the event
-            # loop's async generator shutdown. The cast is only because `websockets` types it as `AsyncIterator`.
+            # Neither `break` nor cancellation closes the iterator; left to the garbage collector, its cleanup lands
+            # in `asyncio.run` teardown, too late to await, and breaks the loop's async generator shutdown.
             connections = cast('AsyncGenerator[websockets.asyncio.client.ClientConnection]', aiter(connector))
 
             async with contextlib.aclosing(connections):
@@ -171,9 +170,8 @@ class ApifyEventManager(EventManager):
                         break
 
                     # Reconnect a healthy connection immediately; back off only on repeated rapid drops. The first
-                    # rapid drop reconnects once without delay (it only primes the backoff generator), and each
-                    # subsequent consecutive rapid drop then sleeps for the next backoff interval. A healthy
-                    # connection resets the generator, so the next rapid drop again gets that one free retry.
+                    # rapid drop retries without delay (it just primes the backoff generator), each consecutive one
+                    # after it sleeps for the next interval. A healthy connection resets the generator.
                     if time.monotonic() - connection_opened_at >= self._HEALTHY_CONNECTION_MIN_DURATION:
                         backoff_delays = None
                     elif backoff_delays is None:

--- a/src/apify/events/_apify_event_manager.py
+++ b/src/apify/events/_apify_event_manager.py
@@ -151,10 +151,9 @@ class ApifyEventManager(EventManager):
             # Used as an async iterator, `connect` reconnects with exponential backoff on failed connection attempts.
             connector = websockets.asyncio.client.connect(ws_url, process_exception=self._process_connection_exception)
 
-            # That iterator is an async generator whose cleanup closes the current connection, and neither `break` nor
-            # cancelling this task closes it. Left suspended, it is closed by the garbage collector instead - on Actor
-            # exit that lands in `asyncio.run` teardown, too late to be awaited, which then breaks the event loop's
-            # async generator shutdown. `websockets` types the iterator as a plain `AsyncIterator`, hence the cast.
+            # Close the iterator explicitly: neither `break` nor cancellation does it, and leaving it to the garbage
+            # collector lands its cleanup in `asyncio.run` teardown, too late to be awaited, which breaks the event
+            # loop's async generator shutdown. The cast is only because `websockets` types it as `AsyncIterator`.
             connections = cast('AsyncGenerator[websockets.asyncio.client.ClientConnection]', aiter(connector))
 
             async with contextlib.aclosing(connections):

--- a/src/apify/events/_apify_event_manager.py
+++ b/src/apify/events/_apify_event_manager.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import time
 from logging import getLogger
-from typing import TYPE_CHECKING, Annotated, Self
+from typing import TYPE_CHECKING, Annotated, Self, cast
 
 import websockets.asyncio.client
 import websockets.client
@@ -20,7 +20,7 @@ from apify._utils import docs_group
 from apify.events._types import DeprecatedEvent, EventMessage, SystemInfoEventData, UnknownEvent
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import AsyncGenerator, Generator
     from types import TracebackType
 
     from crawlee.events._event_manager import EventManagerOptions
@@ -149,31 +149,38 @@ class ApifyEventManager(EventManager):
 
         try:
             # Used as an async iterator, `connect` reconnects with exponential backoff on failed connection attempts.
-            async for websocket in websockets.asyncio.client.connect(
-                ws_url, process_exception=self._process_connection_exception
-            ):
-                self._platform_events_websocket = websocket
-                if self._connected_to_platform_websocket and not self._connected_to_platform_websocket.done():
-                    self._connected_to_platform_websocket.set_result(True)
-                else:
-                    logger.info('Reconnected to the platform events websocket.')
+            connector = websockets.asyncio.client.connect(ws_url, process_exception=self._process_connection_exception)
 
-                connection_opened_at = time.monotonic()
-                connection_lost = await self._consume_messages(websocket)
+            # That iterator is an async generator whose cleanup closes the current connection, and neither `break` nor
+            # cancelling this task closes it. Left suspended, it is closed by the garbage collector instead - on Actor
+            # exit that lands in `asyncio.run` teardown, too late to be awaited, which then breaks the event loop's
+            # async generator shutdown. `websockets` types the iterator as a plain `AsyncIterator`, hence the cast.
+            connections = cast('AsyncGenerator[websockets.asyncio.client.ClientConnection]', aiter(connector))
 
-                if not self._should_reconnect_after_close(websocket, connection_lost=connection_lost):
-                    break
+            async with contextlib.aclosing(connections):
+                async for websocket in connections:
+                    self._platform_events_websocket = websocket
+                    if self._connected_to_platform_websocket and not self._connected_to_platform_websocket.done():
+                        self._connected_to_platform_websocket.set_result(True)
+                    else:
+                        logger.info('Reconnected to the platform events websocket.')
 
-                # Reconnect a healthy connection immediately; back off only on repeated rapid drops. The first
-                # rapid drop reconnects once without delay (it only primes the backoff generator), and each
-                # subsequent consecutive rapid drop then sleeps for the next backoff interval. A healthy
-                # connection resets the generator, so the next rapid drop again gets that one free retry.
-                if time.monotonic() - connection_opened_at >= self._HEALTHY_CONNECTION_MIN_DURATION:
-                    backoff_delays = None
-                elif backoff_delays is None:
-                    backoff_delays = websockets.client.backoff()
-                else:
-                    await asyncio.sleep(next(backoff_delays))
+                    connection_opened_at = time.monotonic()
+                    connection_lost = await self._consume_messages(websocket)
+
+                    if not self._should_reconnect_after_close(websocket, connection_lost=connection_lost):
+                        break
+
+                    # Reconnect a healthy connection immediately; back off only on repeated rapid drops. The first
+                    # rapid drop reconnects once without delay (it only primes the backoff generator), and each
+                    # subsequent consecutive rapid drop then sleeps for the next backoff interval. A healthy
+                    # connection resets the generator, so the next rapid drop again gets that one free retry.
+                    if time.monotonic() - connection_opened_at >= self._HEALTHY_CONNECTION_MIN_DURATION:
+                        backoff_delays = None
+                    elif backoff_delays is None:
+                        backoff_delays = websockets.client.backoff()
+                    else:
+                        await asyncio.sleep(next(backoff_delays))
         except Exception:
             logger.exception('Error in websocket connection')
             if self._connected_to_platform_websocket is not None and not self._connected_to_platform_websocket.done():

--- a/tests/e2e/test_actor_events.py
+++ b/tests/e2e/test_actor_events.py
@@ -130,3 +130,35 @@ async def test_event_listener_can_be_removed_successfully(
     run_result = await run_actor(actor)
 
     assert run_result.status == 'SUCCEEDED'
+
+
+async def test_events_websocket_shutdown_is_clean(
+    make_actor: MakeActorFunction,
+    run_actor: RunActorFunction,
+) -> None:
+    """Test that a run using the platform events websocket exits without an async generator shutdown error."""
+
+    async def main() -> None:
+        from crawlee.crawlers import ParselCrawler, ParselCrawlingContext
+
+        # The crawler run keeps the event loop busy, so an unclosed events websocket iterator would be
+        # garbage-collected only during interpreter shutdown - the timing that triggers the error.
+        async with Actor:
+            crawler = ParselCrawler(max_crawl_depth=2)
+
+            @crawler.router.default_handler
+            async def handler(context: ParselCrawlingContext) -> None:
+                await context.enqueue_links()
+
+            await crawler.run(['http://localhost:8080/'])
+
+    actor = await make_actor(label='actor-events-shutdown', main_func=main)
+    run_result = await run_actor(actor)
+
+    assert run_result.status == 'SUCCEEDED'
+    assert run_result.exit_code == 0
+
+    run_log = await actor.last_run().log().get()
+    assert run_log is not None
+    assert 'error occurred during closing of asynchronous generator' not in run_log
+    assert 'asynchronous generator is already running' not in run_log

--- a/tests/e2e/test_actor_events.py
+++ b/tests/e2e/test_actor_events.py
@@ -141,13 +141,16 @@ async def test_events_websocket_shutdown_is_clean(
     async def main() -> None:
         from crawlee.crawlers import ParselCrawler, ParselCrawlingContext
 
-        # The crawler run keeps the event loop busy, so an unclosed events websocket iterator would be
-        # garbage-collected only during interpreter shutdown - the timing that triggers the error.
+        # A real crawler run is needed: the concurrency around Actor exit is what leaves an unclosed events
+        # websocket iterator's finalizer still in flight when the event loop tears down.
         async with Actor:
+            assert Actor.configuration.actor_events_ws_url, 'The run must use the platform events websocket.'
+
             crawler = ParselCrawler(max_crawl_depth=2)
 
             @crawler.router.default_handler
             async def handler(context: ParselCrawlingContext) -> None:
+                await context.push_data({'url': context.request.url})
                 await context.enqueue_links()
 
             await crawler.run(['http://localhost:8080/'])
@@ -156,7 +159,10 @@ async def test_events_websocket_shutdown_is_clean(
     run_result = await run_actor(actor)
 
     assert run_result.status == 'SUCCEEDED'
-    assert run_result.exit_code == 0
+
+    # The log assertions below are negative, so confirm the crawl that drives them really visited pages.
+    dataset_items_page = await actor.last_run().dataset().list_items()
+    assert dataset_items_page.count > 1
 
     run_log = await actor.last_run().log().get()
     assert run_log is not None

--- a/tests/e2e/test_actor_events.py
+++ b/tests/e2e/test_actor_events.py
@@ -141,8 +141,7 @@ async def test_events_websocket_shutdown_is_clean(
     async def main() -> None:
         from crawlee.crawlers import ParselCrawler, ParselCrawlingContext
 
-        # A real crawler run is needed: the concurrency around Actor exit is what leaves an unclosed events
-        # websocket iterator's finalizer still in flight when the event loop tears down.
+        # Real crawler load is needed: it leaves an unclosed iterator's finalizer in flight at loop teardown.
         async with Actor:
             assert Actor.configuration.actor_events_ws_url, 'The run must use the platform events websocket.'
 
@@ -160,7 +159,7 @@ async def test_events_websocket_shutdown_is_clean(
 
     assert run_result.status == 'SUCCEEDED'
 
-    # The log assertions below are negative, so confirm the crawl that drives them really visited pages.
+    # The log assertions below are negative, so confirm the crawl that drives them actually ran.
     dataset_items_page = await actor.last_run().dataset().list_items()
     assert dataset_items_page.count > 1
 

--- a/tests/unit/events/test_apify_event_manager.py
+++ b/tests/unit/events/test_apify_event_manager.py
@@ -598,8 +598,8 @@ async def test_shutdown_during_reconnect_backoff_is_clean(monkeypatch: pytest.Mo
 
 async def test_exit_closes_the_reconnecting_iterator(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that exiting closes the `connect` async iterator itself, rather than leaving it to the garbage collector."""
-    # Keeping a reference to every iterator prevents the garbage collector from finalizing it, so the assertion below
-    # holds only if the event manager closes the iterator on its own.
+    # Holding a reference to every iterator blocks garbage collection, so the assertion below holds only if the event
+    # manager closes the iterator itself.
     iterators: list[Any] = []
     original_aiter = websockets.asyncio.client.connect.__aiter__
 
@@ -618,9 +618,8 @@ async def test_exit_closes_the_reconnecting_iterator(monkeypatch: pytest.MonkeyP
     ):
         await asyncio.wait_for(client_connected.wait(), timeout=10)
 
-    # An iterator left suspended keeps its websocket open, and closing it is then deferred to the garbage collector.
-    # On Actor exit that lands in `asyncio.run` teardown, too late to be awaited, breaking async generator shutdown.
     assert iterators
+    # A closed async generator has no frame left.
     assert all(iterator.ag_frame is None for iterator in iterators)
 
 

--- a/tests/unit/events/test_apify_event_manager.py
+++ b/tests/unit/events/test_apify_event_manager.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock
 
 import pytest
 import websockets
+import websockets.asyncio.client
 import websockets.asyncio.server
 
 from crawlee.events._types import Event
@@ -24,7 +25,7 @@ from apify.events import ApifyEventManager
 from apify.events._types import SystemInfoEventData
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Awaitable, Callable
+    from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 
 
 DUMMY_SYSTEM_INFO = {
@@ -593,6 +594,34 @@ async def test_shutdown_during_reconnect_backoff_is_clean(monkeypatch: pytest.Mo
     # The parent recurring persist-state task must be stopped too, mirroring the failed-connect lifecycle test.
     persist_state_task = event_manager._emit_persist_state_event_rec_task.task
     assert persist_state_task is None or persist_state_task.done()
+
+
+async def test_exit_closes_the_reconnecting_iterator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that exiting closes the `connect` async iterator itself, rather than leaving it to the garbage collector."""
+    # Keeping a reference to every iterator prevents the garbage collector from finalizing it, so the assertion below
+    # holds only if the event manager closes the iterator on its own.
+    iterators: list[Any] = []
+    original_aiter = websockets.asyncio.client.connect.__aiter__
+
+    def recording_aiter(
+        connector: websockets.asyncio.client.connect,
+    ) -> AsyncIterator[websockets.asyncio.client.ClientConnection]:
+        iterator = original_aiter(connector)
+        iterators.append(iterator)
+        return iterator
+
+    monkeypatch.setattr(websockets.asyncio.client.connect, '__aiter__', recording_aiter)
+
+    async with (
+        _platform_ws_server(monkeypatch) as (_, client_connected),
+        ApifyEventManager(Configuration.get_global_configuration()),
+    ):
+        await asyncio.wait_for(client_connected.wait(), timeout=10)
+
+    # An iterator left suspended keeps its websocket open, and closing it is then deferred to the garbage collector.
+    # On Actor exit that lands in `asyncio.run` teardown, too late to be awaited, breaking async generator shutdown.
+    assert iterators
+    assert all(iterator.ag_frame is None for iterator in iterators)
 
 
 async def test_malformed_message_logs_exception(

--- a/tests/unit/events/test_apify_event_manager.py
+++ b/tests/unit/events/test_apify_event_manager.py
@@ -598,8 +598,8 @@ async def test_shutdown_during_reconnect_backoff_is_clean(monkeypatch: pytest.Mo
 
 async def test_exit_closes_the_reconnecting_iterator(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that exiting closes the `connect` async iterator itself, rather than leaving it to the garbage collector."""
-    # Holding a reference to every iterator blocks garbage collection, so the assertion below holds only if the event
-    # manager closes the iterator itself.
+    # Keeping a reference to every iterator blocks garbage collection, so the assertion holds only if the manager
+    # closes it itself.
     iterators: list[Any] = []
     original_aiter = websockets.asyncio.client.connect.__aiter__
 


### PR DESCRIPTION
Since v4.0.0, an Actor logs `RuntimeError: aclose(): asynchronous generator is already running` right after `Actor.exit()`. Cosmetic - the exit code stays 0 and no data is lost - but it shows up in every run and looks like a failure.

`ApifyEventManager._process_platform_messages` iterates `websockets` `connect(...)` with `async for`. That iterator is an async generator, and neither `break` nor cancelling the task closes it, so the garbage collector does - during `asyncio.run` teardown, where the `aclose()` it schedules lands after `_cancel_all_tasks` took its task snapshot and is never awaited. `loop.shutdown_asyncgens()` then calls `aclose()` on a generator that is still running. Up to v3.4.1 the code used `async with connect(...)`, which unwound synchronously on cancellation.

`contextlib.aclosing` closes the iterator on every exit path - `break`, exception and cancellation alike. The rest of the diff is the loop body re-indenting, a unit test that asserts the iterator is closed, and an E2E test that asserts the error is absent from a run log.

Reported on [Discord](https://discord.com/channels/801163717915574323/1533837354018799808/1533837354018799808).

*✍️ Drafted by Claude Code*
