### PR TITLE
test: poll the first fetch in the shared RQ in-progress test

### DIFF
--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -1629,7 +1629,7 @@ async def test_shared_is_finished_false_while_request_in_progress(
         try:
             await rq.add_request(Request.from_url('https://example.com/in-progress'))
 
-            fetched = await rq.fetch_next_request()
+            fetched = await poll_until_condition(rq.fetch_next_request, timeout=30, backoff_factor=2)
             assert fetched is not None
             request_id = unique_key_to_request_id(fetched.unique_key)
             assert request_id in impl._requests_in_progress


### PR DESCRIPTION
`test_shared_is_finished_false_while_request_in_progress` failed on an unrelated PR's CI
([run 32959613011](https://github.com/apify/apify-sdk-python/actions/runs/32959613011/job/98148839881)) with
`assert None is not None`: its first `fetch_next_request()` came back empty.

In shared mode that is expected, not a client defect. The fetch goes through `list_and_lock_head`, which is
eventually consistent, so a just-committed request can be missing from the head for a moment (#808). The crawler
tolerates it because `is_finished()` still reports `False` while the request is unhandled, so it retries instead of
shutting down.

Every other shared-mode read in the module already polls with `poll_until_condition`, as the note at the top of the
file prescribes; this one call site did not. It now polls with the same `timeout=30, backoff_factor=2` used by the
other shared-only tests in the file (the `rq_poll_timeout` fixture is unavailable here, since the test opens its own
queue instead of using the parametrized fixture).

*✍️ Drafted by Claude Code*
