### PR TITLE
test: poll for dataset items in crawlee e2e tests

### DIFF
--- a/tests/e2e/test_crawlee/conftest.py
+++ b/tests/e2e/test_crawlee/conftest.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ..._utils import poll_until_condition
+
 if TYPE_CHECKING:
     from apify_client._models import Run
     from apify_client._resource_clients import ActorClientAsync
@@ -39,9 +41,16 @@ async def verify_crawler_results(
     """Verify dataset items and KVS record after a crawler Actor run."""
     assert run_result.status == 'SUCCEEDED'
 
-    # Verify dataset items.
-    items = await actor.last_run().dataset().list_items()
-    assert items.count == 3
+    # Verify dataset items. The dataset is eventually consistent - right after a run finishes, the API can already
+    # report the final item count in the pagination headers while the items themselves are not returned yet - so poll
+    # until all the pushed items are readable.
+    dataset = actor.last_run().dataset()
+    items = await poll_until_condition(
+        dataset.list_items,
+        lambda page: len(page.items) >= len(_EXPECTED_PRODUCTS),
+        timeout=30,
+    )
+    assert len(items.items) == len(_EXPECTED_PRODUCTS)
 
     items_by_name = {item['name']: item for item in items.items}
 


### PR DESCRIPTION
`test_playwright_crawler` failed on master ([run 31375518173](https://github.com/apify/apify-sdk-python/actions/runs/31375518173/job/93413747650)) with `AssertionError: Missing product: Widget A` / `assert 'Widget A' in {}`, while the run itself succeeded and `assert items.count == 3` passed on the line above.

The dataset read in `verify_crawler_results` happens immediately after the run finishes. The API returned an empty item list while its pagination headers already reported the final item count, and `DatasetItemsPage.count` is `max(x-apify-pagination-count, len(items))` - so the count assertion passed on the headers alone and the test only broke once it looked at the items.

The read now polls with `poll_until_condition` (30s ceiling) until all pushed items are returned, and asserts on `len(items.items)` instead of the header-derived `count`, which was the misleading part. The helper is shared by all six crawler e2e tests.

Verified by replaying the exact response shape from CI (empty `items`, `count=3`): the old helper reproduces `Missing product: Widget A`, the new one passes after polling, an immediately consistent read still takes a single call, and wrong or extra items still fail fast. `tests/e2e/test_crawlee` against the platform: `test_playwright_crawler`, `test_adaptive_playwright_crawler`, `test_http_crawler` and `test_basic_crawler` pass; `test_parsel_crawler` and `test_beautifulsoup_crawler` could not run on my account (Actor-count limit), they fail before reaching this helper.

*✍️ Drafted by Claude Code*
