### PR TITLE
test: Fix flaky `test_lifecycle_on_platform_without_websocket`

### DIFF
--- a/tests/unit/events/test_apify_event_manager.py
+++ b/tests/unit/events/test_apify_event_manager.py
@@ -25,7 +25,7 @@ from apify.events import ApifyEventManager
 from apify.events._types import SystemInfoEventData
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
+    from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterator
 
 
 DUMMY_SYSTEM_INFO = {
@@ -178,6 +178,22 @@ async def _unresponsive_ws_server(monkeypatch: pytest.MonkeyPatch) -> AsyncGener
         await server.wait_closed()
 
 
+@contextlib.contextmanager
+def _unreachable_ws_url(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Point the events WebSocket URL at a `127.0.0.1` port that is guaranteed to refuse connections.
+
+    A hard-coded port number cannot be assumed dead: every port in the OS ephemeral range is fair game for any
+    `bind(host, 0)` in the suite, so a parallel xdist worker's server can end up listening on exactly that port and
+    the connection then succeeds instead of being refused. Reserving a port with a socket that never calls `listen()`
+    keeps the OS from handing it out to anyone else, while leaving every connect attempt refused with `ECONNREFUSED`.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as reserved_sock:
+        reserved_sock.bind(('127.0.0.1', 0))
+        port: int = reserved_sock.getsockname()[1]
+        monkeypatch.setenv(ActorEnvVars.EVENTS_WEBSOCKET_URL, f'ws://127.0.0.1:{port}')
+        yield
+
+
 async def test_lifecycle_local(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger='apify')
 
@@ -284,12 +300,12 @@ async def test_event_async_handling_local() -> None:
 
 async def test_lifecycle_on_platform_without_websocket(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that a failed websocket connection raises and also exits the parent's recurring persist state task."""
-    monkeypatch.setenv(ActorEnvVars.EVENTS_WEBSOCKET_URL, 'ws://localhost:56565')
-    event_manager = ApifyEventManager(Configuration.get_global_configuration())
+    with _unreachable_ws_url(monkeypatch):
+        event_manager = ApifyEventManager(Configuration.get_global_configuration())
 
-    with pytest.raises(RuntimeError, match=r'Error connecting to platform events websocket!') as exc_info:
-        async with event_manager:
-            pass
+        with pytest.raises(RuntimeError, match=r'Error connecting to platform events websocket!') as exc_info:
+            async with event_manager:
+                pass
 
     # The error that prevented the connection is reported as the cause, not only logged.
     assert isinstance(exc_info.value.__cause__, OSError)


### PR DESCRIPTION
`test_lifecycle_on_platform_without_websocket` pointed the events WebSocket URL at a hard-coded `ws://localhost:56565` and asserted that the connection is refused. That port sits inside the OS ephemeral range (32768-60999 on Linux, 49152-65535 on Windows), so any `bind(host, 0)` elsewhere in the parallel suite can be handed exactly that port, and this test file alone starts three such servers. When a sibling xdist worker got 56565, the connection succeeded and the test failed with `DID NOT RAISE RuntimeError`, as in [this Windows run](https://github.com/apify/apify-sdk-python/actions/runs/34123143315/job/101745572277). Attempt 2 of the same run passed on the same commit.

The test now reserves a port instead of guessing one. A new `_unreachable_ws_url` helper binds `('127.0.0.1', 0)` and holds the socket open without calling `listen()`. Holding it keeps the OS from handing the port to anyone else, and a bound socket that never listens refuses every connect with `ECONNREFUSED`, which is the `OSError` the test asserts as the cause. The assertions themselves are unchanged.

Running a real WebSocket server on `127.0.0.1:56565` reproduces the CI failure exactly, which gives a before/after: 20/20 runs failed before the fix, 0/100 after. The fixed test also survived 0/25 whole-file runs under `--numprocesses=auto` with that port occupied, and 0/60 runs with a background process holding ~400 rotating ephemeral listeners.

*✍️ Drafted by Claude Code*
