### PR TITLE
test: cover PPE charging on the Scrapy integration end-to-end

### DIFF
--- a/tests/e2e/test_scrapy/test_ppe_spider.py
+++ b/tests/e2e/test_scrapy/test_ppe_spider.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from .conftest import get_scrapy_source_files
+
+if TYPE_CHECKING:
+    from ..conftest import MakeActorFunction, RunActorFunction
+
+
+async def test_ppe_spider_charges_pushed_items_within_budget(
+    make_actor: MakeActorFunction,
+    run_actor: RunActorFunction,
+) -> None:
+    """A pay-per-event Scrapy Actor charges the synthetic dataset-item event and stops pushing at the budget cap."""
+    actor = await make_actor(
+        label='scrapy-ppe',
+        source_files=get_scrapy_source_files('spider_basic.py', 'BasicSpider'),
+        additional_requirements=['scrapy>=2.14.0'],
+    )
+
+    await actor.update(
+        pricing_infos=[
+            {
+                'pricingModel': 'PAY_PER_EVENT',
+                'apifyMarginPercentage': 0.0,
+                'createdAt': '2024-01-01T00:00:00.000Z',
+                'startedAt': '2024-01-01T00:00:00.000Z',
+                'pricingPerEvent': {
+                    'actorChargeEvents': {
+                        'apify-default-dataset-item': {
+                            'eventTitle': 'Default dataset item',
+                            'eventPriceUsd': 0.05,
+                            'eventDescription': 'One item written to the default dataset',
+                        },
+                    },
+                },
+            },
+        ]
+    )
+
+    # The spider scrapes three products. At $0.05 an item, a $0.125 budget covers only two of them, so the
+    # third push has to be dropped and never charged. The budget deliberately does not divide evenly into the
+    # item price - hitting the cap exactly would let the platform auto-abort the run and race the clean exit.
+    run = await run_actor(actor, max_total_charge_usd=Decimal('0.125'))
+
+    assert run.status == 'SUCCEEDED'
+    assert run.charged_event_counts == {'apify-default-dataset-item': 2}
+
+    items = await actor.last_run().dataset().list_items()
+    assert items.count == 2

--- a/tests/e2e/test_scrapy/test_ppe_spider.py
+++ b/tests/e2e/test_scrapy/test_ppe_spider.py
@@ -3,15 +3,19 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
+from ..._utils import poll_until_condition
 from .conftest import get_scrapy_source_files
 
 if TYPE_CHECKING:
+    from apify_client import ApifyClientAsync
+
     from ..conftest import MakeActorFunction, RunActorFunction
 
 
 async def test_ppe_spider_charges_pushed_items_within_budget(
     make_actor: MakeActorFunction,
     run_actor: RunActorFunction,
+    apify_client_async: ApifyClientAsync,
 ) -> None:
     """A pay-per-event Scrapy Actor charges the synthetic dataset-item event and stops pushing at the budget cap."""
     actor = await make_actor(
@@ -46,7 +50,20 @@ async def test_ppe_spider_charges_pushed_items_within_budget(
     run = await run_actor(actor, max_total_charge_usd=Decimal('0.125'))
 
     assert run.status == 'SUCCEEDED'
-    assert run.charged_event_counts == {'apify-default-dataset-item': 2}
+
+    expected_charges = {'apify-default-dataset-item': 2}
+
+    # The SDK only tracks the synthetic event internally - the platform derives the charges from dataset writes
+    # asynchronously, so they can lag behind the run reaching a terminal status. Refetch until they propagate.
+    charged_run = await poll_until_condition(
+        apify_client_async.run(run.id).get,
+        lambda refetched: refetched is not None and refetched.charged_event_counts == expected_charges,
+        timeout=120,
+        poll_interval=1,
+    )
+
+    assert charged_run is not None
+    assert charged_run.charged_event_counts == expected_charges
 
     items = await actor.last_run().dataset().list_items()
     assert items.count == 2

--- a/tests/e2e/test_scrapy/test_ppe_spider.py
+++ b/tests/e2e/test_scrapy/test_ppe_spider.py
@@ -65,5 +65,7 @@ async def test_ppe_spider_charges_pushed_items_within_budget(
     assert charged_run is not None
     assert charged_run.charged_event_counts == expected_charges
 
+    # `total` counts the whole dataset, unlike `count`, which only covers the items returned in this page and
+    # can still lag right after a run finishes.
     items = await actor.last_run().dataset().list_items()
-    assert items.count == 2
+    assert items.total == 2


### PR DESCRIPTION
Adds an e2e test that runs a pay-per-event Scrapy Actor on the platform and asserts that pushed items are charged and that `max_total_charge_usd` is enforced. The spider scrapes three products; at $0.05 an item a $0.125 budget covers two, so the third push must be dropped and never charged.

No source changes — the behavior was already correct. This locks it in so a future Scrapy or Twisted upgrade that does change the reactor's scheduling context fails loudly instead of silently costing developers revenue.

*✍️ Drafted by Claude Code*
