### PR TITLE
test: Speed up the unit, integration and E2E test suites

### DIFF
--- a/.github/workflows/_checks.yaml
+++ b/.github/workflows/_checks.yaml
@@ -139,7 +139,7 @@ jobs:
       operating_systems: '["ubuntu-latest", "windows-latest"]'
       python_version_for_codecov: "3.14"
       operating_system_for_codecov: ubuntu-latest
-      tests_concurrency: "1"
+      tests_concurrency: "8"
 
   integration_tests:
     name: Integration tests (${{ matrix.python-version }}, ${{ matrix.os }})
@@ -161,7 +161,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      TESTS_CONCURRENCY: "8"
+      TESTS_CONCURRENCY: "16"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/_checks.yaml
+++ b/.github/workflows/_checks.yaml
@@ -139,7 +139,7 @@ jobs:
       operating_systems: '["ubuntu-latest", "windows-latest"]'
       python_version_for_codecov: "3.14"
       operating_system_for_codecov: ubuntu-latest
-      tests_concurrency: "8"
+      tests_concurrency: "4"
 
   integration_tests:
     name: Integration tests (${{ matrix.python-version }}, ${{ matrix.os }})
@@ -161,7 +161,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      TESTS_CONCURRENCY: "16"
+      TESTS_CONCURRENCY: "8"
 
     steps:
       - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,7 @@ known-first-party = ["apify_client", "crawlee"]
 max-branches = 18
 
 [tool.pytest.ini_options]
-addopts = "-r a --verbose"
+addopts = "-r a --verbose --dist worksteal"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
 timeout = 1800

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -110,12 +110,16 @@ def _isolate_test_environment(prepare_test_env: Callable[[], None]) -> None:
 @pytest.fixture(scope='session')
 def sdk_wheel_path(tmp_path_factory: pytest.TempPathFactory, testrun_uid: str) -> Path:
     """Build the package wheel if it hasn't been built yet, and return the path to the wheel."""
+    # `getbasetemp()` is per-xdist-worker, so both the lock and the indicator file live in its shared parent
+    # directory, which every worker sees.
+    shared_tmp_path = tmp_path_factory.getbasetemp().parent
+
     # Make sure the wheel is not being built concurrently across all the pytest-xdist runners,
     # through locking the building process with a temp file.
-    with FileLock(tmp_path_factory.getbasetemp().parent / 'sdk_wheel_build.lock'):
-        # Make sure the wheel is built exactly once across across all the pytest-xdist runners,
-        # through an indicator file saying that the wheel was already built.
-        was_wheel_built_this_test_run_file = tmp_path_factory.getbasetemp() / f'wheel_was_built_in_run_{testrun_uid}'
+    with FileLock(shared_tmp_path / 'sdk_wheel_build.lock'):
+        # Make sure the wheel is built exactly once across all the pytest-xdist runners, through an indicator
+        # file saying that the wheel was already built.
+        was_wheel_built_this_test_run_file = shared_tmp_path / f'wheel_was_built_in_run_{testrun_uid}'
         if not was_wheel_built_this_test_run_file.exists():
             subprocess.run(
                 args=[sys.executable, '-m', 'build'],

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -34,6 +34,19 @@ _API_URL_ENV_VAR = 'APIFY_INTEGRATION_TESTS_API_URL'
 _SDK_ROOT_PATH = Path(__file__).parent.parent.parent.resolve()
 _MAX_BUILD_ATTEMPTS = 2
 
+# The Actors in these suites install browsers or Scrapy into their images, so their platform builds take several
+# times longer than the rest of the suite.
+_HEAVY_IMAGE_SUITES = ('tests/e2e/test_crawlee/', 'tests/e2e/test_scrapy/')
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Schedule the tests with the heaviest Actor images first.
+
+    pytest-xdist distributes the collection in order, so the longest tests have to come first for the workers to
+    finish at roughly the same time.
+    """
+    items.sort(key=lambda item: not item.nodeid.startswith(_HEAVY_IMAGE_SUITES))
+
 
 @pytest.fixture(scope='session')
 def apify_token() -> str:

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -39,22 +39,6 @@ if TYPE_CHECKING:
 _SHARED_MODE_PROPAGATION_DELAY = 10
 
 
-async def poll_fetch_next_request(rq: RequestQueue, *, timeout: float) -> Request | None:
-    """Fetch the next request from `rq`, retrying an empty result until the queue reports itself finished.
-
-    In shared mode `fetch_next_request` can return `None` while requests are still propagating, so an empty
-    result has to be retried. A queue that is genuinely drained reports `is_finished`, which ends the retrying
-    right away instead of waiting out the whole `timeout`.
-    """
-
-    async def fetch_or_finished() -> Request | bool | None:
-        request = await rq.fetch_next_request()
-        return request if request is not None else await rq.is_finished()
-
-    result = await poll_until_condition(fetch_or_finished, timeout=timeout, backoff_factor=2)
-    return result if isinstance(result, Request) else None
-
-
 async def test_add_and_fetch_requests(
     request_queue_apify: RequestQueue,
     rq_poll_timeout: int,
@@ -71,7 +55,7 @@ async def test_add_and_fetch_requests(
         await rq.add_request(f'https://example.com/{i}')
 
     handled_request_count = 0
-    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
+    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
         Actor.log.info('Fetching next request...')
         queue_operation_info = await rq.mark_request_as_handled(next_request)
         assert queue_operation_info is not None, f'queue_operation_info={queue_operation_info}'
@@ -107,7 +91,7 @@ async def test_add_requests_in_batches(
     Actor.log.info(f'Added {desired_request_count} requests in batch, total in queue: {total_count}')
 
     handled_request_count = 0
-    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
+    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
         if handled_request_count % 20 == 0:
             Actor.log.info(f'Processing request {handled_request_count + 1}...')
         queue_operation_info = await rq.mark_request_as_handled(next_request)
@@ -147,7 +131,7 @@ async def test_add_non_unique_requests_in_batch(
     Actor.log.info(f'Added {desired_request_count} requests with duplicate unique keys, total in queue: {total_count}')
 
     handled_request_count = 0
-    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
+    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
         if handled_request_count % 20 == 0:
             Actor.log.info(f'Processing request {handled_request_count + 1}: {next_request.url}')
         queue_operation_info = await rq.mark_request_as_handled(next_request)
@@ -198,7 +182,7 @@ async def test_forefront_requests_ordering(
 
     # Fetch requests and verify order.
     fetched_urls = []
-    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
+    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
         Actor.log.info(f'Fetched request: {next_request.url}')
         fetched_urls.append(next_request.url)
         await rq.mark_request_as_handled(next_request)
@@ -264,7 +248,7 @@ async def test_request_unique_key_behavior(
     # Only 2 requests should be fetchable.
     fetched_count = 0
     fetched_requests = []
-    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
+    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
         fetched_count += 1
         fetched_requests.append(next_request)
         await rq.mark_request_as_handled(next_request)
@@ -566,7 +550,7 @@ async def test_batch_operations_performance(
 
     # Process all requests.
     processed_count = 0
-    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
+    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
         processed_count += 1
         await rq.mark_request_as_handled(next_request)
         if processed_count >= 50:  # Safety break
@@ -629,7 +613,7 @@ async def test_state_consistency(
 
     # Process remaining requests.
     remaining_count = 0
-    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
+    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
         remaining_count += 1
         await rq.mark_request_as_handled(next_request)
 
@@ -652,7 +636,7 @@ async def test_empty_rq_behavior(request_queue_apify: RequestQueue, rq_poll_time
     assert is_finished is True, f'is_finished={is_finished}'
 
     # Fetch from empty queue
-    next_request = await poll_fetch_next_request(rq, timeout=rq_poll_timeout)
+    next_request = await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2)
     Actor.log.info(f'Fetch result from empty queue: {next_request}')
     assert next_request is None, f'request={next_request}'
 
@@ -693,7 +677,7 @@ async def test_large_batch_operations(
     # Process all in chunks to test performance.
     processed_count = 0
 
-    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
+    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
         await rq.mark_request_as_handled(next_request)
         processed_count += 1
 
@@ -737,7 +721,7 @@ async def test_mixed_string_and_request_objects(
 
     # Fetch and verify all types work.
     fetched_requests = []
-    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
+    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
         fetched_requests.append(next_request)
         await rq.mark_request_as_handled(next_request)
 
@@ -801,7 +785,7 @@ async def test_persistence_across_operations(
 
     # Process remaining.
     remaining_processed = 0
-    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
+    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
         remaining_processed += 1
         await rq.mark_request_as_handled(next_request)
 
@@ -916,7 +900,7 @@ async def test_request_ordering_with_mixed_operations(
 
     # Fetch all requests and verify forefront behavior.
     urls_ordered = list[str]()
-    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
+    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
         urls_ordered.append(next_request.url)
         await rq.mark_request_as_handled(next_request)
 
@@ -1584,7 +1568,7 @@ async def test_concurrent_processing_simulation(apify_token: str, monkeypatch: p
             assert total_after_workers == 20
 
             remaining_count = 0
-            while request := await poll_fetch_next_request(rq, timeout=30):
+            while request := await poll_until_condition(rq.fetch_next_request, timeout=30, backoff_factor=2):
                 remaining_count += 1
                 await rq.mark_request_as_handled(request)
 

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -39,6 +39,22 @@ if TYPE_CHECKING:
 _SHARED_MODE_PROPAGATION_DELAY = 10
 
 
+async def poll_fetch_next_request(rq: RequestQueue, *, timeout: float) -> Request | None:
+    """Fetch the next request from `rq`, retrying an empty result until the queue reports itself finished.
+
+    In shared mode `fetch_next_request` can return `None` while requests are still propagating, so an empty
+    result has to be retried. A queue that is genuinely drained reports `is_finished`, which ends the retrying
+    right away instead of waiting out the whole `timeout`.
+    """
+
+    async def fetch_or_finished() -> Request | bool | None:
+        request = await rq.fetch_next_request()
+        return request if request is not None else await rq.is_finished()
+
+    result = await poll_until_condition(fetch_or_finished, timeout=timeout, backoff_factor=2)
+    return result if isinstance(result, Request) else None
+
+
 async def test_add_and_fetch_requests(
     request_queue_apify: RequestQueue,
     rq_poll_timeout: int,
@@ -55,7 +71,7 @@ async def test_add_and_fetch_requests(
         await rq.add_request(f'https://example.com/{i}')
 
     handled_request_count = 0
-    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
+    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
         Actor.log.info('Fetching next request...')
         queue_operation_info = await rq.mark_request_as_handled(next_request)
         assert queue_operation_info is not None, f'queue_operation_info={queue_operation_info}'
@@ -91,7 +107,7 @@ async def test_add_requests_in_batches(
     Actor.log.info(f'Added {desired_request_count} requests in batch, total in queue: {total_count}')
 
     handled_request_count = 0
-    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
+    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
         if handled_request_count % 20 == 0:
             Actor.log.info(f'Processing request {handled_request_count + 1}...')
         queue_operation_info = await rq.mark_request_as_handled(next_request)
@@ -131,7 +147,7 @@ async def test_add_non_unique_requests_in_batch(
     Actor.log.info(f'Added {desired_request_count} requests with duplicate unique keys, total in queue: {total_count}')
 
     handled_request_count = 0
-    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
+    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
         if handled_request_count % 20 == 0:
             Actor.log.info(f'Processing request {handled_request_count + 1}: {next_request.url}')
         queue_operation_info = await rq.mark_request_as_handled(next_request)
@@ -182,7 +198,7 @@ async def test_forefront_requests_ordering(
 
     # Fetch requests and verify order.
     fetched_urls = []
-    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
+    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
         Actor.log.info(f'Fetched request: {next_request.url}')
         fetched_urls.append(next_request.url)
         await rq.mark_request_as_handled(next_request)
@@ -248,7 +264,7 @@ async def test_request_unique_key_behavior(
     # Only 2 requests should be fetchable.
     fetched_count = 0
     fetched_requests = []
-    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
+    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
         fetched_count += 1
         fetched_requests.append(next_request)
         await rq.mark_request_as_handled(next_request)
@@ -550,7 +566,7 @@ async def test_batch_operations_performance(
 
     # Process all requests.
     processed_count = 0
-    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
+    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
         processed_count += 1
         await rq.mark_request_as_handled(next_request)
         if processed_count >= 50:  # Safety break
@@ -613,7 +629,7 @@ async def test_state_consistency(
 
     # Process remaining requests.
     remaining_count = 0
-    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
+    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
         remaining_count += 1
         await rq.mark_request_as_handled(next_request)
 
@@ -636,7 +652,7 @@ async def test_empty_rq_behavior(request_queue_apify: RequestQueue, rq_poll_time
     assert is_finished is True, f'is_finished={is_finished}'
 
     # Fetch from empty queue
-    next_request = await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2)
+    next_request = await poll_fetch_next_request(rq, timeout=rq_poll_timeout)
     Actor.log.info(f'Fetch result from empty queue: {next_request}')
     assert next_request is None, f'request={next_request}'
 
@@ -677,7 +693,7 @@ async def test_large_batch_operations(
     # Process all in chunks to test performance.
     processed_count = 0
 
-    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
+    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
         await rq.mark_request_as_handled(next_request)
         processed_count += 1
 
@@ -721,7 +737,7 @@ async def test_mixed_string_and_request_objects(
 
     # Fetch and verify all types work.
     fetched_requests = []
-    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
+    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
         fetched_requests.append(next_request)
         await rq.mark_request_as_handled(next_request)
 
@@ -785,7 +801,7 @@ async def test_persistence_across_operations(
 
     # Process remaining.
     remaining_processed = 0
-    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
+    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
         remaining_processed += 1
         await rq.mark_request_as_handled(next_request)
 
@@ -900,7 +916,7 @@ async def test_request_ordering_with_mixed_operations(
 
     # Fetch all requests and verify forefront behavior.
     urls_ordered = list[str]()
-    while next_request := await poll_until_condition(rq.fetch_next_request, timeout=rq_poll_timeout, backoff_factor=2):
+    while next_request := await poll_fetch_next_request(rq, timeout=rq_poll_timeout):
         urls_ordered.append(next_request.url)
         await rq.mark_request_as_handled(next_request)
 
@@ -1568,7 +1584,7 @@ async def test_concurrent_processing_simulation(apify_token: str, monkeypatch: p
             assert total_after_workers == 20
 
             remaining_count = 0
-            while request := await poll_until_condition(rq.fetch_next_request, timeout=30, backoff_factor=2):
+            while request := await poll_fetch_next_request(rq, timeout=30):
                 remaining_count += 1
                 await rq.mark_request_as_handled(request)
 

--- a/tests/unit/actor/test_actor_helpers.py
+++ b/tests/unit/actor/test_actor_helpers.py
@@ -435,8 +435,10 @@ async def test_reboot_proceeds_when_event_listener_exceeds_timeout(
     """Test that a hanging pre-reboot event listener does not block reboot beyond the timeout."""
     apify_client_async_patcher.patch('run', 'reboot', return_value=None)
 
+    release_listener = asyncio.Event()
+
     async def hanging_listener(*_args: object) -> None:
-        await asyncio.sleep(60)
+        await release_listener.wait()
 
     async with Actor:
         Actor.configuration.is_at_home = True
@@ -450,6 +452,9 @@ async def test_reboot_proceeds_when_event_listener_exceeds_timeout(
                 event_listeners_timeout=timedelta(milliseconds=50),
                 custom_after_sleep=timedelta(milliseconds=1),
             )
+
+        # Let the listener finish, so that exiting the context does not wait it out.
+        release_listener.set()
 
     # The timeout was honored and logged.
     assert any('Pre-reboot event listeners did not finish within timeout' in r.message for r in caplog.records)

--- a/tests/unit/test_apify_storages.py
+++ b/tests/unit/test_apify_storages.py
@@ -1,5 +1,5 @@
-import asyncio
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest import mock
@@ -136,10 +136,11 @@ async def test_txt_input_missing_metadata(input_test_configuration: Configuratio
     kvs_path = Path(input_test_configuration.storage_dir) / 'key_value_stores' / 'default'
     input_file = kvs_path / f'{input_test_configuration.input_key}.txt'
     input_file.write_text(EXAMPLE_TXT_INPUT)
+    # Backdate the file so that a rewrite by `KeyValueStore.open` shows up as a changed mtime whatever the
+    # filesystem's timestamp granularity is.
+    backdated_time = input_file.stat().st_mtime - 10
+    os.utime(input_file, (backdated_time, backdated_time))
     last_modified = input_file.stat().st_mtime
-
-    # Make sure that filesystem has enough time to detect changes
-    await asyncio.sleep(1)
 
     kvs = await KeyValueStore.open(
         storage_client=ApifyFileSystemStorageClient(), configuration=input_test_configuration
@@ -156,10 +157,11 @@ async def test_json_input_missing_metadata(input_test_configuration: Configurati
     kvs_path = Path(input_test_configuration.storage_dir) / 'key_value_stores' / 'default'
     input_file = kvs_path / f'{input_test_configuration.input_key}{suffix}'
     input_file.write_text(EXAMPLE_JSON_INPUT)
+    # Backdate the file so that a rewrite by `KeyValueStore.open` shows up as a changed mtime whatever the
+    # filesystem's timestamp granularity is.
+    backdated_time = input_file.stat().st_mtime - 10
+    os.utime(input_file, (backdated_time, backdated_time))
     last_modified = input_file.stat().st_mtime
-
-    # Make sure that filesystem has enough time to detect changes
-    await asyncio.sleep(1)
 
     kvs = await KeyValueStore.open(
         storage_client=ApifyFileSystemStorageClient(), configuration=input_test_configuration
@@ -176,10 +178,11 @@ async def test_bytes_input_missing_metadata(input_test_configuration: Configurat
     kvs_path = Path(input_test_configuration.storage_dir) / 'key_value_stores' / 'default'
     input_file = kvs_path / f'{input_test_configuration.input_key}{suffix}'
     input_file.write_bytes(EXAMPLE_BYTES_INPUT)
+    # Backdate the file so that a rewrite by `KeyValueStore.open` shows up as a changed mtime whatever the
+    # filesystem's timestamp granularity is.
+    backdated_time = input_file.stat().st_mtime - 10
+    os.utime(input_file, (backdated_time, backdated_time))
     last_modified = input_file.stat().st_mtime
-
-    # Make sure that filesystem has enough time to detect changes
-    await asyncio.sleep(1)
 
     kvs = await KeyValueStore.open(
         storage_client=ApifyFileSystemStorageClient(), configuration=input_test_configuration


### PR DESCRIPTION
The CI critical path is the E2E job at ~5.9 min; it and the unit suite mostly wait rather than work (master run `32966697702`).

**E2E**

- `sdk_wheel_path` locks the wheel build on a shared file, but keeps the "already built" marker under the **per-worker** `getbasetemp()`, so all 16 workers rebuild the wheel in turn behind the lock (first worker's first test at 41s, last at 144s). The marker moves next to the lock, into the shared parent dir.
- `test_crawlee`/`test_scrapy` hold the 6 slowest tests but collect last, and xdist distributes in collection order - `test_adaptive_playwright_crawler` (167s) ran t=155s to 322s, ~100s after every other worker went idle. A `pytest_collection_modifyitems` hook puts them first.

**Unit**

- `test_reboot_proceeds_when_event_listener_exceeds_timeout`: 30.1s of 80.5s, because its listener slept 60s and leaving the `Actor` context waited out `cleanup_timeout`. It releases the listener via `asyncio.Event` instead (-> 0.17s).
- 12 tests slept 1s each for mtime granularity; they backdate the input file with `os.utime`.
- `tests_concurrency` 1 -> 4 (the suite ran at ~21% CPU on one worker), plus `--dist worksteal` so a worker that draws several slow tests stops being the critical path.

Locally 81.0s -> 15.5s at 4 workers, 572 passing. Projected CI: unit ~2 -> ~1 min, E2E 5.9 -> ~4 min. E2E is unverified locally (no platform token), so the first CI run is the check.

*✍️ Drafted by Claude Code*
